### PR TITLE
Suppressing warning in ttsconfig.p

### DIFF
--- a/voice/cs/ttsconfig.p
+++ b/voice/cs/ttsconfig.p
@@ -291,9 +291,9 @@ hours(S, []) :- S < 60.
 hours(S, ['1_hour.ogg']) :- S < 120, H is S div 60, pnumber(H, Ogg).
 hours(S, [Ogg, 'hours.ogg']) :- H is S div 60, pnumber(H, Ogg).
 time(Sec) -- ['less_a_minute.ogg'] :- Sec < 30.
-time(Sec) -- [H, '1_minute.ogg'] :- tts, S is round(Sec/60.0), hours(S, H), St is S mod 60, St = 1, pnumber(St, Ogg).
+time(Sec) -- [H, '1_minute.ogg'] :- tts, S is round(Sec/60.0), hours(S, H), St is S mod 60, St = 1, pnumber(St, _Ogg).
 time(Sec) -- [H, Ogg, 'minutes.ogg'] :- tts, S is round(Sec/60.0), hours(S, H), St is S mod 60, pnumber(St, Ogg).
-time(Sec) -- [Ogg, 'minutes.ogg'] :- not(tts), Sec < 300, St is Sec/60, pnumber(St, Ogg).
+time(Sec) -- [Ogg, 'minutes.ogg'] :- not(tts), Sec < 300, St is Sec/60, pnumber(St, _Ogg).
 time(Sec) -- [H, Ogg, 'minutes.ogg'] :- not(tts), S is round(Sec/300.0) * 5, hours(S, H), St is S mod 60, pnumber(St, Ogg).
 
 

--- a/voice/cs/ttsconfig.p
+++ b/voice/cs/ttsconfig.p
@@ -1,7 +1,10 @@
-﻿% for turbo-prolog
+﻿% conditional compilation of operation -- creation (for portability betwean turbo and swi prolog)
+:- if(not(catch(op(500, xfy,'--'),_,fail))).
 :- op('--', xfy, 500).
-% for swi-prolog
-:- op(500, xfy,'--').
+:- endif.
+
+% suppresing warnings that string and -- are not defined on consecutive lines.
+:- discontiguous(string/2,(--)/2).
 
 version(102).
 tts :- version(X), X > 99.


### PR DESCRIPTION
There were several warnings in swi-prolog when reading the file. I have suppressed the warnings which are not oging to be corrected and corrected others. I am not familiar with turbo prolog, so please test it. According to their manual it should work. If this patch get thtough, I can prepare similar patches to other ttsconfig files, so there are not warnings and it is little cleaner.