### PR TITLE
reordered tags for pedeѕtrian routing and lowered time penalties

### DIFF
--- a/routing/routing.xml
+++ b/routing/routing.xml
@@ -716,40 +716,41 @@
 		</way>
 
 		<way attribute="priority">
+			<!-- Additional tags -->
 			<select value="0.05" t="access" v="private"/>
 			<select value="0.05" t="access" v="destination"/>
+			<select value="1.2" t="sidewalk" v="yes"/>
+			<select value="0.9" t="sidewalk" v="no"/>
+
+			<!-- object tags -->
 			<select value="0.7" t="highway" v="motorway"/>
 			<select value="0.7" t="highway" v="motorway_link"/>
 			<select value="0.7" t="highway" v="trunk"/>
 			<select value="0.7" t="highway" v="trunk_link"/>
+			<select value="0.8" t="highway" v="bridleway"/>
 			<select value="0.9" t="highway" v="service"/>
 			<select value="0.9" t="highway" v="primary"/>
 			<select value="0.9" t="highway" v="primary_link"/>
-			<select value="1.2" t="highway" v="pedestrian"/>
-			<select value="1.2" t="highway" v="footway"/>
-			<select value="0.8" t="highway" v="bridleway"/>
+			<select value="1"   t="route"   v="ferry"/>
 			<select value="1.2" t="highway" v="steps"/>
 			<select value="1.2" t="highway" v="living_street"/>
-			<select value="1.2" t="sidewalk" v="yes"/>
-			<select value="0.9" t="sidewalk" v="no"/>
-			<select value="1" t="route" v="ferry"/>
+			<select value="1.2" t="highway" v="pedestrian"/>
+			<select value="1.2" t="highway" v="footway"/>
 
 			<select value="1"/>
 		</way>
 
 		<point attribute="obstacle_time">
-			<select value="30" t="highway" v="traffic_signals"/>
-			<select value="15" t="highway" v="ford" />
-			<select value="15" t="ford" />
-			<select value="15" t="railway" v="crossing" />
-			<select value="15" t="railway" v="level_crossing"/>
+			<select value="5" t="highway" v="traffic_signals"/>
+			<select value="5" t="highway" v="ford" />
+			<select value="5" t="ford" />
+			<select value="5" t="railway" v="crossing" />
+			<select value="5" t="railway" v="level_crossing"/>
 		</point>
 
 		<point attribute="obstacle">
 			<select value="-1" t="foot" v="no"/>
 			<select value="-1" t="pedestrian" v="no"/>
-
-			<select value="10" t="highway" v="traffic_signals"/>
 		</point>
 
 


### PR DESCRIPTION
Reordering the pedestrian routing tags did the trick. The sidewalk tag is picked up now.  I also lowered the time penalties, because they seemed very high to me. you always encounter a fair number of traffic lights which are green, and normally you don't have to wait at all railroad crossing. Also traffic_signals was duplicate in obstacle.
