### PR TITLE
Added access=private and access=destination to pedestrian profile

### DIFF
--- a/routing/routing.xml
+++ b/routing/routing.xml
@@ -610,6 +610,8 @@
 		</way>
 		
 		<way attribute="priority">
+			<select value="0.05" t="access" v="private"/>
+			<select value="0.05" t="access" v="destination"/>
 			<select value="0.7" t="highway" v="motorway"/> 
 			<select value="0.7" t="highway" v="motorway_link"/>
 			<select value="0.7" t="highway" v="trunk"/>
@@ -684,6 +686,9 @@
 		<obstacle tag="railway" value="level_crossing" penalty="15"/>
 		<obstacle tag="barrier" value="debris" penalty="15"/>
 		<obstacle tag="barrier" value="block" penalty="15"/>
+		
+		<avoid tag="access" value="private" decreasedPriority="0.05"/>
+		<avoid tag="access" value="destination" decreasedPriority="0.05"/>
 		
 		<avoid tag="foot" value="no"/>
 		<avoid tag="pedestrian" value="no"/>


### PR DESCRIPTION
Noticed that osmand allows for pedestrian routing over roads tagged access=private. Copied the access rules from the car profile to pedestrian.
