### PR TITLE
Fix routing through cycleway:left|right=opposite_lane

### DIFF
--- a/obf_creation/rendering_types.xml
+++ b/obf_creation/rendering_types.xml
@@ -1133,7 +1133,9 @@
 		<routing_type tag="maxspeed" value="RU:rural" tag2="maxspeed" value2="90" mode="replace" base="true"/>
 		<routing_type tag="maxspeed" value="RU:urban" tag2="maxspeed" value2="60" mode="replace" base="true"/>
 		<routing_type tag="maxspeed" value="CZ:urban" tag2="maxspeed" value2="50" mode="replace" base="true"/>
-				
+		
+		<routing_type tag="cycleway:left" value="opposite_lane" tag2="cycleway" value2="opposite_lane" mode="replace" base="true"/>
+		<routing_type tag="cycleway:right" value="opposite_lane" tag2="cycleway" value2="opposite_lane" mode="replace" base="true"/>
 		
 		<routing_type tag="access" mode="amend"/>
 		<!-- tag used as start with -->


### PR DESCRIPTION
This is necessary to allow contraflow routing along streets tagged 'cycleway:left=opposite_lane'
