### PR TITLE
Translations

### DIFF
--- a/specialphrases/specialphrases_de.txt
+++ b/specialphrases/specialphrases_de.txt
@@ -16,7 +16,7 @@ aerialway_station,Seilbahnstation
 aerodrome,Flugfeld
 aeroway_apron,Vorfeld
 aeroway_gate,Flughafen-Gate
-aeroway_runway,Start- und Landebahn
+aeroway_runway,Start-/Landebahn
 aeroway_taxiway,Rollbahn
 airfield,Militärflugplatz
 airport,Flughafen
@@ -59,9 +59,9 @@ beach_resort,Badeort
 beach,Strand
 beachvolleyball,Beachvolleyball
 beacon,Leuchtfeuer
-beauty,Parfümerie
+beauty,Schönheitspflege
 bed_and_breakfast,Unterkunft
-bench,Bank
+bench,Sitzbank
 beverages,Getränkemarkt
 bicycle,Fahrradladen
 bicycle_parking,Fahrradparkplatz
@@ -70,7 +70,7 @@ biergarten,Biergarten
 billboard,Werbefläche
 bird_hide,Vogelbeobachtung
 bitcoin_yes,Bitcoin
-block,Gebäudeblock
+block,Steinbarriere
 bmx,BMX
 boat_sharing,Boat Sharing
 boatyard,Werft
@@ -119,11 +119,11 @@ cattle_grid,Weiderost
 cave_entrance,Höhleneingang
 cemetery,Friedhof
 chain,Kette
-chalet,Almhütte
+chalet,Ferienhaus
 channel,Kanal
 chapel,Kapelle
 charging_station,Ladestation
-charity,Wohltätigkeitsladen
+charity,Sozialkaufhaus
 chemist,Drogerie
 chess,Schach
 chimney,Schornstein
@@ -174,7 +174,7 @@ danger_area,Gefahrenzone
 deli,Feinkostladen
 dentist,Zahnarzt
 department_store,Warenhhaus
-derelict_canal,Aufgelassener Kanal
+derelict_canal,aufgelassener Kanal
 desert,Wüste
 discount,Diskontladen
 distance_marker,Kilometerstein
@@ -203,6 +203,11 @@ embassy,Botschaft
 emergency_access_point,Rettungspunkt
 emergency_phone,Notrufsäule
 employment_agency,Arbeitsvermittlung
+enforcement_traffic_signals,Rotlichtkamera
+enforcement_maxspeed,Geschwindigkeitsüberwachung
+enforcement_maxheight,Höhenüberwachung
+enforcement_mindistance,Abstandsüberwachung
+enforcement_check,Kontrollpunkt
 entrance,Eingang
 equestrian,Reiten
 estate_agent,Imobilienhändler
@@ -431,6 +436,7 @@ post_office,Postamt
 power_cable_distribution_cabinet,Kabelverteilerschrank
 power_generator,Generator
 power_station,Umspannstation
+power_sub_station,Transformator
 power_substation,Transformator
 preschool,Vorschule
 preserved,bewahrte Bahnstrecke
@@ -441,7 +447,7 @@ pub,Kneipe
 public_building,öffentliches Gebäude
 public_market,öffentlicher Markt
 public,öffentliches Gebäude
-public_transport_platform,Bahn/Bussteig
+public_transport_platform,Bahn-/Bussteig
 public_transport_station,Bahnhof
 quango,halbstaatliche Organisation
 quarry,Steinbruch
@@ -457,8 +463,10 @@ railway,Eisenbahn
 railway_funicular,Standseilbahn
 railway_level_crossing,Bahnübergang
 railway_monorail,Einschienenbahn 
-railway_narrow_gauge,Schmalspurbahnen
+railway_narrow_gauge,Schmalspurbahn
 railway_preserved,Museumsbahn
+railway_rail,Bahngleis
+railway_signal,Bahnhof
 railway_station,Bahnhof
 railway_turntable,Drehscheibe
 range,Waffenübungsplatz
@@ -521,7 +529,7 @@ snow_fence,Schneezaun
 soccer,Fußball
 social_club,Geselligkeitsverein
 social_facility,Sozialeinrichtung
-speed_camera,Blitzer
+speed_camera,Geschwindigkeitsüberwachung
 sports_centre,Sportzentrum
 sports,Sportgeschäft
 spring,Quelle
@@ -625,12 +633,12 @@ water_lock_gate,Schleuse
 water_mill_pond,Mühlteich
 watermill,Wassermühle
 water_park,Wasserpark
-water_point,Wasserpunkt
+water_point,Trinkwasserentnahmestelle
 water_ski,Wasserski
 water_tank,Löschwasserbehälter
 water_tower,Wasserturm
 water_turning_point,Wasserwendestelle
-water,Wasser
+water,Gewässer
 water_weir,Wehr
 water_well,Brunnen
 water_works,Wasserwerk
@@ -644,7 +652,7 @@ wifi,WLAN-Zugangspunkt
 windmill,Windmühle
 wine,Weingeschäft
 wood,Wald
-works,Industriebauten
+works,Fabrik
 wreck,Schiffswrack
 wrestling,Ringen
 yard,Rangierbahnhof


### PR DESCRIPTION
For POI only the value (and poi_prefix) is indexed, not the tag.
This leads to the question, if we should add a poi_prefix, if the value itself is not clear?

For example "yes" is not distinguishable, so I can't translate it:
`<type tag="embankment" value="yes" minzoom="14"/>`
`<type tag="entrance" value="yes" nameTags="addr:flats" minzoom="19"/>`
...

Also values like "main" (or "block") are hard to distinguish, because it could be nearly everything.

I also noticed a very strange thing:
Tags/values are integrated into obf file, even if they are not listed in rendering_types.xml!
For example railway signal or milestone (they are searchable as poi).
Why does this happen?
Or does poi_tag="railway" mean, that all tag="railway" indexed, even if the value is not explicitly listed?

Also some street tags are inside the obf file, even if they are not listed in rendering_types.xml, for example:
sidewalk:left:surface
sidewalk:segregated
maxspeed:backward

I always thought, that only tag/values and routing_types listed in rendering_types.xml are getting inside the obf file?
Am I wrong?
