### PR TITLE
Fix access permission hierarchy in rounting.xml

### DIFF
--- a/routing/routing.xml
+++ b/routing/routing.xml
@@ -96,11 +96,6 @@
 				<select value="-1" t="surface" v="sand"/>
 				<select value="-1" t="surface" v="wood"/>
 			</if>
-			<select value="-1" t="access" v="no"/>
-			<select value="-1" t="access" v="agricultural"/>
-			<select value="-1" t="access" v="forestry"/>
-			<!-- introduce special tag motorcycle ! -->
-			<!-- <select value="-1" t="motorcycle" v="no"/>-->
 			<select value="-1" t="motorcar" v="no"/>
 			<select value="-1" t="motorcar" v="agricultural"/>
 			<select value="-1" t="motorcar" v="forestry"/>
@@ -110,6 +105,11 @@
 			<select value="-1" t="vehicle" v="no"/>
 			<select value="-1" t="vehicle" v="agricultural"/>
 			<select value="-1" t="vehicle" v="forestry"/>
+			<select value="-1" t="access" v="no"/>
+			<select value="-1" t="access" v="agricultural"/>
+			<select value="-1" t="access" v="forestry"/>
+			<!-- introduce special tag motorcycle ! --><!-- What is special in it? It is a defined value and used in the database -->
+			<!-- <select value="-1" t="motorcycle" v="no"/>-->
 			<select value="-1" t="barrier" v="bollard"/>
 			<select value="-1" t="barrier" v="chain"/>
 			<select value="-1" t="barrier" v="debris"/>
@@ -220,19 +220,19 @@
 			</if>
 			<!-- access deprioritize -->
 			<select t="tracktype" v="grade5" value="0.1"/>
-			<select t="access" v="private" value="0.05"/>
-			<select t="access" v="destination" value="0.05"/>
-			<select t="access" v="delivery" value="0.05"/>
-			<select t="motor_vehicle" v="private" value="0.05"/>
-			<select t="motor_vehicle" v="destination" value="0.05"/>
-			<select t="motor_vehicle" v="delivery" value="0.05"/>
 			<select t="motorcar" v="private" value="0.05"/>
 			<select t="motorcar" v="destination" value="0.05"/>
 			<select t="motorcar" v="delivery" value="0.05"/>
+			<select t="motorcycle" v="destination" value="0.05"/> <!-- Why is this here? A car can't go where a motorcycle could -->
+			<select t="motor_vehicle" v="private" value="0.05"/>
+			<select t="motor_vehicle" v="destination" value="0.05"/>
+			<select t="motor_vehicle" v="delivery" value="0.05"/>
 			<select t="vehicle" v="private" value="0.05"/>
 			<select t="vehicle" v="destination" value="0.05"/>
 			<select t="vehicle" v="delivery" value="0.05"/>
-			<select t="motorcycle" v="destination" value="0.05"/>
+			<select t="access" v="private" value="0.05"/>
+			<select t="access" v="destination" value="0.05"/>
+			<select t="access" v="delivery" value="0.05"/>
 
 			<select value="1.1" t="highway" v="motorway"/>
 			<select value="1.1" t="highway" v="motorway_link"/>
@@ -278,32 +278,32 @@
 		</point>
 
 		<point attribute="obstacle">
-			<select value="-1" t="access" v="no"/>
-			<select value="-1" t="access" v="agricultural"/>
-			<select value="-1" t="access" v="forestry"/>
-			<select value="-1" t="vehicle" v="no"/>
-			<select value="-1" t="vehicle" v="agricultural"/>
-			<select value="-1" t="vehicle" v="forestry"/>
 			<select value="-1" t="motorcar" v="no"/>
 			<select value="-1" t="motorcar" v="agricultural"/>
 			<select value="-1" t="motorcar" v="forestry"/>
 			<select value="-1" t="motor_vehicle" v="no"/>
 			<select value="-1" t="motor_vehicle" v="agricultural"/>
 			<select value="-1" t="motor_vehicle" v="forestry"/>
-			
+			<select value="-1" t="vehicle" v="no"/>
+			<select value="-1" t="vehicle" v="agricultural"/>
+			<select value="-1" t="vehicle" v="forestry"/>
+			<select value="-1" t="access" v="no"/>
+			<select value="-1" t="access" v="agricultural"/>
+			<select value="-1" t="access" v="forestry"/>
+
 			<!-- If access for a car is explicitly marked, the barrier is passable. -->
-			<select value="1" t="access" v="yes"/>
-			<select value="1" t="vehicle" v="yes"/>
-			<select value="1" t="motor_vehicle" v="yes"/>
 			<select value="1" t="motorcar" v="yes"/>
-			<select value="1" t="access" v="permissive"/>
-			<select value="1" t="vehicle" v="permissive"/>
-			<select value="1" t="motor_vehicle" v="permissive"/>
 			<select value="1" t="motorcar" v="permissive"/>
-			<select value="1" t="vehicle" v="designated"/>
-			<select value="1" t="motor_vehicle" v="designated"/>
 			<select value="1" t="motorcar" v="designated"/>
-			
+			<select value="1" t="motor_vehicle" v="yes"/>
+			<select value="1" t="motor_vehicle" v="permissive"/>
+			<select value="1" t="motor_vehicle" v="designated"/>
+			<select value="1" t="vehicle" v="yes"/>
+			<select value="1" t="vehicle" v="permissive"/>
+			<select value="1" t="vehicle" v="designated"/>
+			<select value="1" t="access" v="yes"/>
+			<select value="1" t="access" v="permissive"/>
+
 			<select value="5"   t="barrier" v="cattle_grid"/>
 			<select value="1"   t="barrier" v="border_control"/>
 			<select value="300" t="barrier" v="bump_gate"/>


### PR DESCRIPTION
As the file is evaluated from top to bottom and the first match to hit wins, the hierarchical access tags must be ordered from the most specific one to the most general one. A road can be marked access=no + motorcar=yes and will be passable by a car (or access=yes, motor_vehicle=no is not passable by a car). So we must act on the motorcar=yes, not on the access=no.
