### PR TITLE
Added railway=platform and public_transport=platform to pedestrian routing

### DIFF
--- a/routing/routing.xml
+++ b/routing/routing.xml
@@ -594,6 +594,8 @@
 			<select value="1" t="highway" v="footway"/>
 			<select value="1" t="highway" v="byway"/>
 			<select value="1" t="highway" v="platform"/>
+			<select value="1" t="railway" v="platform"/>
+			<select value="1" t="public_transport" v="platform"/>
 			<select value="1" t="highway" v="services"/>
 			<select value="1" t="highway" v="bridleway"/>
 			<select value="1" t="highway" v="steps"/>
@@ -672,6 +674,9 @@
 		<road tag="highway" value="pedestrian" speed="5" priority="1.2" />
 		<road tag="highway" value="footway" speed="5" priority="1.2" />
 		<road tag="highway" value="byway" speed="5" priority="1" />
+		<road tag="highway" value="platform" speed="5" priority="1" />
+		<road tag="railway" value="platform" speed="5" priority="1" />
+		<road tag="public_transport" value="platform" speed="5" priority="1" />
 		<road tag="highway" value="services" speed="5" priority="1" />
 		<road tag="highway" value="bridleway" speed="5" priority="0.8" />
 		<road tag="highway" value="steps" speed="4" priority="1.2" />


### PR DESCRIPTION
there was an entry for highway=platform in the pedestrian routing profile, but not for railway=platform or public_transport=platform.
