### PR TITLE
replaced "Vorbereiten zum" by "Demnächst" in German

### DIFF
--- a/voice/de/ttsconfig.p
+++ b/voice/de/ttsconfig.p
@@ -34,7 +34,7 @@ string('route_calculate.ogg', 'Route wurde neu berechnet ').
 string('distance.ogg', ', Die Entfernung beträgt ').
 
 % LEFT/RIGHT
-string('prepare.ogg', 'vorbereiten zum ').
+string('prepare.ogg', 'Demnächst ').  % Demnächst sounds better then Vorbereiten zum
 string('after.ogg', 'nach ').
 
 string('left.ogg', 'links abbiegen ').


### PR DESCRIPTION
When listening to Osmand's speech while navigating, I often hear from German TTS:
"Vorbereiten zum in 100 Meter Rechts abbiegen" what sounds really clumsy.

"Demnächst in 100 Meter abbiegen" or "Demnächst rechts abbiegen" sounds really better.
