### PR TITLE
Adding rendering for black hiking trails

### DIFF
--- a/rendering_styles/Touring-view_(more-contrast-and-details).render.xml
+++ b/rendering_styles/Touring-view_(more-contrast-and-details).render.xml
@@ -142,6 +142,7 @@
 		<filter tag="osmc_symbol_green" value="" order="95"/>
 		<filter tag="osmc_symbol_blue" value="" order="95"/>
 		<filter tag="osmc_symbol_yellow" value="" order="95"/>
+		<filter tag="osmc_symbol_black" value="" order="95"/>
 
 		<filter appMode="bicycle" showCycleRoutes="true" tag="lcn_network" value="lcn" order="110"/>
 		<filter appMode="bicycle" showCycleRoutes="true" tag="rcn_network" value="rcn" order="111"/>
@@ -160,6 +161,8 @@
 
 		<filter minzoom="12" tag="osmc_symbol_green" value="" nameTag="osmc_symbol_white_green_bar_name" textMinDistance="100" textColor="#ffffff" textSize="12" textBold="true" textOrder="7" textShield="osmc_white_green_bar"/>
 		<filter minzoom="12" tag="osmc_symbol_green" value="" nameTag="osmc_symbol_white_green_backslash_name" textMinDistance="100" textColor="#ffffff" textSize="12" textBold="true" textOrder="7" textShield="osmc_white_green_backslash"/>
+		
+		<filter minzoom="12" tag="osmc_symbol_black" value="" nameTag="osmc_symbol_white_black_bar_name" textMinDistance="100" textColor="#ffffff" textSize="12" textBold="true" textOrder="7" textShield="osmc_white_black_bar"/>
 
 		<group>
 			<filter appMode="bicycle" showCycleRoutes="true" tag="lcn_network" value="lcn" nameTag="lcn_ref" textColor="#0000ff" textOrder="22"/>
@@ -594,6 +597,14 @@
 			<filter minzoom="15" maxzoom="15" strokeWidth="12" pathEffect="16_12_12"/>
 			<filter minzoom="16" maxzoom="16" strokeWidth="16" pathEffect="32_24_24"/>
 			<filter minzoom="17"              strokeWidth="20" pathEffect="32_24_24"/>
+		</filter>
+		
+		<filter tag="osmc_symbol_black" value="" color="#31000000" osmcTraces="true">
+			<filter minzoom="12" maxzoom="13" strokeWidth="8" pathEffect="8_6_8"    />
+			<filter minzoom="14" maxzoom="14" strokeWidth="10" pathEffect="8_6_8"   />
+			<filter minzoom="15" maxzoom="15" strokeWidth="12" pathEffect="16_12_16" />
+			<filter minzoom="16" maxzoom="16" strokeWidth="16" pathEffect="32_24_32"/>
+			<filter minzoom="17"              strokeWidth="20" pathEffect="32_24_32"/>
 		</filter>
 
 		<group>


### PR DESCRIPTION
In Poland, marking hiking trails are available in five standard colors: red, green, yellow, blue and black.

I would like to ask for the rendering for the following combination of tags: osmc: symbol: black: white: black_bar

See also:
https://github.com/osmandapp/OsmAnd-resources/pull/59
https://github.com/osmandapp/OsmAnd-resources/pull/62
