### PR TITLE
Moved highway entries from priority to speed

### DIFF
--- a/routing/routing.xml
+++ b/routing/routing.xml
@@ -389,113 +389,6 @@
 			<select value="25" t="highway" v="ford" />
 			<select value="25" t="ford" />
 		</point>
-
-
-		<!-- OLD Routing API -->
-
-		<road tag="highway" value="motorway" speed="16" priority="0.4" >
-			<specialization input="avoid_motorway" speed="0"/>
-		</road>
-		<road tag="highway" value="motorway_link" speed="16" priority="0.4" >
-			<specialization input="avoid_motorway" speed="0"/>
-		</road>
-
-		<road tag="highway" value="trunk" speed="16" priority="0.4" >
-			<specialization input="avoid_motorway" speed="0"/>
-		</road>
-		<road tag="highway" value="trunk_link" speed="16" priority="0.4">
-			<specialization input="avoid_motorway" speed="0"/>
-		</road>
-		<road tag="highway" value="primary" speed="16" priority="0.8" />
-		<road tag="highway" value="primary_link" speed="16" priority="0.8" />
-		<road tag="highway" value="secondary" speed="16" priority="1" />
-		<road tag="highway" value="secondary_link" speed="16" priority="1" />
-		<road tag="highway" value="tertiary" speed="16" priority="1" />
-		<road tag="highway" value="tertiary_link" speed="16" priority="1" />
-		<road tag="highway" value="road" speed="16" priority="1" />
-		<road tag="highway" value="residential" speed="16" priority="1.1" />
-		<road tag="highway" value="cycleway" speed="16" priority="1.5" />
-
-		<road tag="highway" value="unclassified" speed="13" priority="1" />
-		<road tag="highway" value="service" speed="13" priority="1" />
-		<road tag="highway" value="track" speed="12" priority="1" />
-		<road tag="highway" value="path" speed="12" priority="1" />
-		<road tag="highway" value="living_street" speed="15" priority="1.1" />
-		<road tag="highway" value="pedestrian" speed="10" priority="0.9" />
-		<road tag="highway" value="footway" speed="8" priority="0.9" />
-		<road tag="highway" value="byway" speed="8" priority="1" />
-		<road tag="highway" value="services" speed="13" priority="1" />
-		<road tag="highway" value="bridleway" speed="8" priority="0.8" />
-		<road tag="highway" value="steps" speed="3" priority="0.5" />
-		<road tag="route" value="ferry" speed="5" priority="1.0" >
-			<specialization input="avoid_ferries" speed="0"/>
-		</road>
-		
-
-		<obstacle tag="highway" value="traffic_signals" penalty="30" routingPenalty="10"/>
-		<obstacle tag="highway" value="stop" penalty="15" routingPenalty="1"/>
-		<obstacle tag="highway" value="give_way" penalty="7"/>
-		<obstacle tag="highway" value="ford" penalty="15"/>
-		<obstacle tag="ford" value="" penalty="15"/>
-		<obstacle tag="railway" value="crossing" penalty="5"/>
-		<obstacle tag="railway" value="level_crossing" penalty="5"/>
-		<obstacle tag="barrier" value="cycle_barrier" penalty="10"/>
-		
-		
-		<avoid tag="tracktype" value="grade2" decreasedPriority="1">
-			<specialization input="avoid_unpaved" decreasedPriority="0.4"/>
-		</avoid>
-		<avoid tag="tracktype" value="grade3" decreasedPriority="1">
-			<specialization input="avoid_unpaved" decreasedPriority="0.1"/>
-		</avoid>
-		<avoid tag="tracktype" value="grade4" decreasedPriority="0.8">
-			<specialization input="avoid_unpaved" decreasedPriority="0.1"/>
-		</avoid>
-		<avoid tag="tracktype" value="grade5" decreasedPriority="0.8">
-			<specialization input="avoid_unpaved" decreasedPriority="0.1"/>
-		</avoid>
-		<avoid tag="surface" value="compacted" decreasedPriority="1">
-			<specialization input="avoid_unpaved" decreasedPriority="0.4"/>
-		</avoid>
-		<avoid tag="surface" value="dirt" decreasedPriority="0.8">
-			<specialization input="avoid_unpaved" decreasedPriority="0.1"/>
-		</avoid>
-		<avoid tag="surface" value="earth" decreasedPriority="0.8">
-			<specialization input="avoid_unpaved" decreasedPriority="0.1"/>
-		</avoid>
-		<avoid tag="surface" value="gravel" decreasedPriority="0.8">
-			<specialization input="avoid_unpaved" decreasedPriority="0.1"/>
-		</avoid>
-		<avoid tag="surface" value="fine_gravel" decreasedPriority="1">
-			<specialization input="avoid_unpaved" decreasedPriority="0.4"/>
-		</avoid>
-		<avoid tag="surface" value="grass" decreasedPriority="0.8">
-			<specialization input="avoid_unpaved" decreasedPriority="0.1"/>
-		</avoid>
-		<avoid tag="surface" value="ground" decreasedPriority="0.8">
-			<specialization input="avoid_unpaved" decreasedPriority="0.1"/>
-		</avoid>
-		<avoid tag="surface" value="mud" decreasedPriority="0.8">
-			<specialization input="avoid_unpaved" decreasedPriority="0.1"/>
-		</avoid>
-		<avoid tag="surface" value="pebblestone" decreasedPriority="0.8">
-			<specialization input="avoid_unpaved" decreasedPriority="0.1"/>
-		</avoid>
-		<avoid tag="surface" value="sand" decreasedPriority="0.8">
-			<specialization input="avoid_unpaved" decreasedPriority="0.1"/>
-		</avoid>
-		<avoid tag="surface" value="wood" decreasedPriority="0.8">
-			<specialization input="avoid_unpaved" decreasedPriority="0.1"/>
-		</avoid>
-		<avoid tag="surface" value="unpaved" decreasedPriority="0.8">
-			<specialization input="avoid_unpaved" decreasedPriority="0.1"/>
-		</avoid>
-		<avoid tag="access" value="private" decreasedPriority="0.1"/>
-		<avoid tag="barrier" value="debris" decreasedPriority="0.1"/>
-
-		<avoid tag="bicycle" value="no"/>
-=======
->>>>>>> upstream/master
 	</routingProfile>
 
 	<routingProfile name="pedestrian" baseProfile="pedestrian" restrictionsAware="false" minDefaultSpeed="3" maxDefaultSpeed="5"
@@ -597,7 +490,6 @@
 		</point>
 
 
-		
 	</routingProfile>
 
 </osmand_routing_config>


### PR DESCRIPTION
I moved all the highway entries for bicycle routing from the priorities section to speed section, so they only show up once. I calculated the new speeds using speed=priority*16km/h.
