### PR TITLE
Added surface and smoothness to routing_type

### DIFF
--- a/obf_creation/rendering_types.xml
+++ b/obf_creation/rendering_types.xml
@@ -1170,6 +1170,8 @@
 		<routing_type tag="train" mode="amend"/>
 		<routing_type tag="tracktype" mode="amend"/>
 		<routing_type tag="sidewalk" mode="amend"/>
+		<routing_type tag="surface" mode="amend"/>
+		<routing_type tag="smoothness" mode="amend"/>
 		<routing_type tag="traffic_calming" mode="amend"/>
 		<routing_type tag="turn:lanes" mode="amend"/>
 		<routing_type tag="turn" mode="amend"/>


### PR DESCRIPTION
The option "Avoid unpaved roads" does not work. I added "surface" as routing types to fix this bug. Also i added "smoothness" as routing types for future "Avoid bad roads".
