### PR TITLE
Map oneway=1 to oneway=yes at obf creation time, not routing time.

### DIFF
--- a/obf_creation/rendering_types.xml
+++ b/obf_creation/rendering_types.xml
@@ -5208,6 +5208,7 @@
 		<routing_type tag="roundabout" mode="amend" base="true"/>
 		<routing_type tag="oneway" mode="amend" base="true"/>
 		<routing_type tag="oneway:bicycle" mode="amend"/>
+		<routing_type tag="oneway" value="1" tag2="oneway" value2="yes" mode="replace"/>
 
 		<routing_type tag="maxspeed" mode="amend" base="true"/>
 		<routing_type tag="maxspeed:practical" mode="amend" base="true"/>

--- a/routing/routing.xml
+++ b/routing/routing.xml
@@ -177,8 +177,8 @@
 
 		<way attribute="oneway">
 			<select value="1" t="oneway" v="yes"/>
-			<select value="1" t="oneway" v="1"/>
 			<select value="-1" t="oneway" v="-1"/>
+			<select value="0" t="oneway" v="no"/>
 			<select value="1" t="roundabout"/>
 			<select value="1" t="junction" v="roundabout"/>
 		</way>
@@ -515,8 +515,8 @@
 			<select value="0" t="oneway:bicycle" v="no"/>
 			<select value="1" t="oneway:bicycle" v="yes"/>
 			<select value="1" t="oneway" v="yes"/>
-			<select value="1" t="oneway" v="1"/>
 			<select value="-1" t="oneway" v="-1"/>
+			<select value="0" t="oneway" v="no"/>
 			<select value="1" t="roundabout"/>
 			<select value="1" t="junction" v="roundabout"/>
 		</way>


### PR DESCRIPTION
Replace oneway=1 with oneway=yes in rendering_types.xml for routing purposes. This should save us the need to evaluate this outdated value at routing runtime (in routing.xml).