### PR TITLE
Prioritize foot=official paths in pedestrian mode

### DIFF
--- a/obf_creation/rendering_types.xml
+++ b/obf_creation/rendering_types.xml
@@ -2816,6 +2816,7 @@
 		<routing_type tag="enforcement" mode="amend"/>
 		<routing_type tag="ferry" mode="amend"/>
 		<routing_type tag="foot" mode="amend"/>
+		<routing_type tag="pedestrian" tag2="foot" mode="replace"/>
 		<routing_type tag="goods" mode="amend"/>
 		<routing_type tag="hgv" mode="amend"/>
 		<routing_type tag="horse" mode="amend"/>

--- a/routing/routing.xml
+++ b/routing/routing.xml
@@ -423,9 +423,9 @@
 			<select value="-1" t="route" v="ferry">
 				<if param="avoid_ferries"/>
 			</select>
-			<!-- <select value="-1" t="access" v="no"/> -->
 
 			<select value="-1" t="bicycle" v="no"/>
+			<select value="-1" t="bicycle" v="use_sidepath"/>
 			<select value="1"  t="bicycle" v="yes"/>
 			<select value="1"  t="bicycle" v="permissive"/>
 			<select value="1"  t="bicycle" v="designated"/>
@@ -546,9 +546,6 @@
 			<select value="0.1" t="access" v="private"/>
 			<select value="0.1" t="barrier" v="debris"/>
 
-			<select value="1.4" t="bicycle" v="designated"/>
-			<select value="1.2" t="bicycle" v="yes"/>
-
 			<select value="1.6" t="cycleway" v="lane"/>
 			<select value="1.6" t="cycleway" v="opposite_lane"/>
 			<select value="1.6" t="cycleway" v="share_busway"/>
@@ -558,6 +555,10 @@
 			<select value="1.6" t="cycleway" v="shared_lane"/>
 
 			<select value="1.5" t="highway" v="cycleway"/>
+
+			<select value="1.4" t="bicycle" v="designated"/>
+			<select value="1.3" t="bicycle" v="official"/>
+			<select value="1.2" t="bicycle" v="yes"/>
 
 			<select value="0.5" t="highway" v="motorway"/>
 			<select value="0.5" t="highway" v="motorway_link"/>
@@ -630,6 +631,7 @@
 				<if param="avoid_ferries"/>
 			</select>
 			<select value="-1" t="foot" v="no"/>
+			<select value="-1" t="foot" v="use_sidepath"/>
 			<select value="1"  t="foot" v="yes"/>
 			<select value="1"  t="foot" v="permissive"/>
 			<select value="1"  t="foot" v="designated"/>
@@ -683,7 +685,7 @@
 			<!-- Additional tags -->
 			<select value="0.05" t="foot" v="private"/>
 			<select value="0.05" t="foot" v="destination"/>
-			<select value="1.5" t="foot" v="official"/>
+			<select value="1.3" t="foot" v="official"/>
 			<select value="0.05" t="access" v="private"/>
 			<select value="0.05" t="access" v="destination"/>
 

--- a/routing/routing.xml
+++ b/routing/routing.xml
@@ -630,7 +630,6 @@
 				<if param="avoid_ferries"/>
 			</select>
 			<select value="-1" t="foot" v="no"/>
-			<select value="-1" t="pedestrian" v="no"/>
 			<select value="1"  t="foot" v="yes"/>
 			<select value="1"  t="foot" v="permissive"/>
 			<select value="1"  t="foot" v="designated"/>
@@ -684,6 +683,7 @@
 			<!-- Additional tags -->
 			<select value="0.05" t="foot" v="private"/>
 			<select value="0.05" t="foot" v="destination"/>
+			<select value="1.5" t="foot" v="official"/>
 			<select value="0.05" t="access" v="private"/>
 			<select value="0.05" t="access" v="destination"/>
 
@@ -718,7 +718,6 @@
 
 		<point attribute="obstacle">
 			<select value="-1" t="foot" v="no"/>
-			<select value="-1" t="pedestrian" v="no"/>
 			<select value="1"  t="foot" v="yes"/>
 			<select value="1"  t="foot" v="permissive"/>
 			<select value="1"  t="foot" v="designated"/>


### PR DESCRIPTION
Foot=official is used on officially marked paths that pedestrians should (and in some countries even must) use. So give it some priority. Also remove rules detecting "pedestrian=no" as that is an outdated tag no longer used much. We can support it via tag rewriting in rendering_types.xml.