### PR TITLE
Support various types of pedestrian crossings in routing.xml

### DIFF
--- a/routing/routing.xml
+++ b/routing/routing.xml
@@ -328,6 +328,8 @@
 			<select value="25" t="barrier"/>
 			<select value="10" t="traffic_calming"/>
 			<select value="30" t="highway" v="traffic_signals"/>
+			<select value="1"  t="crossing" v="unmarked"/>
+			<select value="5"  t="crossing" v="uncontrolled"/>
 			<select value="15" t="highway" v="crossing"/>
 			<select value="15" t="highway" v="stop"/>
 			<select value="10" t="highway" v="give_way"/>
@@ -456,6 +458,8 @@
 			<select value="1"  t="access" v="yes"/>
 			<select value="1"  t="access" v="permissive"/>
 
+			<select value="-1" t="crossing" v="no"/>
+
 			<select value="1" t="highway" v="motorway"/>
 			<select value="1" t="highway" v="motorway_link"/>
 			<select value="1" t="highway" v="trunk"/>
@@ -582,14 +586,17 @@
 
 		<point attribute="obstacle_time">
 			<select value="10" t="barrier" v="cycle_barrier"/>
-			<select value="5" t="barrier"/>
+			<select value="5"  t="barrier"/>
 			<select value="30" t="highway" v="traffic_signals"/>
+			<select value="10" t="crossing" v="unmarked"/>
+			<select value="5"  t="crossing" v="uncontrolled"/>
+			<select value="30" t="crossing" v="traffic_signals"/>
 			<select value="15" t="highway" v="stop"/>
-			<select value="7" t="highway" v="give_way"/>
-			<select value="25" t="highway" v="ford" />
-			<select value="25" t="ford" />
+			<select value="7"  t="highway" v="give_way"/>
+			<select value="25" t="highway" v="ford"/>
+			<select value="25" t="ford"/>
 
-			<select value="25" t="railway" v="crossing" />
+			<select value="25" t="railway" v="crossing"/>
 			<select value="25" t="railway" v="level_crossing"/>
 		</point>
 
@@ -616,9 +623,14 @@
 			<select value="1"  t="access" v="yes"/>
 			<select value="1"  t="access" v="permissive"/>
 
+			<select value="-1" t="crossing" v="no"/>
+
 			<select value="10" t="barrier" v="cycle_barrier"/>
 			<select value="5" t="barrier"/>
 			<select value="10" t="highway" v="traffic_signals"/>
+			<select value="10" t="crossing" v="unmarked"/>
+			<select value="5"  t="crossing" v="uncontrolled"/>
+			<select value="30" t="crossing" v="traffic_signals"/>
 			<select value="10" t="highway" v="stop"/>
 			<select value="7" t="highway" v="give_way"/>
 			<select value="25" t="highway" v="ford" />
@@ -655,6 +667,8 @@
 			<select value="-1" t="access" v="no"/>
 			<select value="1"  t="access" v="yes"/>
 			<select value="1"  t="access" v="permissive"/>
+
+			<select value="-1" t="crossing" v="no"/>
 
 			<select value="1" t="highway" v="motorway"/>
 			<select value="1" t="highway" v="motorway_link"/>
@@ -732,6 +746,10 @@
 
 		<point attribute="obstacle_time">
 			<select value="5" t="highway" v="traffic_signals"/>
+			<select value="10" t="crossing" v="unmarked"/>
+			<select value="5"  t="crossing" v="uncontrolled"/>
+			<select value="30" t="crossing" v="traffic_signals"/>
+			<select value="5" t="highway" v="crossing"/>
 			<select value="5" t="highway" v="ford" />
 			<select value="5" t="ford" />
 			<select value="5" t="railway" v="crossing" />
@@ -749,6 +767,8 @@
 			<select value="-1" t="access" v="no"/>
 			<select value="1"  t="access" v="yes"/>
 			<select value="1"  t="access" v="permissive"/>
+
+			<select value="-1" t="crossing" v="no"/>
 		</point>
 	</routingProfile>
 </osmand_routing_config>


### PR DESCRIPTION
Support various types of pedestrian crossings in routing.xml. I think not all crossing types should have the same obstacle time.

In car mode, if the pedestrian crossing=uncontrolled, then there will probably not be such a long wait time (15 secs) as for crossing=traffic_signals, or highway=crossing (type undefined). But for crossing=unmarked, the car probably has priority, so make the obstacle time really small.

In foot mode, crossing unmarked and uncontrolled may incur some wait time, as cars may pass. On crossing=traffic_signals, the wait time can be longer. crossing=no means it is not passable so I add value=-1 to obstacle. The wiki allows adding these to the way (not only the junction node), so I put that also in "access" block.

Similarly for bike mode.

http://wiki.openstreetmap.org/wiki/Key:crossing