### PR TITLE
Update rendering_types; add more rendering styles

### DIFF
--- a/obf_creation/rendering_types.xml
+++ b/obf_creation/rendering_types.xml
@@ -35,7 +35,8 @@
 	<type tag="vehicle" value="no" minzoom="15" additional="true" only_map="true"/>
 	<type tag="motor_vehicle" value="no" minzoom="15" additional="true" only_map="true"/>
 	<type tag="motorcar" value="no" minzoom="15" additional="true" only_map="true"/>
-
+	<type tag="bicycle" value="no" minzoom="15" additional="true" only_map="true"/>
+	<type tag="foot" value="no" minzoom="15" additional="true" only_map="true"/>
 
 	<type tag="access" value="no" minzoom="15" additional="true"/>
 	<type tag="access" value="false" target_value="no" minzoom="15" additional="true"/>
@@ -45,6 +46,8 @@
 	<type tag="vehicle" value="no" minzoom="15" additional="true"/>
 	<type tag="motor_vehicle" value="no" minzoom="15" additional="true"/>
 	<type tag="motorcar" value="no" minzoom="15" additional="true"/>
+	<type tag="bicycle" value="no" minzoom="15" additional="true"/>
+	<type tag="foot" value="no" minzoom="15" additional="true"/>
 	<type tag="fee" value="yes" minzoom="15" additional="true"/>
 	
 	<type tag="religion" value="christian" minzoom="15" additional="true"/>


### PR DESCRIPTION
After having updated the rendering for the motorcar and motor_vehicle access=no tags, I discovered that OsmAnd does the same for bicycle and foot. It routes correctly but doesn't show it on the map. This is important for the (new?) bicycle and hiking styles.
