### PR TITLE
Update cycle-map render; add render property OpenFietsMap

### DIFF
--- a/rendering_styles/Cycle-map.render.xml
+++ b/rendering_styles/Cycle-map.render.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<renderingStyle name="cycle-map-OFM.render" depends="default" defaultColor="#D8F7BA" version="1">
+<renderingStyle name="cycle-map.render" depends="default" defaultColor="#D8F7BA" version="1">
 
 
 <!--


### PR DESCRIPTION
 OpenFietsMap is "big" in Holland. They can be found at http://openfietsmap.nl/.
I added the rendering style as a new Render property to the Cycle-Map-render.xml which means that this is a big change. The rendering style is based on http://www.openfietsmap.nl/home/legenda.
There was a big demand from the Openfietsmap members to have something for the phone instead of a Garmin device and some are already using OsmAnd.
One big important feature is missing (also for other countries) and those are the node numbers (see also issue https://code.google.com/p/osmand/issues/detail?id=2312).
Changes are now committed even though node numbers are missing, to be able to have the rendering profile in the next release.
