### PR TITLE
Add international, national and local network nodes to cycle/walking networks

### DIFF
--- a/obf_creation/rendering_types.xml
+++ b/obf_creation/rendering_types.xml
@@ -843,9 +843,11 @@
 		<type tag="amenity" value="car_wash" minzoom="15" />
 		<type tag="amenity" value="grit_bin" minzoom="15" />
 		<type tag="amenity" value="compressed_air" minzoom="15" />
+		<type tag="iwn_ref" value="" minzoom="14" nameTags="iwn_ref" poi_prefix="walking_node_"/>
 		<type tag="nwn_ref" value="" minzoom="14" nameTags="nwn_ref" poi_prefix="walking_node_"/>
 		<type tag="rwn_ref" value="" minzoom="14" nameTags="rwn_ref" poi_prefix="walking_node_"/>
 		<type tag="lwn_ref" value="" minzoom="14" nameTags="lwn_ref" poi_prefix="walking_node_"/>
+		<type tag="icn_ref" value="" minzoom="14" nameTags="icn_ref" poi_prefix="cycle_node_"/>
 		<type tag="ncn_ref" value="" minzoom="14" nameTags="ncn_ref" poi_prefix="cycle_node_"/>
 		<type tag="rcn_ref" value="" minzoom="14" nameTags="rcn_ref" poi_prefix="cycle_node_"/>
 		<type tag="lcn_ref" value="" minzoom="14" nameTags="lcn_ref" poi_prefix="cycle_node_"/>


### PR DESCRIPTION
OsmAnd only displayed regional network nodes. Also added international (iwn/icn), national (nwn/ncn) and local (lwn/lcn) network nodes.
Might need second step to modify render.xml files.
