### PR TITLE
Observe "abutters" tag in routing.xml.

### DIFF
--- a/routing/routing.xml
+++ b/routing/routing.xml
@@ -200,16 +200,9 @@
 			<!-- shortway handled internally -->
 			<select value="$maxspeed:practical" t="maxspeed:practical"/>
 			<select value="$maxspeed" t="maxspeed"/>
-			<select value="110" t="highway" v="motorway"/>
-			<select value="110" t="highway" v="motorway_link"/>
-			<select value="100" t="highway" v="trunk"/>
-			<select value="75" t="highway" v="trunk_link"/>
-			<!-- generally linking larger towns. -->
-			<select value="65" t="highway" v="primary"/>
-			<select value="50" t="highway" v="primary_link"/>
-			<!-- generally linking smaller towns and villages -->
-			<select value="60" t="highway" v="secondary"/>
-			<select value="50" t="highway" v="secondary_link"/>
+			
+			<!-- roads with speeds lower than 50 and those that we want to ignore abutters
+			     must be placed before the "abutters" block below. -->
 			<!-- important urban roads -->
 			<select value="45" t="highway" v="tertiary"/>
 			<select value="40" t="highway" v="tertiary_link"/>
@@ -223,6 +216,27 @@
 			<select value="30" t="highway" v="service"/>
 			<select value="25" t="highway" v="living_street"/>
 			<select value="15" t="route" v="ferry"/>
+
+			<!-- most important backbone roads -->
+			<select value="110" t="highway" v="motorway"/>
+			<select value="110" t="highway" v="motorway_link"/>
+			<select value="100" t="highway" v="trunk"/>
+			<select value="75" t="highway" v="trunk_link"/>
+
+			<!-- Some values of "abutters" mean the road is inside a place,
+			     so cap the speed even if it is a high level road (below). -->
+			<select value="50" t="abutters" v="residential"/>
+			<select value="50" t="abutters" v="commercial"/>
+			<select value="50" t="abutters" v="retail"/>
+			<select value="50" t="abutters" v="industrial"/>
+			<select value="50" t="abutters" v="mixed"/>
+
+			<!-- generally linking larger towns -->
+			<select value="65" t="highway" v="primary"/>
+			<select value="50" t="highway" v="primary_link"/>
+			<!-- generally linking smaller towns and villages -->
+			<select value="60" t="highway" v="secondary"/>
+			<select value="50" t="highway" v="secondary_link"/>
 		</way>
 
 		<way attribute="priority">


### PR DESCRIPTION
Some values of "abutters" mean that the road is inside a place (village, city, town), so a speed limit can apply. See http://wiki.openstreetmap.org/wiki/Abutters and https://wiki.openstreetmap.org/wiki/OSM_tags_for_routing/Maxspeed . It is not easily possible to determine this information from landuse or other methods (see the comments there), for some countries. For countries where it is possible is OsmAnd preprocessing the map files to include this information in some way?