### PR TITLE
Undo last change: a path is not unpaved by default

### DIFF
--- a/routing/routing.xml
+++ b/routing/routing.xml
@@ -466,8 +466,7 @@
 
 		<way attribute="priority">
 			<if param="avoid_unpaved">
-                <select value="0.1" t="highway" v="path"/>
-				<select value="0.4" t="tracktype" v="grade2"/>
+                		<select value="0.4" t="tracktype" v="grade2"/>
 				<select value="0.1" t="tracktype" v="grade3"/>
 				<select value="0.1" t="tracktype" v="grade4"/>
 				<select value="0.1" t="tracktype" v="grade5"/>


### PR DESCRIPTION
See http://wiki.openstreetmap.org/wiki/Tag:highway%3Dpath
path="A route open to the public which is not intended for motor vehicles"
"These routes may have any type of surface."

See also http://wiki.openstreetmap.org/wiki/Highway_examples
