### PR TITLE
Update default render; Addition colors for pedestrain roads in car and b...

### DIFF
--- a/rendering_styles/default.render.xml
+++ b/rendering_styles/default.render.xml
@@ -1431,7 +1431,7 @@
 			</groupFilter>
 			<!-- pedestrian roads are forbidden for cars and cyclists: show them like that in car and bicycle mode -->
 			<groupFilter appMode="car" tag="highway" value="pedestrian" color="#F7D4D4"/>
-			<groupFilter appMode="bicycle" tag="highway" value="pedestrian" color="#F7D4D4"/>
+			<!-- <groupFilter appMode="bicycle" tag="highway" value="pedestrian" color="#F7D4D4"/> -->
 		</group>
 
 		<!-- Next segment: Highways without grade distinction (cycleway, bridleway, black path): pathEffect 4_2. Base setting for highways with possible grade distinction but none specified (track, byway, red footway): 5_5 -->


### PR DESCRIPTION
...icycle mode

In our default rendering profile we have for roads an additional="access=no" and an additional="access=private".
In such a case a road gets a slightly pinkish-red color instead of one of the normal colors.

Pedestrian roads are prohibited for cars and cyclists. IMO: a pedestrian road should get the same color in "car" and "bicycle" mode.

See also https://groups.google.com/forum/#!topic/osmand/Q0fhn4usxWU where I posted some information.
