### PR TITLE
Add new category "color_coded" for rendering of trails

### DIFF
--- a/obf_creation/rendering_types.xml
+++ b/obf_creation/rendering_types.xml
@@ -149,6 +149,45 @@
 		<type tag="osmc_symbol_blue"   nameTags="osmc_symbol_white_blue_bar_name"   value="" minzoom="12"/>
 		<type tag="osmc_symbol_black"   nameTags="osmc_symbol_white_black_bar_name"   value="" minzoom="12"/>
 	</category>
+	
+	<!-- For the purpose of rendering the color-coded trails using the tag "colour" or "color", when they are not used tags "osmc_symbol" -->
+	<category name="color_coded">
+		<type tag="color"  value="red"      target_tag="color_coded" target_value="red" minzoom="8" additional="true"/>
+		<type tag="colour" value="red"      target_tag="color_coded" target_value="red" minzoom="8" additional="true"/>
+		<type tag="color"  value="#FF0000"  target_tag="color_coded" target_value="red" minzoom="8" additional="true"/>
+		<type tag="colour" value="#FF0000"  target_tag="color_coded" target_value="red" minzoom="8" additional="true"/>
+		<type tag="color"  value="#ff0000"  target_tag="color_coded" target_value="red" minzoom="8" additional="true"/>
+		<type tag="colour" value="#ff0000"  target_tag="color_coded" target_value="red" minzoom="8" additional="true"/>
+		
+		<type tag="color"  value="yellow"   target_tag="color_coded" target_value="yellow" minzoom="8" additional="true"/>
+		<type tag="colour" value="yellow"   target_tag="color_coded" target_value="yellow" minzoom="8" additional="true"/>
+		<type tag="color"  value="#FFFF00"  target_tag="color_coded" target_value="yellow" minzoom="8" additional="true"/>
+		<type tag="colour" value="#FFFF00"  target_tag="color_coded" target_value="yellow" minzoom="8" additional="true"/>
+		<type tag="color"  value="#ffff00"  target_tag="color_coded" target_value="yellow" minzoom="8" additional="true"/>
+		<type tag="colour" value="#ffff00"  target_tag="color_coded" target_value="yellow" minzoom="8" additional="true"/>
+				
+		<type tag="color"  value="green"    target_tag="color_coded" target_value="green" minzoom="8" additional="true"/>
+		<type tag="colour" value="green"    target_tag="color_coded" target_value="green" minzoom="8" additional="true"/>
+		<type tag="color"  value="#00FF00"  target_tag="color_coded" target_value="green" minzoom="8" additional="true"/>
+		<type tag="colour" value="#00FF00"  target_tag="color_coded" target_value="green" minzoom="8" additional="true"/>
+		<type tag="color"  value="#00ff00"  target_tag="color_coded" target_value="green" minzoom="8" additional="true"/>
+		<type tag="colour" value="#00ff00"  target_tag="color_coded" target_value="green" minzoom="8" additional="true"/>
+		
+		<type tag="color"  value="blue"     target_tag="color_coded" target_value="blue" minzoom="8" additional="true"/>
+		<type tag="colour" value="blue"     target_tag="color_coded" target_value="blue" minzoom="8" additional="true"/>
+		<type tag="color"  value="#0000FF"  target_tag="color_coded" target_value="blue" minzoom="8" additional="true"/>
+		<type tag="colour" value="#0000FF"  target_tag="color_coded" target_value="blue" minzoom="8" additional="true"/>
+		<type tag="color"  value="#0000ff"  target_tag="color_coded" target_value="blue" minzoom="8" additional="true"/>
+		<type tag="colour" value="#0000ff"  target_tag="color_coded" target_value="blue" minzoom="8" additional="true"/>
+		
+		<type tag="color"  value="black"    target_tag="color_coded" target_value="black" minzoom="8" additional="true"/>
+		<type tag="colour" value="black"    target_tag="color_coded" target_value="black" minzoom="8" additional="true"/>
+		<type tag="color"  value="#000000"  target_tag="color_coded" target_value="black" minzoom="8" additional="true"/>
+		<type tag="colour" value="#000000"  target_tag="color_coded" target_value="black" minzoom="8" additional="true"/>
+		<type tag="color"  value="#000000"  target_tag="color_coded" target_value="black" minzoom="8" additional="true"/>
+		<type tag="colour" value="#000000"  target_tag="color_coded" target_value="black" minzoom="8" additional="true"/>
+	</category>
+	
 
 	<category name="cycleway">
 		<type tag="cycleway" value="lane" minzoom="12"/>


### PR DESCRIPTION
For the purpose of rendering the color-coded trails using the tag "colour" or "color" (when tags "osmc_symbol" are not used)

See: https://groups.google.com/forum/#!topic/osmand/eLQiAMXYxu0

Link to a map with an explanatory view routes rendered in color: http://osmapa.pl/?lon=16.31899&lat=54.18042&zoom=13&map=1&o=TTFF

See also the example of tagging in my country: http://cycling.waymarkedtrails.org/en/relation/111432?zoom=13&lat=54.22628&lon=16.40435&hill=0#pref
