### PR TITLE
add man_made=pier polygon filters

### DIFF
--- a/rendering_styles/default.render.xml
+++ b/rendering_styles/default.render.xml
@@ -1317,9 +1317,9 @@
 			<groupFilter nightMode="true" color="#685454"/>
 		</group>
 
-		<filter tag="man_made" value="pier" minzoom="12" maxzoom="13" color="#f2efe9" strokeWidth="1"/>
-			<filter tag="man_made" value="pier" minzoom="14" maxzoom="15" color="#f2efe9" strokeWidth="3"/>
-			<filter tag="man_made" value="pier" minzoom="16" color="#f2efe9" strokeWidth="6"/>
+		<filter tag="man_made" value="pier" minzoom="12" maxzoom="13" color="#f2efe9" />
+			<filter tag="man_made" value="pier" minzoom="14" maxzoom="15" color="#f2efe9" />
+			<filter tag="man_made" value="pier" minzoom="16" color="#f2efe9" />
 		
 		<!-- Special nature, with shaders -->
 		<!-- Looks like shaders are not working without color statement, hence color="#100000" introduced for now where missing -->


### PR DESCRIPTION
On issue https://code.google.com/p/osmand/issues/detail?id=2327

Filters for man_made=pier added to <polygon> xml tag in default.render.xml to render pier objects which are polygons.
