### PR TITLE
Fix for "Can't find poi typre for poi reference 'town_hall'

### DIFF
--- a/poi/phrases/it/phrases.xml
+++ b/poi/phrases/it/phrases.xml
@@ -484,7 +484,7 @@
 	<string name="poi_craft_tinsmith">Lattoniere</string>
 	<string name="poi_craft_upholsterer">Tappezziere</string>
 	<string name="poi_funeral_directors">Impresa di pompe funebri</string>
-	<string name="poi_town_hall">Municipio</string>
+	<string name="poi_townhall">Municipio</string>
 	<string name="poi_research">Centro di ricerca e sviluppo</string>
 	<string name="poi_it">Ufficio IT</string>
 	<string name="poi_newspaper">Redazione giornalistica</string>


### PR DESCRIPTION
There was a misspelling town_hall istead of townhall.