### PR TITLE
Discourage ways with *=use_sidepath (copy of issue #338)

### DIFF
--- a/routing/routing.xml
+++ b/routing/routing.xml
@@ -433,7 +433,6 @@
 			<select value="-1" t="route" v="ferry">
 				<if param="avoid_ferries"/>
 			</select>
-			<!-- <select value="-1" t="access" v="no"/> -->
 
 			<select value="-1" t="bicycle" v="no"/>
 			<select value="1"  t="bicycle" v="yes"/>
@@ -441,6 +440,7 @@
 			<select value="1"  t="bicycle" v="designated"/>
 			<select value="1"  t="bicycle" v="destination"/>
 			<select value="1"  t="bicycle" v="official"/>
+			<select value="1"  t="bicycle" v="use_sidepath"/>
 
 			<select value="-1" t="vehicle" v="no"/>
 			<!-- 
@@ -540,6 +540,7 @@
 			<select value="0.1" t="bicycle" v="destination"/>
 			<select value="0.1" t="access" v="private"/>
 			<select value="0.1" t="barrier" v="debris"/>
+			<select value="0.1" t="bicycle" v="use_sidepath"/>
 
 			<if param="avoid_unpaved">
 				<select value="0.4" t="tracktype" v="grade2"/>
@@ -655,6 +656,7 @@
 			<select value="1"  t="foot" v="designated"/>
 			<select value="1"  t="foot" v="destination"/>
 			<select value="1"  t="foot" v="official"/>
+			<select value="1"  t="foot" v="use_sidepath"/>
 
 			<select value="-1" t="access" v="no"/>
 			<select value="1"  t="access" v="yes"/>
@@ -713,6 +715,8 @@
 
 			<select value="1.2" t="sidewalk" v="yes"/>
 			<select value="0.9" t="sidewalk" v="no"/>
+
+			<select value="0.1" t="foot" v="use_sidepath"/>
 
 			<!-- object tags -->
 			<select value="0.7" t="highway" v="motorway"/>


### PR DESCRIPTION
See http://wiki.openstreetmap.org/wiki/Tag:bicycle%3Duse_sidepath for how the tag is to be used.
At http://wiki.openstreetmap.org/wiki/Proposed_features/use_sidepath#Routing they specifically call out OsmAnd as not supporting the tag yet.
We could use value="-1" for some countries, while for some countries using such ways for foot/bicycle may still be allowed. So reducing the priority may be the middle ground.