### PR TITLE
Support access=official in routing.xml

### DIFF
--- a/routing/routing.xml
+++ b/routing/routing.xml
@@ -103,6 +103,7 @@
 			<select value="1"  t="motorcar" v="designated"/>
 			<select value="1"  t="motorcar" v="destination"/>
 			<select value="1"  t="motorcar" v="customers"/>
+			<select value="1"  t="motorcar" v="official"/>
 
 			<select value="-1" t="motor_vehicle" v="no"/>
 			<select value="-1" t="motor_vehicle" v="agricultural"/>
@@ -112,6 +113,7 @@
 			<select value="1"  t="motor_vehicle" v="designated"/>
 			<select value="1"  t="motor_vehicle" v="destination"/>
 			<select value="1"  t="motor_vehicle" v="customers"/>
+			<select value="1"  t="motor_vehicle" v="official"/>
 
 			<select value="-1" t="vehicle" v="no"/>
 			<select value="-1" t="vehicle" v="agricultural"/>
@@ -351,7 +353,8 @@
 			<select value="1"  t="motorcar" v="designated"/>
 			<select value="1"  t="motorcar" v="destination"/>
 			<select value="1"  t="motorcar" v="customers"/>
-
+			<select value="1"  t="motorcar" v="official"/>
+			
 			<select value="-1" t="motor_vehicle" v="no"/>
 			<select value="-1" t="motor_vehicle" v="agricultural"/>
 			<select value="-1" t="motor_vehicle" v="forestry"/>
@@ -360,6 +363,7 @@
 			<select value="1"  t="motor_vehicle" v="designated"/>
 			<select value="1"  t="motor_vehicle" v="destination"/>
 			<select value="1"  t="motor_vehicle" v="customers"/>
+			<select value="1"  t="motor_vehicle" v="official"/>
 
 			<select value="-1" t="vehicle" v="no"/>
 			<select value="-1" t="vehicle" v="agricultural"/>
@@ -425,6 +429,8 @@
 			<select value="1"  t="bicycle" v="yes"/>
 			<select value="1"  t="bicycle" v="permissive"/>
 			<select value="1"  t="bicycle" v="designated"/>
+			<select value="1"  t="bicycle" v="destination"/>
+			<select value="1"  t="bicycle" v="official"/>
 
 			<select value="-1" t="vehicle" v="no"/>
 			<select value="-1" t="vehicle" v="agricultural"/>
@@ -432,6 +438,7 @@
 			<select value="1"  t="vehicle" v="yes"/>
 			<select value="1"  t="vehicle" v="permissive"/>
 			<select value="1"  t="vehicle" v="designated"/>
+			<select value="1"  t="vehicle" v="destination"/>
 
 			<select value="-1" t="access" v="no"/>
 			<select value="-1" t="access" v="agricultural"/>
@@ -579,6 +586,7 @@
 			<select value="1"  t="bicycle" v="yes"/>
 			<select value="1"  t="bicycle" v="permissive"/>
 			<select value="1"  t="bicycle" v="designated"/>
+			<select value="1"  t="bicycle" v="official"/>
 
 			<select value="-1" t="vehicle" v="no"/>
 			<select value="-1" t="vehicle" v="agricultural"/>
@@ -626,6 +634,8 @@
 			<select value="1"  t="foot" v="yes"/>
 			<select value="1"  t="foot" v="permissive"/>
 			<select value="1"  t="foot" v="designated"/>
+			<select value="1"  t="foot" v="destination"/>
+			<select value="1"  t="foot" v="official"/>
 
 			<select value="-1" t="access" v="no"/>
 			<select value="1"  t="access" v="yes"/>
@@ -672,8 +682,11 @@
 
 		<way attribute="priority">
 			<!-- Additional tags -->
+			<select value="0.05" t="foot" v="private"/>
+			<select value="0.05" t="foot" v="destination"/>
 			<select value="0.05" t="access" v="private"/>
 			<select value="0.05" t="access" v="destination"/>
+
 			<select value="1.2" t="sidewalk" v="yes"/>
 			<select value="0.9" t="sidewalk" v="no"/>
 
@@ -709,13 +722,12 @@
 			<select value="1"  t="foot" v="yes"/>
 			<select value="1"  t="foot" v="permissive"/>
 			<select value="1"  t="foot" v="designated"/>
+			<select value="1"  t="foot" v="destination"/>
+			<select value="1"  t="foot" v="official"/>
 
 			<select value="-1" t="access" v="no"/>
 			<select value="1"  t="access" v="yes"/>
 			<select value="1"  t="access" v="permissive"/>
 		</point>
-
-
 	</routingProfile>
-
 </osmand_routing_config>


### PR DESCRIPTION
Access=official (and variants of it like bicycle=official and foot=official) are used quite a lot and and the roads should be at least as allowed and preferred as =designated. Let's support the value so that we mistakenly do not avoid roads like bicycle=official+vehicle=no.