### PR TITLE
Added public transport tag replcement to routing section

### DIFF
--- a/obf_creation/rendering_types.xml
+++ b/obf_creation/rendering_types.xml
@@ -1105,8 +1105,8 @@
 		<routing_type tag="cycleway" mode="register" base="true"/>
 
 		<routing_type tag="public_transport" mode="register"/>
-		<type tag="railway" value="platform" tag2="public_transport" value2="platform" mode="replace" mode="replace"/>
-		<type tag="highway" value="platform" tag2="public_transport" value2="platform" mode="replace" mode="replace"/>
+		<routing_type tag="railway" value="platform" tag2="public_transport" value2="platform" mode="replace"/>
+		<routing_type tag="highway" value="platform" tag2="public_transport" value2="platform" mode="replace"/>
 		
 		<routing_type tag="int_ref" mode="text" base="true"/>
 		<routing_type tag="name" mode="text" base="true"/>


### PR DESCRIPTION
public_transport=platform does not show up in car routing, so I removed the base tag. I also added the tag replacements railway=platform and highway=platform to public_transport=platform to the routing section. They already were replaced for rendering, but not yet for routing.
