### PR TITLE
Changed cycleway to amend and removed base

### DIFF
--- a/obf_creation/rendering_types.xml
+++ b/obf_creation/rendering_types.xml
@@ -1106,7 +1106,6 @@
 		<routing_type tag="junction" mode="register" base="true"/>
 		<routing_type tag="route" mode="register" base="true"/>
 		 <!-- <routing_type tag="route" value="bus" mode="register" base="true" relation="true"/>  -->
-		<routing_type tag="cycleway" mode="register" base="true"/>
 
 		<routing_type tag="public_transport" mode="register"/>
 		<routing_type tag="railway" value="platform" tag2="public_transport" value2="platform" mode="replace"/>
@@ -1141,6 +1140,7 @@
 		<routing_type tag="maxspeed" value="RU:urban" tag2="maxspeed" value2="60" mode="replace" base="true"/>
 		<routing_type tag="maxspeed" value="CZ:urban" tag2="maxspeed" value2="50" mode="replace" base="true"/>
 
+		<routing_type tag="cycleway" mode="amend"/>
 		<routing_type tag="cycleway:left" value="lane" tag2="cycleway" value2="lane" mode="replace"/>
 		<routing_type tag="cycleway:right" value="lane" tag2="cycleway" value2="lane" mode="replace"/>
 		<routing_type tag="cycleway:left"  value="opposite_lane" tag2="cycleway" value2="opposite_lane" mode="replace"/>


### PR DESCRIPTION
Changed cycleway to amend instead of register (the tag cycleway=\* is amended to highway=\*  instead of a main object tag), and removed base="true", since it is not used for car routing.
