### PR TITLE
Do not avoid highway=cycleway with conflicting vehicle tag

### DIFF
--- a/routing/routing.xml
+++ b/routing/routing.xml
@@ -435,7 +435,10 @@
 			<select value="1"  t="bicycle" v="destination"/>
 			<select value="1"  t="bicycle" v="official"/>
 
-			<select value="1" t="highway" v="cycleway"/>
+			<select value="-1" t="highway" v="motorway"/>
+			<select value="-1" t="highway" v="motorway_link"/>
+			<select value="1"  t="highway" v="cycleway"/>
+			<select value="1"  t="highway" v="path"/>
 
 			<select value="-1" t="vehicle" v="no"/>
 			<select value="-1" t="vehicle" v="agricultural"/>
@@ -451,8 +454,6 @@
 			<select value="1"  t="access" v="yes"/>
 			<select value="1"  t="access" v="permissive"/>
 
-			<select value="1" t="highway" v="motorway"/>
-			<select value="1" t="highway" v="motorway_link"/>
 			<select value="1" t="highway" v="trunk"/>
 			<select value="1" t="highway" v="trunk_link"/>
 			<select value="1" t="highway" v="primary"/>
@@ -466,7 +467,6 @@
 			<select value="1" t="highway" v="unclassified"/>
 			<select value="1" t="highway" v="service"/>
 			<select value="1" t="highway" v="track"/>
-			<select value="1" t="highway" v="path"/>
 			<select value="1" t="highway" v="living_street"/>
 			<select value="1" t="highway" v="pedestrian"/>
 			<select value="1" t="highway" v="footway"/>
@@ -644,12 +644,16 @@
 			<select value="1"  t="foot" v="destination"/>
 			<select value="1"  t="foot" v="official"/>
 
+			<select value="-1" t="highway" v="motorway"/>
+			<select value="-1" t="highway" v="motorway_link"/>
+			<select value="1"  t="highway" v="path"/>
+			<select value="1"  t="highway" v="pedestrian"/>
+			<select value="1"  t="highway" v="footway"/>
+
 			<select value="-1" t="access" v="no"/>
 			<select value="1"  t="access" v="yes"/>
 			<select value="1"  t="access" v="permissive"/>
 
-			<select value="1" t="highway" v="motorway"/>
-			<select value="1" t="highway" v="motorway_link"/>
 			<select value="1" t="highway" v="trunk"/>
 			<select value="1" t="highway" v="trunk_link"/>
 			<select value="1" t="highway" v="primary"/>
@@ -664,10 +668,7 @@
 			<select value="1" t="highway" v="unclassified"/>
 			<select value="1" t="highway" v="service"/>
 			<select value="1" t="highway" v="track"/>
-			<select value="1" t="highway" v="path"/>
 			<select value="1" t="highway" v="living_street"/>
-			<select value="1" t="highway" v="pedestrian"/>
-			<select value="1" t="highway" v="footway"/>
 			<select value="1" t="highway" v="byway"/>
 			<select value="1" t="highway" v="platform"/>
 			<select value="1" t="railway" v="platform"/>

--- a/routing/routing.xml
+++ b/routing/routing.xml
@@ -435,6 +435,8 @@
 			<select value="1"  t="bicycle" v="destination"/>
 			<select value="1"  t="bicycle" v="official"/>
 
+			<select value="1" t="highway" v="cycleway"/>
+
 			<select value="-1" t="vehicle" v="no"/>
 			<select value="-1" t="vehicle" v="agricultural"/>
 			<select value="-1" t="vehicle" v="forestry"/>
@@ -461,7 +463,6 @@
 			<select value="1" t="highway" v="tertiary_link"/>
 			<select value="1" t="highway" v="road"/>
 			<select value="1" t="highway" v="residential"/>
-			<select value="1" t="highway" v="cycleway"/>
 			<select value="1" t="highway" v="unclassified"/>
 			<select value="1" t="highway" v="service"/>
 			<select value="1" t="highway" v="track"/>


### PR DESCRIPTION
For example http://www.openstreetmap.org/way/126308212 is tagged
highway=cycleway and vehicle=agricultural, so this part of the national
cycle network was excluded from routing.