### PR TITLE
In routing, disallow lift_gate and swing_gate access for cars by defa…

### DIFF
--- a/routing/routing.xml
+++ b/routing/routing.xml
@@ -385,6 +385,9 @@
 			<select value="100" t="barrier" v="height_restrictor"/>
 			<select value="100" t="barrier" v="sally_port"/>
 			<select value="1"   t="barrier" v="toll_booth"/>
+			<!-- These 2 shouldn't be allowed per the wiki (access=no is assumed) but people often do not add the proper access tags. -->
+			<select value="1000" t="barrier" v="lift_gate"/>
+			<select value="1000" t="barrier" v="swing_gate"/>
 			<!-- Without explicit access marking, barriers other than the listed values above are impassable to a car. -->
 			<select value="-1" t="barrier"/>
 

--- a/routing/routing.xml
+++ b/routing/routing.xml
@@ -101,6 +101,8 @@
 			<select value="1"  t="motorcar" v="yes"/>
 			<select value="1"  t="motorcar" v="permissive"/>
 			<select value="1"  t="motorcar" v="designated"/>
+			<select value="1"  t="motorcar" v="destination"/>
+			<select value="1"  t="motorcar" v="customers"/>
 
 			<select value="-1" t="motor_vehicle" v="no"/>
 			<select value="-1" t="motor_vehicle" v="agricultural"/>
@@ -108,6 +110,8 @@
 			<select value="1"  t="motor_vehicle" v="yes"/>
 			<select value="1"  t="motor_vehicle" v="permissive"/>
 			<select value="1"  t="motor_vehicle" v="designated"/>
+			<select value="1"  t="motor_vehicle" v="destination"/>
+			<select value="1"  t="motor_vehicle" v="customers"/>
 
 			<select value="-1" t="vehicle" v="no"/>
 			<select value="-1" t="vehicle" v="agricultural"/>
@@ -115,12 +119,16 @@
 			<select value="1"  t="vehicle" v="yes"/>
 			<select value="1"  t="vehicle" v="permissive"/>
 			<select value="1"  t="vehicle" v="designated"/>
+			<select value="1"  t="vehicle" v="destination"/>
+			<select value="1"  t="vehicle" v="customers"/>
 
 			<select value="-1" t="access" v="no"/>
 			<select value="-1" t="access" v="agricultural"/>
 			<select value="-1" t="access" v="forestry"/>
 			<select value="1"  t="access" v="yes"/>
 			<select value="1"  t="access" v="permissive"/>
+			<select value="1"  t="access" v="destination"/>
+			<select value="1"  t="access" v="customers"/>
 
 			<!-- introduce special tag motorcycle ! --><!-- What is special in it? It is a defined value and used in the database -->
 			<!-- <select value="-1" t="motorcycle" v="no"/>-->
@@ -254,16 +262,20 @@
 			<select t="motorcar" v="private" value="0.05"/>
 			<select t="motorcar" v="destination" value="0.05"/>
 			<select t="motorcar" v="delivery" value="0.05"/>
+			<select t="motorcar" v="customers" value="0.05"/>
 			<select t="motorcycle" v="destination" value="0.05"/> <!-- Why is this here? A car can't go where a motorcycle could -->
 			<select t="motor_vehicle" v="private" value="0.05"/>
 			<select t="motor_vehicle" v="destination" value="0.05"/>
 			<select t="motor_vehicle" v="delivery" value="0.05"/>
+			<select t="motor_vehicle" v="customers" value="0.05"/>
 			<select t="vehicle" v="private" value="0.05"/>
 			<select t="vehicle" v="destination" value="0.05"/>
 			<select t="vehicle" v="delivery" value="0.05"/>
+			<select t="vehicle" v="customers" value="0.05"/>
 			<select t="access" v="private" value="0.05"/>
 			<select t="access" v="destination" value="0.05"/>
 			<select t="access" v="delivery" value="0.05"/>
+			<select t="access" v="customers" value="0.05"/>
 
 			<select value="1.1" t="highway" v="motorway"/>
 			<!-- make links slightly smaller so in connections they will not be used -->
@@ -295,10 +307,12 @@
 		</way>
 
 		<point attribute="obstacle_time">
-			<select value="25" t="barrier" v="toll_booth"/>
 			<select value="5"  t="barrier" v="entrance"/>
 			<select value="15" t="barrier" v="gate"/>
 			<select value="5"  t="barrier" v="height_restrictor"/>
+			<select value="15" t="barrier" v="lift_gate"/>
+			<select value="30" t="barrier" v="swing_gate"/>
+			<select value="25" t="barrier" v="toll_booth"/>
 			<select value="25" t="barrier"/>
 			<select value="10" t="traffic_calming"/>
 			<select value="30" t="highway" v="traffic_signals"/>
@@ -335,6 +349,8 @@
 			<select value="1"  t="motorcar" v="yes"/>
 			<select value="1"  t="motorcar" v="permissive"/>
 			<select value="1"  t="motorcar" v="designated"/>
+			<select value="1"  t="motorcar" v="destination"/>
+			<select value="1"  t="motorcar" v="customers"/>
 
 			<select value="-1" t="motor_vehicle" v="no"/>
 			<select value="-1" t="motor_vehicle" v="agricultural"/>
@@ -342,6 +358,8 @@
 			<select value="1"  t="motor_vehicle" v="yes"/>
 			<select value="1"  t="motor_vehicle" v="permissive"/>
 			<select value="1"  t="motor_vehicle" v="designated"/>
+			<select value="1"  t="motor_vehicle" v="destination"/>
+			<select value="1"  t="motor_vehicle" v="customers"/>
 
 			<select value="-1" t="vehicle" v="no"/>
 			<select value="-1" t="vehicle" v="agricultural"/>
@@ -349,21 +367,23 @@
 			<select value="1"  t="vehicle" v="yes"/>
 			<select value="1"  t="vehicle" v="permissive"/>
 			<select value="1"  t="vehicle" v="designated"/>
+			<select value="1"  t="vehicle" v="destination"/>
+			<select value="1"  t="vehicle" v="customers"/>
 
 			<select value="-1" t="access" v="no"/>
 			<select value="-1" t="access" v="agricultural"/>
 			<select value="-1" t="access" v="forestry"/>
 			<select value="1"  t="access" v="yes"/>
 			<select value="1"  t="access" v="permissive"/>
+			<select value="1"  t="access" v="destination"/>
+			<select value="1"  t="access" v="customers"/>
 
 			<select value="5"   t="barrier" v="cattle_grid"/>
 			<select value="300" t="barrier" v="border_control"/>
 			<select value="300" t="barrier" v="bump_gate"/>
 			<select value="1"   t="barrier" v="entrance"/>
 			<select value="100" t="barrier" v="height_restrictor"/>
-			<select value="300" t="barrier" v="lift_gate"/>
 			<select value="100" t="barrier" v="sally_port"/>
-			<select value="300" t="barrier" v="swing_gate"/>
 			<select value="1"   t="barrier" v="toll_booth"/>
 			<!-- Without explicit access marking, barriers other than the listed values above are impassable to a car. -->
 			<select value="-1" t="barrier"/>


### PR DESCRIPTION
…ult, but also support destination and customers access.

According to http://wiki.openstreetmap.org/wiki/Barriers barriers with undocumented access default to access=no. So if there is no explicit access tag on the node, consider lift_gate and swing_gate as impassable with a car too. Lift_gate wiki even mentions cars cannot pass by default.

I expect some paid/mall parking areas to be blocked by a lift_gate tagged with access=customers or access=destination. So let's allow passing those by car, of course with a very low priority, so that the road is only chosen if it is the "last mile" to the destination.