### PR TITLE
highway=services|rest_area as POI

### DIFF
--- a/obf_creation/rendering_types.xml
+++ b/obf_creation/rendering_types.xml
@@ -163,7 +163,8 @@
 		<type tag="highway" value="footway" minzoom="12" nameTags="ref"/>
 		<type tag="highway" value="steps" minzoom="14" nameTags="ref"/>
 		<type tag="highway" value="bridleway" minzoom="12" nameTags="ref"/>
-		<type tag="highway" value="services" minzoom="12" nameTags="ref"/>
+		<type tag="highway" value="services" minzoom="12" nameTags="ref" poi_category="transportation/>
+		<type tag="highway" value="rest_area" minzoom="12" nameTags="ref" poi_category="transportation/>
 		<type tag="highway" value="raceway" minzoom="12" nameTags="ref"/>
 		<!-- <type id="" tag="highway" value="bus_guideway" minzoom="15" /> -->
 


### PR DESCRIPTION
It is currently not considered as POI, so you cannot search it and display it on the map, which would be very useful when you travel on motorways/large roads.

Is nameTags="ref" useful for highway=services|rest_area?
