### PR TITLE
Add agricultural/forestry/delivery/private restrictions to "car" routing...

### DIFF
--- a/routing/routing.xml
+++ b/routing/routing.xml
@@ -78,12 +78,19 @@
 				<select value="-1" t="surface" v="wood"/>
 			</if>
 			<select value="-1" t="access" v="no"/>
+			<select value="-1" t="access" v="agricultural"/>
+			<select value="-1" t="access" v="forestry"/>
 			<!-- introduce special tag motorcycle ! -->
 			<!-- <select value="-1" t="motorcycle" v="no"/>-->
 			<select value="-1" t="motorcar" v="no"/>
+			<select value="-1" t="motorcar" v="agricultural"/>
+			<select value="-1" t="motorcar" v="forestry"/>
 			<select value="-1" t="motor_vehicle" v="no"/>
 			<select value="-1" t="motor_vehicle" v="agricultural"/>
+			<select value="-1" t="motor_vehicle" v="forestry"/>
 			<select value="-1" t="vehicle" v="no"/>
+			<select value="-1" t="vehicle" v="agricultural"/>
+			<select value="-1" t="vehicle" v="forestry"/>
 			<select value="-1" t="barrier" v="bollard"/>
 			<select value="-1" t="barrier" v="chain"/>
 			<select value="-1" t="barrier" v="debris"/>
@@ -194,8 +201,16 @@
 			<select t="tracktype" v="grade5" value="0.1"/>
 			<select t="access" v="private" value="0.05"/>
 			<select t="access" v="destination" value="0.05"/>
+			<select t="access" v="delivery" value="0.05"/>
 			<select t="motor_vehicle" v="private" value="0.05"/>
+			<select t="motor_vehicle" v="destination" value="0.05"/>
+			<select t="motor_vehicle" v="delivery" value="0.05"/>
+			<select t="motorcar" v="private" value="0.05"/>
 			<select t="motorcar" v="destination" value="0.05"/>
+			<select t="motorcar" v="delivery" value="0.05"/>
+			<select t="vehicle" v="private" value="0.05"/>
+			<select t="vehicle" v="destination" value="0.05"/>
+			<select t="vehicle" v="delivery" value="0.05"/>
 			<select t="motorcycle" v="destination" value="0.05"/>
 
 			<select value="1.1" t="highway" v="motorway"/>


### PR DESCRIPTION
... in routing.xml.

Cars should not be allowed into agricultural/forestry designated roads (both values are used according to taginfo and are documented). Also, going into private/delivery only roads should only be possible as last resort (e.g. to reach the final destination point).

Something should also be done with access=customers, but I am not sure what the 'value' should be in that case. It probably doesn't matter that there is no rule for that as such roads are often leaf and no exit roads so OsmAnd is not needing them for drive-though.
