### PR TITLE
Update rendering_types.xml

### DIFF
--- a/obf_creation/rendering_types.xml
+++ b/obf_creation/rendering_types.xml
@@ -687,9 +687,9 @@
 
 
 	<category name="man_made" poi_tag="man_made" poi_category="man_made">
-		<type tag="building" minzoom="16" poi_category="" nameTags="addr:housenumber,addr:flats" order="70"/>
+	<!--	<type tag="building" minzoom="16" poi_category="" nameTags="addr:housenumber,addr:flats" order="70"/>
 		<type tag="addr:housenumber" minzoom="16" poi_category="" nameTags="addr:housenumber"/>
-		<type tag="addr:flats" minzoom="16" poi_category="" nameTags="addr:flats,ref"/>
+		<type tag="addr:flats" minzoom="16" poi_category="" nameTags="addr:flats,ref"/> -->
 		<type tag="entrance" value="main" nameTags="addr:flats" minzoom="17" poi_category="" />
 		<type tag="entrance" value="main_entrance" target_value="main" minzoom="17" poi_category="" />
 		<type tag="entrance" value="yes" nameTags="addr:flats" minzoom="17" poi_category="" />


### PR DESCRIPTION
The first 3 lines (690, 691 & 692) of this section make that all houses turn into POIs. This is absolutely terrible as it will make it almost impossible to search on real POIs.
As far as I'm concerned the entrance tags should be removed as well as they are not POIs either, but as the number entrance tags is minimal compared to housenumbers it is of less concern.
