### PR TITLE
Fix area rendering: assign objectType=3 (polygon)

### DIFF
--- a/rendering_styles/default.render.xml
+++ b/rendering_styles/default.render.xml
@@ -178,8 +178,21 @@
 			<filter tag="public_transport" value="station"/>
 			<filter tag="public_transport" value="platform"/>
 			<groupFilter>
-				<filter point="false" objectType="2" order="58"/>
+				<filter point="false" area="false" objectType="2" order="58"/>
+				<filter area="true" point="false" objectType="3"/>
 				<filter point="true" objectType="1" order="128"/>
+			</groupFilter>
+		</group>
+		
+		<group>
+			<filter tag="highway" value="pedestrian"/>
+			<filter tag="highway" value="service"/>
+			<filter tag="highway" value="road"/>
+			<filter tag="highway" value="unclassified"/>
+			<filter tag="highway" value="residential"/>
+			<filter tag="highway" value="footway"/>
+			<groupFilter>
+				<filter area="true" point="false" objectType="3"/>
 			</groupFilter>
 		</group>
 		


### PR DESCRIPTION
Seems that this rule does not assign objectType="3" to areas, because empty tags or values ("") do not work in this case?

> <filter area="true" tag="" value="" order="5" objectType="3"/>

So areas which should be rendered as areas have to be specified explicitly.

If I specify them explicitly (see patch), areas are rendered correctly.

https://groups.google.com/forum/#!topic/osmand/pfS_rR8w1ZY
