### PR TITLE
Pulling up the "highway-path" and "highway-footway" in bicycle mode

### DIFF
--- a/rendering_styles/default.render.xml
+++ b/rendering_styles/default.render.xml
@@ -1157,10 +1157,12 @@
 				<switch>
 					<case tag="highway" value="path" order="37">
 						<apply_if appMode="pedestrian" order="60"/>
+						<apply_if appMode="bicycle" order="60"/>
 						<apply_if layer="1" order="90"/>
 					</case>
 					<case tag="highway" value="footway" order="37">
 						<apply_if appMode="pedestrian" order="60"/>
+						<apply_if appMode="bicycle" order="60"/>
 						<apply_if layer="1" order="90"/>
 						<apply_if additional="footway=crossing" order="90"/>
 					</case>


### PR DESCRIPTION
I think it would be better that in the bicycle mode the paths were more visible, as in pedestrian mode or like eg in OpenCycleMap.
