### PR TITLE
Fix taxiway nameTags

### DIFF
--- a/obf_creation/rendering_types.xml
+++ b/obf_creation/rendering_types.xml
@@ -379,7 +379,7 @@
 		<type tag="aeroway" value="terminal" minzoom="15" />
 		<type tag="aeroway" value="helipad" minzoom="10" />
 		<type tag="aeroway" value="runway" minzoom="11" poi_prefix="aeroway_"/>
-		<type tag="aeroway" value="taxiway" minzoom="12" poi_prefix="aeroway_"/>
+		<type tag="aeroway" value="taxiway" minzoom="12" nameTags="ref" poi_prefix="aeroway_"/>
 		<type tag="aeroway" value="apron" minzoom="12" poi_prefix="aeroway_"/>
 		<type tag="aeroway" value="airport" minzoom="11" />
 		<type tag="aeroway" value="gate" minzoom="15" nameTags="ref" poi_prefix="aeroway_"/>


### PR DESCRIPTION
Name for taxiway is used in default.render.xml but absent in rendering_types.xml
