### PR TITLE
Update rendering_types; add missing rendering styles

### DIFF
--- a/obf_creation/rendering_types.xml
+++ b/obf_creation/rendering_types.xml
@@ -32,12 +32,19 @@
 	<type tag="access" value="private" minzoom="15" additional="true" only_map="true"/>
 	<type tag="access" value="yes" minzoom="15" additional="true" only_map="true"/>
 	<type tag="access" value="true" target_value="yes" minzoom="15" additional="true" only_map="true"/>
+	<type tag="vehicle" value="no" minzoom="15" additional="true" only_map="true"/>
+	<type tag="motor_vehicle" value="no" minzoom="15" additional="true" only_map="true"/>
+	<type tag="motorcar" value="no" minzoom="15" additional="true" only_map="true"/>
+
 
 	<type tag="access" value="no" minzoom="15" additional="true"/>
 	<type tag="access" value="false" target_value="no" minzoom="15" additional="true"/>
 	<type tag="access" value="private" minzoom="15" additional="true"/>
 	<type tag="access" value="yes" minzoom="15" additional="true"/>
 	<type tag="access" value="true" target_value="yes" minzoom="15" additional="true"/>
+	<type tag="vehicle" value="no" minzoom="15" additional="true"/>
+	<type tag="motor_vehicle" value="no" minzoom="15" additional="true"/>
+	<type tag="motorcar" value="no" minzoom="15" additional="true"/>
 	<type tag="fee" value="yes" minzoom="15" additional="true"/>
 	
 	<type tag="religion" value="christian" minzoom="15" additional="true"/>


### PR DESCRIPTION
Added a few rendering styles. The rendering styles are used in the routing, and work correctly as such, but they are not used in the rendering. The routing tells you you can't enter a street (and that is correct), but the map doesn't tell you it is not allowed to enter a street: this is confusing.
(Thanks to user Allroads)
