### PR TITLE
Update routing.xml

### DIFF
--- a/routing/routing.xml
+++ b/routing/routing.xml
@@ -432,6 +432,10 @@
 				<select value="0.1" t="tracktype" v="grade3"/>
 				<select value="0.1" t="tracktype" v="grade4"/>
 				<select value="0.1" t="tracktype" v="grade5"/>
+				<select value="0.4" t="smoothness" v="very_bad"/>
+				<select value="0.1" t="smoothness" v="horrible"/>
+				<select value="0.1" t="smoothness" v="very_horrible"/>
+				<select value="0.1" t="smoothness" v="impassable"/>
 				<select value="0.1" t="surface" v="unpaved"/>
 				<select value="0.4" t="surface" v="compacted"/>
 				<select value="0.1" t="surface" v="dirt"/>
@@ -450,6 +454,8 @@
 			<select value="0.8" t="surface" v="grass"/>
 			<select value="0.8" t="tracktype" v="grade4"/>
 			<select value="0.8" t="tracktype" v="grade5"/>
+			<select value="0.8" t="smoothness" v="very_horrible"/>
+			<select value="0.8" t="smoothness" v="impassable"/>
 			<select value="0.1" t="access" v="private"/>
 			<select value="0.1" t="barrier" v="debris"/>
 


### PR DESCRIPTION
When you use "Avoid unpaved" at bicycle routing, there is no use of "smoothness" tag. At this time there are 260 000 + using of this tag according to http://taginfo.openstreetmap.org/keys/smoothness

So I added this tag to bicycle routing to \if param="avoid_unpaved"> with values very_bad, horrible, very_horrible, imapassable (according to wiki) and made values same as tracktype (0.4, 0.1, 0.1, 0.1). Also I added "smoothness" to \way attribute="priority">.