### PR TITLE
also regard ATMs at banks and post office mapped as `atm=yes` when searching for ATMs

### DIFF
--- a/poi/phrases/de/phrases.xml
+++ b/poi/phrases/de/phrases.xml
@@ -36,6 +36,9 @@
 	<string name="poi_astronomical_observatory">Observatorium</string>
 	<string name="poi_athletics">Sport</string>
 	<string name="poi_atm">Geldautomat</string>
+	<string name="poi_atm:standalone">Geldautomat (frei stehend)</string>
+	<string name="poi_atm:at_bank">Geldautomat (in Bank)</string>
+	<string name="poi_atm:at_post_office">Geldautomat (in Post)</string>
 	<string name="poi_attraction">Attraktion</string>
 	<string name="poi_atv">Quad-Store</string>
 	<string name="poi_audiologist">Gehörspezialist</string>

--- a/poi/phrases/en/phrases.xml
+++ b/poi/phrases/en/phrases.xml
@@ -682,6 +682,9 @@
 
 	<string name="poi_bank">Bank</string>
 	<string name="poi_atm">ATM</string>
+	<string name="poi_atm:standalone">ATM (standalone)</string>
+	<string name="poi_atm:at_bank">ATM (at bank)</string>
+	<string name="poi_atm:at_post_office">ATM (at post office)</string>
 	<string name="poi_payment_terminal">Payment terminal</string>
 	<string name="poi_money_lender">Money lender</string>
 	<string name="poi_pawnbroker">Pawnbroker</string>

--- a/poi/poi_types.xml
+++ b/poi/poi_types.xml
@@ -786,7 +786,9 @@
 			<poi_type name="funeral_directors" tag="shop" value="funeral_directors"/>
 			<poi_reference name="bureau_de_change"/>
 			<poi_reference name="driving_school"/>
-			<poi_type name="post_office" tag="amenity" value="post_office"/>
+			<poi_type name="post_office" tag="amenity" value="post_office">
+				<poi_additional name="atm:at_post_office" tag="atm" value="yes"/>
+			</poi_type>
 			<poi_type name="post_box" tag="amenity" value="post_box"/>
 			<poi_type name="beauty" tag="shop" value="beauty">
 				<poi_additional name="beauty_salon_nails" tag="beauty" value="nails"/>
@@ -818,8 +820,14 @@
 			<poi_reference name="rest_area"/>
 		</poi_category>
 		<poi_category name="finance" default_tag="finance">
-			<poi_type name="bank" tag="amenity" value="bank"/>
-			<poi_type name="atm" tag="amenity" value="atm"/>
+			<poi_type name="bank" tag="amenity" value="bank">
+				<poi_additional name="atm:at_bank" tag="atm" value="yes"/>
+			</poi_type>
+			<poi_filter name="atm">
+				<poi_type name="atm:standalone" tag="amenity" value="atm"/>
+				<poi_reference name="atm:at_bank"/>
+				<poi_reference name="atm:at_post_office"/>
+			</poi_filter>
 			<poi_type name="payment_terminal" tag="amenity" value="payment_terminal"/>
 			<poi_type name="money_lender" tag="shop" value="money_lender"/>
 			<poi_type name="bureau_de_change" tag="amenity" value="bureau_de_change"/>


### PR DESCRIPTION
Follow up to #334. 

Do you think this one would work at least till a better solution would be implemented? If not, I'll patiently wait for a better implementation, I promise ;)

[Currently, 92 % of all `atm=yes` usages are in combination with `amenity=bank`](http://taginfo.openstreetmap.org/tags/atm=yes#combinations).

Thanks for considering this :)