### PR TITLE
Make landuse=industrial darken than residential

### DIFF
--- a/rendering_styles/default.render.xml
+++ b/rendering_styles/default.render.xml
@@ -1127,9 +1127,9 @@
 		<case nightMode="true" attrColorValue="#aaaaaa"/>
 		<case attrColorValue="#666666"/>
 	</renderingAttribute>
-	<renderingConstant name="landuseIndustrialColorDay" value="#dfd1d6"/>
-	<renderingConstant name="landuseIndustrialColorNight" value="#3b3b3b"/>
-	<renderingConstant name="landuseResidentialColorDay" value="#cdcdcd"/>
+	<renderingConstant name="landuseIndustrialColorDay" value="#cfc0c8"/>
+	<renderingConstant name="landuseIndustrialColorNight" value="#302d2d"/>
+	<renderingConstant name="landuseResidentialColorDay" value="#d0d0d0"/>
 	<renderingConstant name="landuseResidentialColorNight" value="#3b3b3b"/>
 	<renderingConstant name="landuseResidentialRuralColorDay" value="#cdd5cd"/>
 	<renderingConstant name="landuseRailwayColorDay" value="#dfd1d6"/>
@@ -1151,7 +1151,7 @@
 		<case nightMode="true" attrColorValue="#3b3b3b"/>
 		<case attrColorValue="#bde3cb"/>
 	</renderingAttribute>
-	<renderingConstant name="landuseGaragesColorDay" value="#dfd1d6"/>
+	<renderingConstant name="landuseGaragesColorDay" value="#cdc6bf"/>
 	<renderingConstant name="landuseGaragesColorNight" value="#362d2d"/>
 	<renderingConstant name="leisureResortColorDay" value="#b0b6fdb6"/>
 	<renderingConstant name="leisureResortColorNight" value="#362d2d"/>


### PR DESCRIPTION
Default OsmAnd style contains different but very close colors for residential and industrial areas. I think industrial should be a bit darker (and of course still no prominent).
https://www.dropbox.com/s/pk7hz3cqstvz2q0/Ind.png?dl=0
https://www.dropbox.com/s/u1h4d8j4nu4rzr9/Ind_new.png?dl=0