### PR TITLE
Avoid trunks too if "avoid_motorway" is selected.

### DIFF
--- a/routing/routing.xml
+++ b/routing/routing.xml
@@ -55,6 +55,12 @@
 			<select value="-1" t="highway" v="motorway_link">
 				<if param="avoid_motorway"/>
 			</select>
+			<select value="-1" t="highway" v="trunk">
+				<if param="avoid_motorway"/>
+			</select>
+			<select value="-1" t="highway" v="trunk_link">
+				<if param="avoid_motorway"/>
+			</select>
 			<select value="-1" t="toll" v="yes">
 				<if param="avoid_toll"/>
 			</select>


### PR DESCRIPTION
Trunks are already considered as motorways in the "prefer_motorway" option below so make it consistent. This should fix ticket 811, which is now inaccessible to me due to unknown reasons.
