### PR TITLE
Update default.render.xml

### DIFF
--- a/rendering_styles/default.render.xml
+++ b/rendering_styles/default.render.xml
@@ -2302,7 +2302,8 @@
 			<filter tag="cycleway" value="lane"/>
 			<filter tag="cycleway" value="track"/>
 			<filter tag="cycleway" value="opposite_lane"/>
-			<groupFilter appMode="bicycle" minzoom="14" color="#0000ff" strokeWidth="2" pathEffect="8_4"/>
+			<groupFilter minzoom="14" color="#0000ff" strokeWidth="2" pathEffect="8_4"/>
+			<groupFilter appMode="car" disable="true"/>
 		</group>
 
 		<filter appMode="bicycle" tag="cycleway" minzoom="14" value="share_busway" color="#0000ff" strokeWidth="2" pathEffect="8_8"/>


### PR DESCRIPTION
Cycleways as lanes were only displayed in bicycle mode. They need to be displayed in all modes except car modes. In browse mode I want to know where I can bicycle as well and in hiking mode it can be useful as well.
