### PR TITLE
Addition of several unpaved road types to avoid_unpaved profile as well ...

### DIFF
--- a/routing/routing.xml
+++ b/routing/routing.xml
@@ -68,11 +68,46 @@
 			<select value="-1" t="surface" v="unpaved">
 				<if param="avoid_unpaved"/>
 			</select>
+			<select value="-1" t="surface" v="compacted">
+				<if param="avoid_unpaved"/>
+			</select>
+			<select value="-1" t="surface" v="dirt">
+				<if param="avoid_unpaved"/>
+			</select>
+			<select value="-1" t="surface" v="earth">
+				<if param="avoid_unpaved"/>
+			</select>
+			<select value="-1" t="surface" v="gravel">
+				<if param="avoid_unpaved"/>
+			</select>
+			<select value="-1" t="surface" v="fine-gravel">
+				<if param="avoid_unpaved"/>
+			</select>
+			<select value="-1" t="surface" v="grass">
+				<if param="avoid_unpaved"/>
+			</select>
+			<select value="-1" t="surface" v="ground">
+				<if param="avoid_unpaved"/>
+			</select>
+			<select value="-1" t="surface" v="mud">
+				<if param="avoid_unpaved"/>
+			</select>
+			<select value="-1" t="surface" v="pebblestone">
+				<if param="avoid_unpaved"/>
+			</select>
+			<select value="-1" t="surface" v="sand">
+				<if param="avoid_unpaved"/>
+			</select>
+			<select value="-1" t="surface" v="wood">
+				<if param="avoid_unpaved"/>
+			</select>
 			<select value="-1" t="access" v="no"/>
 			<select value="-1" t="motorcycle" v="no"/>
 			<select value="-1" t="motorcar" v="no"/>
 			<select value="-1" t="motor_vehicle" v="no"/>
 			<select value="-1" t="vehicle" v="no"/>
+			<select value="-1" t="barrier" v="bollard"/>
+			<select value="-1" t="barrier" v="chain"/>
 			<select value="-1" t="barrier" v="debris"/>
 			<select value="-1" t="barrier" v="block"/>
 			


### PR DESCRIPTION
...as some barrier types
Unpaved road types added are quite common in OSM data, as a filtering of planet shows. Below figures are only for residential highways:
      60998     gravel
      31056     ground
      24754     dirt
      21959     paving_stones
      10772     sand
       9281     compacted
       1273     pebblestone
       1100     grass
        346     mud
        227     earth
        224     fine_gravel
        182     wood
