### PR TITLE
fi: Fixed several typos, word orders, left/right distinction

### DIFF
--- a/routing/routing.xml
+++ b/routing/routing.xml
@@ -474,8 +474,8 @@
 
 			<select value="1.5" t="highway" v="cycleway"/>
 
-			<select value="0.05" t="highway" v="motorway"/>
-			<select value="0.05" t="highway" v="motorway_link"/>
+			<select value="0.4" t="highway" v="motorway"/>
+			<select value="0.4" t="highway" v="motorway_link"/>
 			<select value="0.4" t="highway" v="trunk"/>
 			<select value="0.4" t="highway" v="trunk_link"/>
 			<select value="0.8" t="highway" v="primary"/>
@@ -498,7 +498,7 @@
 			<select value="0.8" t="highway" v="platform"/>
 			<select value="1" t="highway" v="services"/>
 			<select value="0.8" t="highway" v="bridleway"/>
-			<select value="0.3" t="highway" v="steps"/>
+			<select value="0.5" t="highway" v="steps"/>
 			<select value="1" t="route" v="ferry"/>
 
 		</way>
@@ -531,10 +531,10 @@
 
 		<!-- OLD Routing API -->
 
-		<road tag="highway" value="motorway" speed="16" priority="0.1" >
+		<road tag="highway" value="motorway" speed="16" priority="0.4" >
 			<specialization input="avoid_motorway" speed="0"/>
 		</road>
-		<road tag="highway" value="motorway_link" speed="16" priority="0.1" >
+		<road tag="highway" value="motorway_link" speed="16" priority="0.4" >
 			<specialization input="avoid_motorway" speed="0"/>
 		</road>
 
@@ -564,7 +564,7 @@
 		<road tag="highway" value="byway" speed="8" priority="1" />
 		<road tag="highway" value="services" speed="13" priority="1" />
 		<road tag="highway" value="bridleway" speed="8" priority="0.8" />
-		<road tag="highway" value="steps" speed="3" priority="0.3" />
+		<road tag="highway" value="steps" speed="3" priority="0.5" />
 		<road tag="route" value="ferry" speed="5" priority="1.0" >
 			<specialization input="avoid_ferries" speed="0"/>
 		</road>
@@ -655,16 +655,13 @@
 		<way attribute="priority">
 			<select value="0.05" t="access" v="private"/>
 			<select value="0.05" t="access" v="destination"/>
-			<select value="0.05" t="highway" v="motorway"/>
-			<select value="0.05" t="highway" v="motorway_link"/>
+			<select value="0.7" t="highway" v="motorway"/>
+			<select value="0.7" t="highway" v="motorway_link"/>
 			<select value="0.7" t="highway" v="trunk"/>
 			<select value="0.7" t="highway" v="trunk_link"/>
 			<select value="0.9" t="highway" v="service"/>
 			<select value="0.9" t="highway" v="primary"/>
 			<select value="0.9" t="highway" v="primary_link"/>
-			<select value="1.1" t="highway" v="track"/>
-			<select value="1.1" t="highway" v="path"/>
-			<select value="1.1" t="highway" v="living_street"/>
 			<select value="1.2" t="highway" v="pedestrian"/>
 			<select value="1.2" t="highway" v="footway"/>
 			<select value="0.8" t="highway" v="bridleway"/>
@@ -714,9 +711,9 @@
 
 		<road tag="highway" value="unclassified" speed="5" priority="1" />
 		<road tag="highway" value="service" speed="5" priority="1" />
-		<road tag="highway" value="track" speed="5" priority="1.1" />
-		<road tag="highway" value="path" speed="5" priority="1.1" />
-		<road tag="highway" value="living_street" speed="5" priority="1.1" />
+		<road tag="highway" value="track" speed="5" priority="1" />
+		<road tag="highway" value="path" speed="5" priority="1" />
+		<road tag="highway" value="living_street" speed="5" priority="1" />
 		<road tag="highway" value="pedestrian" speed="5" priority="1.2" />
 		<road tag="highway" value="footway" speed="5" priority="1.2" />
 		<road tag="highway" value="byway" speed="5" priority="1" />


### PR DESCRIPTION
There were some typos and word order issues in the Finnish TTS strings, probably resulting from a machine translation.
Also changed all instances of "vasemmalle" to "vasempaan" to fit with the Finnish military custom on differentiating between left/right in noisy environments. Grammatically these are interchangeable in this context, but it is much easier to hear the difference this way.
