### PR TITLE
Add more weight options in routing.xml

### DIFF
--- a/routing/routing.xml
+++ b/routing/routing.xml
@@ -63,7 +63,7 @@
 		<parameter id="avoid_ferries" name="Avoid ferries" description="Avoid ferries" type="boolean"/>
 		<parameter id="avoid_motorway" name="Avoid motorways" description="Avoid motorways" type="boolean"/>
 		<parameter id="avoid_borders" name="Avoid border crossing" description="Avoid crossing a border into another country" type="boolean"/>
-		<parameter id="weight" name="Weight" description="Weight" type="numeric" values="0,1500,3000" valueDescriptions="-,1.5t,3t"/>
+		<parameter id="weight" name="Weight" description="Weight" type="numeric" values="0,1500,3000,5000,10000,15000,20000" valueDescriptions="-,1.5t,3t,5t,10t,15t,20t">/
 
 		<way attribute="access">
 			<select value="-1" t="highway" v="motorway">


### PR DESCRIPTION
I propose to add more weight options in routing.xml. Until there is a proper support for buses and hgvs in a special routing profile, I think these options need to be in car profile.

I wonder when HGV profile gets supported, it already can be enabled via developer plugin in OsmAnd. But there seem no special settings for it in routing.xml. I'd be happy if OsmAnd got a HGV and BUS profiles. Some of the maxheight, maxweight, maxlength and access options could be moved there so that the car profile does not have too many unnecessary options.