### PR TITLE
Increase preference of living_street for pedestrians

### DIFF
--- a/routing/routing.xml
+++ b/routing/routing.xml
@@ -666,6 +666,7 @@
 			<select value="1.2" t="highway" v="footway"/>
 			<select value="0.8" t="highway" v="bridleway"/>
 			<select value="1.2" t="highway" v="steps"/>
+			<select value="1.2" t="highway" v="living_street"/>
 			<select value="1" t="route" v="ferry"/>
 
 			<select value="1"/>
@@ -713,7 +714,7 @@
 		<road tag="highway" value="service" speed="5" priority="1" />
 		<road tag="highway" value="track" speed="5" priority="1" />
 		<road tag="highway" value="path" speed="5" priority="1" />
-		<road tag="highway" value="living_street" speed="5" priority="1" />
+		<road tag="highway" value="living_street" speed="5" priority="1.2" />
 		<road tag="highway" value="pedestrian" speed="5" priority="1.2" />
 		<road tag="highway" value="footway" speed="5" priority="1.2" />
 		<road tag="highway" value="byway" speed="5" priority="1" />


### PR DESCRIPTION
Pedestrians have priority on living streets and thus ought to be safer than normal roads. I tested a scenario nearby and an increased preference value at least seems to produce a good result (contrasted to using just normal streets).
