### PR TITLE
Discourage ways with *=use_sidepath

### DIFF
--- a/routing/routing.xml
+++ b/routing/routing.xml
@@ -476,6 +476,7 @@
 		</way>
 
 		<way attribute="priority">
+			<select value="0.1" t="bicycle" v="use_sidepath"/>
 			<if param="avoid_unpaved">
 				<select value="0.4" t="tracktype" v="grade2"/>
 				<select value="0.1" t="tracktype" v="grade3"/>
@@ -636,6 +637,8 @@
 			<select value="0.05" t="access" v="destination"/>
 			<select value="1.2" t="sidewalk" v="yes"/>
 			<select value="0.9" t="sidewalk" v="no"/>
+
+			<select value="0.1" t="foot" v="use_sidepath"/>
 
 			<!-- object tags -->
 			<select value="0.7" t="highway" v="motorway"/>


### PR DESCRIPTION
See http://wiki.openstreetmap.org/wiki/Tag:bicycle%3Duse_sidepath for how the tag is to be used.
At http://wiki.openstreetmap.org/wiki/Proposed_features/use_sidepath#Routing they specifically call out OsmAnd as not supporting the tag yet.
We could use value="-1" for some countries, while for some countries using such ways for foot/bicycle may still be allowed. So reducing the priority may be the middle ground.