### PR TITLE
Allow avoiding border crossings in car/bicycle routing.

### DIFF
--- a/routing/routing.xml
+++ b/routing/routing.xml
@@ -62,6 +62,7 @@
 		<parameter id="avoid_unpaved" name="Avoid unpaved roads" description="Avoid unpaved roads" type="boolean"/>
 		<parameter id="avoid_ferries" name="Avoid ferries" description="Avoid ferries" type="boolean"/>
 		<parameter id="avoid_motorway" name="Avoid motorways" description="Avoid motorways" type="boolean"/>
+		<parameter id="avoid_borders" name="Avoid border crossing" description="Avoid crossing a border into another country" type="boolean"/>
 		<parameter id="weight" name="Weight" description="Weight" type="numeric" values="0,1500,3000" valueDescriptions="-,1.5t,3t"/>
 
 		<way attribute="access">
@@ -313,6 +314,9 @@
 			<if param="avoid_toll">
 				<select value="-1" t="barrier" v="toll_booth"/>	
 			</if>
+			<if param="avoid_borders">
+				<select value="-1" t="barrier" v="border_control"/>
+			</if>
 			<!-- If access for a car is explicitly marked, the barrier is passable,
 			     with a slight penalty.
 			     If no access for a car is explicitly marked, the barrier is impassable.
@@ -372,6 +376,7 @@
 		<parameter id="avoid_ferries" name="Avoid ferries" description="Avoid ferries" type="boolean"/>
 		<parameter id="avoid_motorway" name="Avoid motorways" description="Avoid motorways" type="boolean"/>
 		<parameter id="avoid_unpaved" name="Avoid unpaved roads" description="Avoid unpaved roads" type="boolean"/>
+		<parameter id="avoid_borders" name="Avoid border crossing" description="Avoid crossing a border into another country" type="boolean"/>
 
 		<way attribute="access">
 			<if param="avoid_motorway">
@@ -538,6 +543,9 @@
 		</point>
 
 		<point attribute="obstacle">
+			<if param="avoid_borders">
+				<select value="-1" t="barrier" v="border_control"/>
+			</if>
 			<select value="-1" t="bicycle" v="no"/>
 			<select value="1"  t="bicycle" v="yes"/>
 			<select value="1"  t="bicycle" v="permissive"/>


### PR DESCRIPTION
Allow avoiding border crossings in car/bicycle routing. This can be useful for concave country parts (where the best route would be a shortcut trough another country). Or when there is a motorway near the border in the neighbouring country and OsmAnd would pick that as the fastest road. I have a real example of this case on a 400km trip (that OsmAnd calculated). It may be preferrable to avoid the foreign country, e.g. due to visa requirements, tolls, insurance coverage, etc. Of course best would be if OsmAnd considered administrative boundary relations to determine if a road is crossing into another country, but that is probably quite expensive for computation.