### PR TITLE
Lower motorway_link default maxspeed

### DIFF
--- a/routing/routing.xml
+++ b/routing/routing.xml
@@ -128,7 +128,7 @@
 			<select value="$maxspeed:practical" t="maxspeed:practical"/>
 			<select value="$maxspeed" t="maxspeed"/>
 			<select value="110" t="highway" v="motorway"/>
-			<select value="110" t="highway" v="motorway_link"/>
+			<select value="90" t="highway" v="motorway_link"/>
 			<select value="100" t="highway" v="trunk"/>
 			<select value="75" t="highway" v="trunk_link"/>
 			<!-- generally linking larger towns. -->


### PR DESCRIPTION
From http://wiki.openstreetmap.org/wiki/OSM_tags_for_routing/Maxspeed#Motorcar we can infer that our motorway_link default maxspeed is too high (it's the same as motorway).

This will also prevent osmand to route some sections using a motorway_link (while instead it should be using a motorway)
