### PR TITLE
Permit highway=platform for routing

### DIFF
--- a/routing/routing.xml
+++ b/routing/routing.xml
@@ -367,6 +367,7 @@
 			<select value="1" t="highway" v="pedestrian"/>
 			<select value="1" t="highway" v="footway"/>
 			<select value="1" t="highway" v="byway"/>
+			<select value="1" t="highway" v="platform"/>
 			<select value="1" t="highway" v="services"/>
 			<select value="1" t="highway" v="bridleway"/>
 			<select value="1" t="highway" v="steps"/>
@@ -399,6 +400,7 @@
 			<select value="10" t="highway" v="pedestrian"/>
 			<select value="8" t="highway" v="footway"/>
 			<select value="8" t="highway" v="byway"/>
+			<select value="5" t="highway" v="platform"/>
 			<select value="13" t="highway" v="services"/>
 			<select value="8" t="highway" v="bridleway"/>
 			<select value="3" t="highway" v="steps"/>
@@ -441,6 +443,7 @@
 			<select value="0.9" t="highway" v="pedestrian"/>
 			<select value="0.9" t="highway" v="footway"/>
 			<select value="1" t="highway" v="byway"/>
+			<select value="0.8" t="highway" v="platform"/>
 			<select value="1" t="highway" v="services"/>
 			<select value="0.8" t="highway" v="bridleway"/>
 			<select value="0.5" t="highway" v="steps"/>
@@ -579,6 +582,7 @@
 			<select value="1" t="highway" v="pedestrian"/>
 			<select value="1" t="highway" v="footway"/>
 			<select value="1" t="highway" v="byway"/>
+			<select value="1" t="highway" v="platform"/>
 			<select value="1" t="highway" v="services"/>
 			<select value="1" t="highway" v="bridleway"/>
 			<select value="1" t="highway" v="steps"/>


### PR DESCRIPTION
modern public transport tagging uses highway=platform, and pedestrians
are supposed to be able to walk along them. Make it so.
Also allow bicycles to pass through (at slow pace and lower priority),
they can use footways as well.
