### PR TITLE
Fixes in the "color_coded" category

### DIFF
--- a/obf_creation/rendering_types.xml
+++ b/obf_creation/rendering_types.xml
@@ -204,7 +204,7 @@
 	
 	<!-- For the purpose of rendering the color-coded trails using the tag "colour" or "color", when they are not used tags "osmc_symbol" -->
 	<category name="color_coded">
-		<type tag="color_coded"  value="red" minzoom="8" additional="true" relation="true"/>
+		<type tag="color_coded"  value="red" minzoom="8" relation="true"/>
 		<type tag="color"  value="red"      target_tag="color_coded" target_value="red" />
 		<type tag="colour" value="red"      target_tag="color_coded" target_value="red" />
 		<type tag="color"  value="#FF0000"  target_tag="color_coded" target_value="red" />
@@ -212,7 +212,7 @@
 		<type tag="color"  value="#ff0000"  target_tag="color_coded" target_value="red" />
 		<type tag="colour" value="#ff0000"  target_tag="color_coded" target_value="red" />
 		
-		<type tag="color_coded"  value="yellow" minzoom="8" additional="true" relation="true"/>
+		<type tag="color_coded"  value="yellow" minzoom="8" relation="true"/>
 		<type tag="color"  value="yellow"   target_tag="color_coded" target_value="yellow" />
 		<type tag="colour" value="yellow"   target_tag="color_coded" target_value="yellow" />
 		<type tag="color"  value="#FFFF00"  target_tag="color_coded" target_value="yellow" />
@@ -220,7 +220,7 @@
 		<type tag="color"  value="#ffff00"  target_tag="color_coded" target_value="yellow" />
 		<type tag="colour" value="#ffff00"  target_tag="color_coded" target_value="yellow" />
 				
-		<type tag="color_coded"  value="green" minzoom="8" additional="true" relation="true"/>
+		<type tag="color_coded"  value="green" minzoom="8" relation="true"/>
 		<type tag="color"  value="green"    target_tag="color_coded" target_value="green" />
 		<type tag="colour" value="green"    target_tag="color_coded" target_value="green" />
 		<type tag="color"  value="#00FF00"  target_tag="color_coded" target_value="green" />
@@ -228,7 +228,7 @@
 		<type tag="color"  value="#00ff00"  target_tag="color_coded" target_value="green" />
 		<type tag="colour" value="#00ff00"  target_tag="color_coded" target_value="green" />
 		
-		<type tag="color_coded"  value="blue" minzoom="8" additional="true" relation="true"/>
+		<type tag="color_coded"  value="blue" minzoom="8" relation="true"/>
 		<type tag="color"  value="blue"     target_tag="color_coded" target_value="blue" />
 		<type tag="colour" value="blue"     target_tag="color_coded" target_value="blue" />
 		<type tag="color"  value="#0000FF"  target_tag="color_coded" target_value="blue" />
@@ -236,7 +236,7 @@
 		<type tag="color"  value="#0000ff"  target_tag="color_coded" target_value="blue" />
 		<type tag="colour" value="#0000ff"  target_tag="color_coded" target_value="blue" />
 		
-		<type tag="color_coded"  value="black" minzoom="8" additional="true" relation="true"/>
+		<type tag="color_coded"  value="black" minzoom="8" relation="true"/>
 		<type tag="color"  value="black"    target_tag="color_coded" target_value="black" />
 		<type tag="colour" value="black"    target_tag="color_coded" target_value="black" />
 		<type tag="color"  value="#000000"  target_tag="color_coded" target_value="black" />


### PR DESCRIPTION
I think that the simultaneous use of both keys "additional" together with"relation" can cause problems in the propagation of tags from relation to other objects. I think it must be fixed.

So please take a look and merge.
