### PR TITLE
Changed translation for poi_chemist, which is not "Farmacia" in Italian.

### DIFF
--- a/poi/phrases/it/phrases.xml
+++ b/poi/phrases/it/phrases.xml
@@ -27,7 +27,7 @@
 	<string name="poi_bathroom_furnishing">Arredo bagno</string>
 	<string name="poi_bed">Arredamento camera da letto</string>
 	<string name="poi_carpet">Negozio tappeti</string>
-	<string name="poi_chemist">Farmacia</string>
+	<string name="poi_chemist">Mesticheria</string>
 	<string name="poi_clothes">Abbigliamento</string>
 	<string name="poi_child_clothes">Abbigliamento bambini</string>
 	<string name="poi_shoes">Negozio calzature</string>


### PR DESCRIPTION
This is because adding a "Farmacia" POI in OsmAnd should insert amenity=pharmacy, not shop=chemist.
In Italy there are not "Chemist" shops, the more similar kind of shop is the "mesticheria", which sells various goods for housekeeping and personal care.