### PR TITLE
Added all bicycle and cycleway tags from obf creation to routing.xml

### DIFF
--- a/routing/routing.xml
+++ b/routing/routing.xml
@@ -497,7 +497,6 @@
 			<select value="1.6" t="cycleway" v="share_busway"/>
 			<select value="1.6" t="cycleway" v="track"/>
 			<select value="1.6" t="cycleway" v="opposite_track"/>
-			<select value="1.6" t="cycleway" v="opposite"/>
 			<select value="1.6" t="cycleway" v="shared"/>
 			<select value="1.6" t="cycleway" v="shared_lane"/>
 


### PR DESCRIPTION
Removed line 414 because bicycle=designated always goes together with a highway

Removed line 433 and 434 because cycleway:left/right is converted to cycleway

Removed line 453 to have bicycle=designated/yes both in the priority section

Added the cycleway=\* varieties to the priorities section
