### PR TITLE
Fixed "hangup" in endsWithString with long strings

### DIFF
--- a/voice/de/ttsconfig.p
+++ b/voice/de/ttsconfig.p
@@ -142,7 +142,7 @@ removeSemicolonAto(A1,A2) :- atom_codes(A1,S1),removeSemicolonStr(S1,S2),atom_co
 reverseStr([H|T], A, R) :- reverseStr(T, [H|A], R).
 reverseStr([], A, A).
 
-% Utility: toLowerCaseStr(OldString,NewString)
+% Utility: startsWithStr(String,Match)
 startsWithStr([],[]).
 startsWithStr([H1|T1],[]):- startsWithStr(T1,[]).
 startsWithStr([H1|T1],[H1|T2]):- startsWithStr(T1,T2).


### PR DESCRIPTION
- In previous version sub_atom/5 was used to check for substring. This is very slow with strings longer then 15 chars. No we reverse the string and see if head of list is same. Works better.
- Add "platz" to list of male streets.
