### PR TITLE
Update routing.xml; Refine penalties

### DIFF
--- a/routing/routing.xml
+++ b/routing/routing.xml
@@ -158,16 +158,16 @@
 			</if>
 			
 			<select value="0" t="highway" v="motorway"/>
-			<select value="0" t="highway" v="motorway_link"/>
-			<select value="0" t="highway" v="trunk"/>
-			<select value="0" t="highway" v="trunk_link"/>
+			<select value="10" t="highway" v="motorway_link"/>
+			<select value="10" t="highway" v="trunk"/>
+			<select value="15" t="highway" v="trunk_link"/>
 			<select value="50" t="highway" v="primary"/>
 			<select value="50" t="highway" v="primary_link"/>
 			<select value="100" t="highway" v="secondary"/>
 			<select value="100" t="highway" v="secondary_link"/>
 			<select value="150" t="highway" v="tertiary"/>
 			<select value="150" t="highway" v="tertiary_link"/>
-			<select value="250"/>
+			<select value="200"/>
 			
 			<!--
 			<select value="" t="highway" v="road"/>


### PR DESCRIPTION
Add this moment there are no penalties when going from motorway to motorway_link (and trunk to trunk_link). It sometimes happens that when a motorway_link exiting from a motorway, running parallel to the motorway, and leading back to the motorway is chosen by OsmAnd. This happens when the motorway_link is the inner bend and the motorway is the outer bend, causing the motorway_link to be 1-2 seconds faster (in theory).
The other requirement is that both the motorway and motorway_link don't have a maxspeed or have the same maxspeed.

Additionally I lowered the overall select value as in cities the value of 250 is a bit too much. For longer routes it is less critical.

Solution for penalties contributed by Peter B. in the mailing list.
Lowering overall value based on an issue in the mailing list and by a little trial & error by myself.