### PR TITLE
Made highway=service lower priority for pedestrian routing

### DIFF
--- a/routing/routing.xml
+++ b/routing/routing.xml
@@ -659,6 +659,7 @@
 			<select value="0.7" t="highway" v="motorway_link"/>
 			<select value="0.7" t="highway" v="trunk"/>
 			<select value="0.7" t="highway" v="trunk_link"/>
+			<select value="0.9" t="highway" v="service"/>
 			<select value="0.9" t="highway" v="primary"/>
 			<select value="0.9" t="highway" v="primary_link"/>
 			<select value="1.2" t="highway" v="pedestrian"/>
@@ -697,6 +698,7 @@
 
 		<road tag="highway" value="trunk" speed="5" priority="0.7" />
 		<road tag="highway" value="trunk_link" speed="5" priority="0.7" />
+		<road tag="highway" value="service" speed="5" priority="0.9" />
 		<road tag="highway" value="primary" speed="5" priority="0.9" />
 		<road tag="highway" value="primary_link" speed="5" priority="0.9" />
 		<road tag="highway" value="secondary" speed="5" priority="1" />


### PR DESCRIPTION
Pedestrian routing was guiding me through alleyways and parking lots, so it seemed like a good idea to give them a lower priority in the pedestrian profile.
