### PR TITLE
Add "abutters" tag to routing section.

### DIFF
--- a/obf_creation/rendering_types.xml
+++ b/obf_creation/rendering_types.xml
@@ -2028,7 +2028,7 @@
 		<type tag="seamark:small_craft_facility:category" minzoom="13" additional="true"/>
 		<type tag="seamark:small_craft_facility:2:category" minzoom="13" additional="true"/>
 		<entity_convert pattern="tag_transform" from_tag="seamark:small_craft_facility:category" if_not_tag1="seamark:type" to_tag1="seamark:type" to_value1="small_craft_facility" to_tag2="seamark:small_craft_facility:category"/>
-		<!-- Shifting indexes to fix sitiation when :0: :1: :2: exists on the same object. This simplifies rendering style.
+		<!-- Shifting indexes to fix situation when :0: :1: :2: exists on the same object. This simplifies rendering style.
 		     convert :2: to :3: if exists (:0: + :1:)
 		     convert :1: to :2: if exists :0:
 		     convert :1: to : if not exists :0: -->
@@ -2135,7 +2135,6 @@
 		<routing_type tag="bridge:name" mode="text"/>
 		<!-- avoid garbage in route types -->
 
-		<routing_type tag="toll" mode="amend" base="true"/>
 		<routing_type tag="roundabout" mode="amend" base="true"/>
 		<routing_type tag="oneway" mode="amend" base="true"/>
 		<routing_type tag="oneway:bicycle" mode="amend"/>
@@ -2218,6 +2217,7 @@
 		<routing_type tag="turn:lanes" mode="amend"/>
 		<routing_type tag="turn" mode="amend"/>
 		<routing_type tag="tunnel" mode="amend"/>
+		<routing_type tag="abutters" mode="amend"/>
 		
 	</category>
 </osmand_types>


### PR DESCRIPTION
Roads with "abutters" set may indicate whether the road is in a city (place) or not. Basing e.g. maxspeed on this tag can be beneficial for some countries.

And the "toll" rule seemed to be duplicate so I remove it.