### PR TITLE
Adding "osmc_symbol_black" to category "osmc" in rendering_types.xml

### DIFF
--- a/obf_creation/rendering_types.xml
+++ b/obf_creation/rendering_types.xml
@@ -147,6 +147,7 @@
 		<type tag="osmc_symbol_yellow" nameTags="osmc_symbol_white_yellow_bar_name,osmc_symbol__yellow_diamond_name" value="" minzoom="12"/>
 		<type tag="osmc_symbol_green"  nameTags="osmc_symbol_white_green_bar_name,osmc_symbol_white_green_backslash_name"  value="" minzoom="12"/>
 		<type tag="osmc_symbol_blue"   nameTags="osmc_symbol_white_blue_bar_name"   value="" minzoom="12"/>
+		<type tag="osmc_symbol_black"   nameTags="osmc_symbol_white_black_bar_name"   value="" minzoom="12"/>
 	</category>
 
 	<category name="cycleway">


### PR DESCRIPTION
In Poland, marking hiking trails are available in five standard colors: red, green, yellow, blue and black.

OsmAnd in the current version 1.5.2 renders only four colors: red, green, yellow and blue. There is no rendering trails in black.

I would like to ask for the rendering for the following combination of tags: osmc: symbol: black: white: black_bar
