### PR TITLE
registered public_transport to allow routing over platforms

### DIFF
--- a/obf_creation/rendering_types.xml
+++ b/obf_creation/rendering_types.xml
@@ -61,8 +61,7 @@
 	<type tag="layer" value="5" target_value="1" minzoom="10" additional="true" only_map="true"/>
 	<type tag="layer" value="+5" target_value="1" minzoom="10" additional="true" only_map="true"/>
 	<type tag="layer" value="-5" target_value="-1" minzoom="10" additional="true" only_map="true"/>
-	<type tag="covered" value="yes" target_tag="layer" target_value="-1" minzoom="10" additional="true"
-		only_map="true"/>
+	<type tag="covered" value="yes" target_tag="layer" target_value="-1" minzoom="10" additional="true" only_map="true"/>
 
 	<type tag="bridge" value="yes" minzoom="10" additional="true" only_map="true"/>
 	<type tag="tunnel" value="yes" minzoom="10" additional="true" only_map="true"/>
@@ -168,7 +167,6 @@
 		<type tag="noexit" value="yes" minzoom="16"/>
 		<type tag="highway" value="motorway_junction" minzoom="13" nameTags="ref"/>
 		<type tag="highway" value="bus_stop" minzoom="15" poi_category="transportation"/>
-		<type tag="highway" value="platform" minzoom="15" poi_category="transportation"/>
 		<type tag="highway" value="turning_circle" minzoom="16" poi_category="transportation"/>
 		<type tag="highway" value="emergency_access_point" minzoom="16" poi_category="emergency"/>
 		<type tag="highway" value="speed_camera" minzoom="16" poi_category="transportation"/>
@@ -336,7 +334,6 @@
 		<type tag="barrier" value="kent_carriage_gap" minzoom="15" />
 	</category>
 
-
 	<category name="waterway"  poi_tag="waterway" poi_category="man_made">
 		<type tag="waterway" value="stream" minzoom="13" poi_category="natural"/>
 		<type tag="waterway" value="riverbank" minzoom="8" poi_category="natural"/>
@@ -367,7 +364,6 @@
 		<type tag="railway" value="construction" minzoom="15" />
 		<type tag="railway" value="monorail" minzoom="15" />
 		<type tag="railway" value="funicular" minzoom="15" />
-		<type tag="railway" value="platform" minzoom="15" />
 		<type tag="railway" value="station" minzoom="12" />
 		<type tag="railway" value="turntable" minzoom="15" />
 		<type tag="railway" value="halt" minzoom="13" poi_prefix=""/>
@@ -380,10 +376,11 @@
 	
 	<category name="public_transport" poi_tag="public_transport" poi_category="transportation" poi_prefix="public_transport_">
 		<type tag="public_transport" value="platform" minzoom="15" />
+		<type tag="railway" value="platform" target_tag="public_transport" minzoom="15"/>
+		<type tag="highway" value="platform" target_tag="public_transport" minzoom="15"/>
 		<type tag="public_transport" value="station" minzoom="15" />
 		<type tag="public_transport" value="stop_position" minzoom="15" poi_prefix=""/>
 	</category>
-
 
 	<category name="aeroway" poi_tag="aeroway" poi_category="transportation">
 		<type tag="aeroway" value="aerodrome" minzoom="6" />
@@ -694,9 +691,7 @@
 		<type tag="natural" value="lake" minzoom="4" />
 		<type tag="natural" value="wetland" minzoom="6" />
 		<type tag="natural" value="wood" minzoom="6" />
-		<type tag="landuse" value="wood" minzoom="6"
-
-			target_tag="natural" target_value="wood" poi_category="natural" />
+		<type tag="landuse" value="wood" minzoom="6" target_tag="natural" target_value="wood" poi_category="natural" />
 		<type tag="contour" value="elevation" minzoom="11" />
 	</category>
 	<category name="contourtype">


### PR DESCRIPTION
I added public_transport to the the routing category to allow (pedestrian) routing over public_transport=platform. This didn't work before, but now validated it with real data.
