### PR TITLE
Update routing.xml with better highway transitions

### DIFF
--- a/routing/routing.xml
+++ b/routing/routing.xml
@@ -196,13 +196,13 @@
 			<select value="10" t="highway" v="motorway_link"/>
 			<select value="10" t="highway" v="trunk"/>
 			<select value="15" t="highway" v="trunk_link"/>
-			<select value="50" t="highway" v="primary"/>
-			<select value="50" t="highway" v="primary_link"/>
-			<select value="100" t="highway" v="secondary"/>
-			<select value="100" t="highway" v="secondary_link"/>
-			<select value="150" t="highway" v="tertiary"/>
-			<select value="150" t="highway" v="tertiary_link"/>
-			<select value="200"/>
+			<select value="15" t="highway" v="primary"/>
+			<select value="20" t="highway" v="primary_link"/>
+			<select value="20" t="highway" v="secondary"/>
+			<select value="23" t="highway" v="secondary_link"/>
+			<select value="23" t="highway" v="tertiary"/>
+			<select value="25" t="highway" v="tertiary_link"/>
+			<select value="27"/>
 			
 			<!--
 			<select value="" t="highway" v="road"/>
@@ -212,7 +212,8 @@
 			<select value="" t="highway" v="service"/>
 			
 			<select value="" t="highway" v="living_street"/>
-			<select value="" t="route" v="ferry"/>-->
+			<select value="" t="route" v="ferry"/>
+			-->
 		</way>
 
 		<way attribute="speed" type="speed">


### PR DESCRIPTION
Currently has questionable time penalties causing very unhelpful fastest routing outcomes:

35 seconds from trunk_link to primary/primary_link?
50 seconds from primary/primary_link to secondary/secondary_link?
50 seconds from secondary/secondary_link to tertiary/tertiary_link?
50 seconds from tertiary/tertiary_link to anything lower? e.g. unclassified/residential.

The time differences should diminish as the road prominence reduces as they are non-linear in capacity.

Avoiding the 50 second penalty from tertiary to unclassified, and the others, will restore sane routing while keeping the intended desire of this feature to simulate delays leaving higher load roads.

It would still be better to consider speed limit and number of lanes to derive a penalty than the classification types.