### PR TITLE
Remove unused oneway tags in routing.xml

### DIFF
--- a/routing/routing.xml
+++ b/routing/routing.xml
@@ -158,12 +158,10 @@
 
 		<way attribute="oneway">
 			<select value="1" t="oneway" v="yes"/>
-			<select value="-1" t="oneway" v="reverse"/>
 			<select value="1" t="oneway" v="1"/>
-			<select value="1" t="oneway" v="+1"/>
 			<select value="-1" t="oneway" v="-1"/>
-			<select value="1" t="roundabout" />
-			<select value="1" t="junction" v="roundabout" />
+			<select value="1" t="roundabout"/>
+			<select value="1" t="junction" v="roundabout"/>
 		</way>
 
 		<way attribute="penalty_transition">


### PR DESCRIPTION
The tags of oneway=reverse (not reversible) and oneway=+1 aren't used in the world, see http://taginfo.openstreetmap.org/keys/oneway . So we can probably get some speed by not looking for them.