### PR TITLE
Rendering bicycle networks names bug fix

### DIFF
--- a/rendering_styles/default.render.xml
+++ b/rendering_styles/default.render.xml
@@ -1869,10 +1869,6 @@
 			<case tag="rcn_network" value="rcn" nameTag="rcn_ref" textOrder="8"/>
 			<case tag="ncn_network" value="ncn" nameTag="ncn_ref" textOrder="7"/>
 			<case tag="icn_network" value="icn" nameTag="icn_ref" textOrder="7"/>
-			<case tag="lcn_network" value="lcn" nameTag="ref" textOrder="9"/>
-			<case tag="rcn_network" value="rcn" nameTag="ref" textOrder="8"/>
-			<case tag="ncn_network" value="ncn" nameTag="ref" textOrder="7"/>
-			<case tag="icn_network" value="icn" nameTag="ref" textOrder="7"/>
 			<case tag="network" value="lcn" nameTag="lcn_ref" textOrder="9"/>
 			<case tag="network" value="rcn" nameTag="rcn_ref" textOrder="8"/>
 			<case tag="network" value="ncn" nameTag="ncn_ref" textOrder="7"/>


### PR DESCRIPTION
I suppose this piece of code is unnecessary, because cause incorrect display of cycling networks names.
