### PR TITLE
Update rendering_types; add routing nodes

### DIFF
--- a/obf_creation/rendering_types.xml
+++ b/obf_creation/rendering_types.xml
@@ -229,14 +229,14 @@
 	</category>
 
 	<category name="routing nodes">
-		<type tag="iwn_ref" value="" minzoom="14" nameTags="iwn_ref" minzoom="8"/>
-		<type tag="nwn_ref" value="" minzoom="14" nameTags="nwn_ref" minzoom="8"/>
-		<type tag="rwn_ref" value="" minzoom="14" nameTags="rwn_ref" minzoom="8"/>
-		<type tag="lwn_ref" value="" minzoom="14" nameTags="lwn_ref" minzoom="8"/>
-		<type tag="icn_ref" value="" minzoom="14" nameTags="icn_ref" minzoom="8"/>
-		<type tag="ncn_ref" value="" minzoom="14" nameTags="ncn_ref" minzoom="8"/>
-		<type tag="rcn_ref" value="" minzoom="14" nameTags="rcn_ref" minzoom="8"/>
-		<type tag="lcn_ref" value="" minzoom="14" nameTags="lcn_ref" minzoom="8"/>
+		<type tag="iwn_ref" value="" nameTags="iwn_ref" minzoom="8"/>
+		<type tag="nwn_ref" value="" nameTags="nwn_ref" minzoom="8"/>
+		<type tag="rwn_ref" value="" nameTags="rwn_ref" minzoom="8"/>
+		<type tag="lwn_ref" value="" nameTags="lwn_ref" minzoom="8"/>
+		<type tag="icn_ref" value="" nameTags="icn_ref" minzoom="8"/>
+		<type tag="ncn_ref" value="" nameTags="ncn_ref" minzoom="8"/>
+		<type tag="rcn_ref" value="" nameTags="rcn_ref" minzoom="8"/>
+		<type tag="lcn_ref" value="" nameTags="lcn_ref" minzoom="8"/>
 	</category>
 
 	<category name="tracktype">


### PR DESCRIPTION
As a lot of cycle routes are mixed relations with walking routes we do need a specific category that separates the nodes from the routes, otherwise OsmAnd mixes them (walking routes with cycling nodes and vice versa).
