### PR TITLE
Do not add road class transition penalty in routing.xml if determining s...

### DIFF
--- a/routing/routing.xml
+++ b/routing/routing.xml
@@ -143,7 +143,10 @@
 			<if param="no_new_routing">
 				<select value="0"/>
 			</if>
-
+			<if param="short_way">
+				<select value="0"/>
+			</if>
+			
 			<select value="0" t="highway" v="motorway"/>
 			<select value="0" t="highway" v="motorway_link"/>
 			<select value="0" t="highway" v="trunk"/>
@@ -166,7 +169,6 @@
 			<select value="" t="highway" v="living_street"/>
 			<select value="" t="route" v="ferry"/>-->
 		</way>
-
 
 		<way attribute="speed" type="speed">
 			<!-- shortway handled internally -->


### PR DESCRIPTION
...hortest way.

The penalty probably shouldn't be added if looking for shortest way. Otherwise a longer road may be chosen, that has less penalty.
