### PR TITLE
Deleted motorway_link from car navigation

### DIFF
--- a/routing/routing.xml
+++ b/routing/routing.xml
@@ -72,9 +72,6 @@
 			<select value="-1" t="highway" v="motorway">
 				<if param="avoid_motorway"/>
 			</select>
-			<select value="-1" t="highway" v="motorway_link">
-				<if param="avoid_motorway"/>
-			</select>
 			<select value="-1" t="toll" v="yes">
 				<if param="avoid_toll"/>
 			</select>


### PR DESCRIPTION
I think whith this little modification [#1202](https://github.com/osmandapp/Osmand/issues/1202) is fixed.
The motorway_link ending/coming from a motorway, so I think, it is not necessary to add this to the routing.xml