### PR TITLE
Convert pedestrian=* to foot=* in rendering_types.xml

### DIFF
--- a/obf_creation/rendering_types.xml
+++ b/obf_creation/rendering_types.xml
@@ -2820,6 +2820,7 @@
 		<routing_type tag="enforcement" mode="amend"/>
 		<routing_type tag="ferry" mode="amend"/>
 		<routing_type tag="foot" mode="amend"/>
+		<routing_type tag="pedestrian" tag2="foot" mode="replace"/>
 		<routing_type tag="goods" mode="amend"/>
 		<routing_type tag="hgv" mode="amend"/>
 		<routing_type tag="horse" mode="amend"/>

--- a/routing/routing.xml
+++ b/routing/routing.xml
@@ -637,7 +637,6 @@
 				<if param="avoid_ferries"/>
 			</select>
 			<select value="-1" t="foot" v="no"/>
-			<select value="-1" t="pedestrian" v="no"/>
 			<select value="1"  t="foot" v="yes"/>
 			<select value="1"  t="foot" v="permissive"/>
 			<select value="1"  t="foot" v="designated"/>
@@ -725,7 +724,6 @@
 
 		<point attribute="obstacle">
 			<select value="-1" t="foot" v="no"/>
-			<select value="-1" t="pedestrian" v="no"/>
 			<select value="1"  t="foot" v="yes"/>
 			<select value="1"  t="foot" v="permissive"/>
 			<select value="1"  t="foot" v="designated"/>


### PR DESCRIPTION
pedestrian=* is an undocumented tag, is used only 600 times in the world and is seems people use it instead of foot=*. So convert it to foot=* so that we do not need to check for it in routing.xml.