### PR TITLE
Add cycleway:left/right=opposite_lane

### DIFF
--- a/obf_creation/rendering_types.xml
+++ b/obf_creation/rendering_types.xml
@@ -291,6 +291,8 @@
 		<type tag="cycleway" value="lane" minzoom="12"/>
 		<type tag="cycleway" value="opposite_lane" minzoom="12"/>
 		<type tag="cycleway" value="track" minzoom="12"/>
+		<type tag="cycleway:left" target_tag="cycleway" value="opposite_lane" minzoom="12"/>
+		<type tag="cycleway:right" target_tag="cycleway" value="opposite_lane" minzoom="12"/>
 		<type tag="cycleway:left" target_tag="cycleway" value="lane" minzoom="12"/>
 		<type tag="cycleway:right" target_tag="cycleway" value="lane" minzoom="12"/>
 	</category>	


### PR DESCRIPTION
Only cycleway=opposite_lane was considered, although cycleway:left (or cycleway:right) often occurs and is the recommended tag.

In the case of a street which is tagged "cycleway:left=lane" and "cycleway:right=opposite_lane", which value will be chosen for cycleway tag in obf?
It should be 'opposite_lane' (because it gives the information it is not a oneway street for bicycle), but I'm not sure it will.
