### PR TITLE
Support some more access rules in bicycle mode

### DIFF
--- a/routing/routing.xml
+++ b/routing/routing.xml
@@ -520,6 +520,11 @@
 		</way>
 
 		<way attribute="priority">
+			<select value="0.1" t="bicycle" v="private"/>
+			<select value="0.1" t="bicycle" v="destination"/>
+			<select value="0.1" t="access" v="private"/>
+			<select value="0.1" t="barrier" v="debris"/>
+
 			<if param="avoid_unpaved">
 				<select value="0.4" t="tracktype" v="grade2"/>
 				<select value="0.1" t="tracktype" v="grade3"/>
@@ -543,12 +548,7 @@
 			<select value="0.8" t="surface" v="grass"/>
 			<select value="0.8" t="tracktype" v="grade4"/>
 			<select value="0.8" t="tracktype" v="grade5"/>
-			<select value="0.1" t="access" v="private"/>
-			<select value="0.1" t="barrier" v="debris"/>
-
-			<select value="1.4" t="bicycle" v="designated"/>
-			<select value="1.2" t="bicycle" v="yes"/>
-
+			
 			<select value="1.6" t="cycleway" v="lane"/>
 			<select value="1.6" t="cycleway" v="opposite_lane"/>
 			<select value="1.6" t="cycleway" v="share_busway"/>
@@ -558,6 +558,10 @@
 			<select value="1.6" t="cycleway" v="shared_lane"/>
 
 			<select value="1.5" t="highway" v="cycleway"/>
+
+			<select value="1.5" t="bicycle" v="official"/>
+			<select value="1.4" t="bicycle" v="designated"/>
+			<select value="1.2" t="bicycle" v="yes"/>
 
 			<select value="0.5" t="highway" v="motorway"/>
 			<select value="0.5" t="highway" v="motorway_link"/>


### PR DESCRIPTION
Improve priority of roads when bicycle=official/private/destination is set. Reorder the rules so that it makes sense for the first hit to win. E.g. cycleway=* should win even when bicycle=yes is set.