### PR TITLE
Avoid paths when avoiding unpaved

### DIFF
--- a/routing/routing.xml
+++ b/routing/routing.xml
@@ -466,6 +466,7 @@
 
 		<way attribute="priority">
 			<if param="avoid_unpaved">
+                <select value="0.1" t="highway" v="path"/>
 				<select value="0.4" t="tracktype" v="grade2"/>
 				<select value="0.1" t="tracktype" v="grade3"/>
 				<select value="0.1" t="tracktype" v="grade4"/>


### PR DESCRIPTION
In bicycle mode, when selecting 'avoid unpaved', osmand still sends you along paths, which are by default unpaved (at least in my neighbourhood) and never marked with a surface 'unpaved' as this seems to be the default for a path.

Result is that route guidance is guiding you along tracks which are not rideable by bike.

This modification alleviates that.
