### PR TITLE
Support smoothness tag in rounting.xml

### DIFF
--- a/routing/routing.xml
+++ b/routing/routing.xml
@@ -98,8 +98,13 @@
 				<select value="-1" t="surface" v="pebblestone"/>
 				<select value="-1" t="surface" v="sand"/>
 				<select value="-1" t="surface" v="wood"/>
+				<select value="-1" t="smoothness" v="very_bad"/>
 			</if>
 
+			<select value="-1" t="smoothness" v="impassable"/>
+			<select value="-1" t="smoothness" v="very_horrible"/>
+			<select value="-1" t="smoothness" v="horrible"/>
+			
 			<select value="-1" t="motorcar" v="no"/>
 			<select value="-1" t="motorcar" v="agricultural"/>
 			<select value="-1" t="motorcar" v="forestry"/>
@@ -287,6 +292,7 @@
 			<select t="access" v="destination" value="0.05"/>
 			<select t="access" v="delivery" value="0.05"/>
 			<select t="access" v="customers" value="0.05"/>
+			<select t="smoothness" v="very_bad" value="0.1"/>
 
 			<select value="1.1" t="highway" v="motorway"/>
 			<!-- make links slightly smaller so in connections they will not be used -->
@@ -433,6 +439,8 @@
 			<select value="-1" t="route" v="ferry">
 				<if param="avoid_ferries"/>
 			</select>
+
+			<select value="-1" t="smoothness" v="impassable"/>
 
 			<select value="-1" t="bicycle" v="no"/>
 			<select value="1"  t="bicycle" v="yes"/>


### PR DESCRIPTION
I propose to add support for smoothness key. According to http://wiki.openstreetmap.org/wiki/Key:smoothness values of impassable down to horrible are not passable to normal car. I think that is what the "car" profile in OsmAnd presents. The value of very_bad for "high clearance car" is questionable. So I allow it for users that do not care about unpaved roads. Those probably have something better than a "city car" and may be interested in these worse roads too.
For bikes I am not sure what kind of bike OsmAnd tries to present, so for safety I allow all smoothness except "impassable".  	Because even "very_horrible" is defined to be passable by mountain bike.