### PR TITLE
make barrier=gate impassable to a car by default

### DIFF
--- a/routing/routing.xml
+++ b/routing/routing.xml
@@ -262,18 +262,21 @@
 		</way>
 
 		<point attribute="obstacle_time">
+			<select value="25" t="barrier" v="toll_booth"/>
+			<select value="5"  t="barrier" v="entrance"/>
+			<select value="15" t="barrier" v="gate"/>
+			<select value="5"  t="barrier" v="height_restrictor"/>
 			<select value="25" t="barrier"/>
 			<select value="10" t="traffic_calming"/>
 			<select value="30" t="highway" v="traffic_signals"/>
 			<select value="15" t="highway" v="crossing"/>
 			<select value="15" t="highway" v="stop"/>
 			<select value="10" t="highway" v="give_way"/>
-			<select value="25" t="barrier" v="toll_booth"/>
 			<select value="25" t="highway" v="ford"/>
 			<select value="25" t="ford"/>
 
-			<select t="railway" v="crossing" value="25" />
-			<select t="railway" v="level_crossing" value="25"/>
+			<select value="25" t="railway" v="crossing"/>
+			<select value="25" t="railway" v="level_crossing"/>
 		</point>
 
 		<point attribute="obstacle">
@@ -312,21 +315,20 @@
 			<select value="300" t="barrier" v="border_control"/>
 			<select value="300" t="barrier" v="bump_gate"/>
 			<select value="1"   t="barrier" v="entrance"/>
-			<select value="300" t="barrier" v="gate"/>
 			<select value="100" t="barrier" v="height_restrictor"/>
 			<select value="300" t="barrier" v="lift_gate"/>
 			<select value="100" t="barrier" v="sally_port"/>
 			<select value="300" t="barrier" v="swing_gate"/>
-			<select value="1" t="barrier" v="toll_booth"/>
+			<select value="1"   t="barrier" v="toll_booth"/>
 			<!-- Without explicit access marking, barriers other than the listed values above are impassable to a car. -->
 			<select value="-1" t="barrier"/>
 
 			<select value="10" t="traffic_calming"/>
 			<!-- New introduction to not drive through city -->
-			<select value="15" t="highway" v="traffic_signals"/>			
+			<select value="15" t="highway" v="traffic_signals"/>
 
-			<select t="highway" v="ford" value="25"/>
-			<select t="ford" value="25"/>
+			<select value="25" t="highway" v="ford"/>
+			<select value="25" t="ford"/>
 		</point>
 	</routingProfile>
 


### PR DESCRIPTION
It seems the the default is access=no, unless marked otherwise (which OsmAnd already checks).

The other changes are just cleanup and lowering the time needed to cross an entrance/gate/restrictor with a car when it is passable for a car (passes the access checks).

(Once OsmAnd supports getting the height of the vehicle, barrier=height_restrictor can be checked against the height and the passed without much penalty).