### PR TITLE
Create h_osmc_white_black_bar.svg

### DIFF
--- a/icons/svg/shaders/icons/svg/shaders/h_osmc_white_black_bar.svg
+++ b/icons/svg/shaders/icons/svg/shaders/h_osmc_white_black_bar.svg
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 16.0.4, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" id="Слой_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 width="16.145px" height="2.977px" viewBox="429.79 276.701 16.145 2.977" enable-background="new 429.79 276.701 16.145 2.977"
+	 xml:space="preserve">
+<rect x="429.79" y="276.701" fill="#000000" width="16.145" height="2.977"/>
+</svg>


### PR DESCRIPTION
In Poland, marking hiking trails are available in five standard colors: red, green, yellow, blue and black.

OsmAnd in the current version 1.5.2 renders only four colors: red, green, yellow and blue. There is no rendering trails in black.

I would like to ask for the rendering for the following combination of tags: "osmc: symbol: black: white: black_bar", and therefore you will need a new icon with a black bar.
