### PR TITLE
Reduce highway priority for pedestrians

### DIFF
--- a/routing/routing.xml
+++ b/routing/routing.xml
@@ -717,8 +717,12 @@
 			<select value="0.7" t="highway" v="trunk"/>
 			<select value="0.7" t="highway" v="trunk_link"/>
 			<select value="0.9" t="highway" v="service"/>
-			<select value="0.9" t="highway" v="primary"/>
-			<select value="0.9" t="highway" v="primary_link"/>
+			<select value="0.7" t="highway" v="primary"/>
+			<select value="0.7" t="highway" v="primary_link"/>
+			<select value="0.7" t="highway" v="secondary"/>
+			<select value="0.7" t="highway" v="secondary_link"/>
+			<select value="0.7" t="highway" v="tertiary"/>
+			<select value="0.7" t="highway" v="tertiary_link"/>
 			<select value="1.2" t="highway" v="pedestrian"/>
 			<select value="1.2" t="highway" v="footway"/>
 			<select value="0.8" t="highway" v="bridleway"/>


### PR DESCRIPTION
Adds secondary and tertiary highways and sets priority to 0.7 along with primary for pedestrian routing.
