### PR TITLE
Consider points with access=private and destination

### DIFF
--- a/routing/routing.xml
+++ b/routing/routing.xml
@@ -377,7 +377,6 @@
 			<select value="0"  t="motorcar" v="yes"/>
 			<select value="0"  t="motorcar" v="permissive"/>
 			<select value="0"  t="motorcar" v="designated"/>
-			<select value="0"  t="motorcar" v="destination"/>
 			<select value="0"  t="motorcar" v="customers"/>
 			<select value="0"  t="motorcar" v="official"/>
 			
@@ -389,7 +388,6 @@
 			<select value="0"  t="motor_vehicle" v="yes"/>
 			<select value="0"  t="motor_vehicle" v="permissive"/>
 			<select value="0"  t="motor_vehicle" v="designated"/>
-			<select value="0"  t="motor_vehicle" v="destination"/>
 			<select value="0"  t="motor_vehicle" v="customers"/>
 			<select value="0"  t="motor_vehicle" v="official"/>
 
@@ -401,7 +399,6 @@
 			<select value="0"  t="vehicle" v="yes"/>
 			<select value="0"  t="vehicle" v="permissive"/>
 			<select value="0"  t="vehicle" v="designated"/>
-			<select value="0"  t="vehicle" v="destination"/>
 			<select value="0"  t="vehicle" v="customers"/>
 
 			<select value="-1" t="access" v="no"/>
@@ -411,7 +408,6 @@
 			<select value="60"  t="access" v="destination"/>
 			<select value="0"  t="access" v="yes"/>
 			<select value="0"  t="access" v="permissive"/>
-			<select value="0"  t="access" v="destination"/>
 			<select value="0"  t="access" v="customers"/>
 
 			<select value="5"   t="barrier" v="cattle_grid"/>
@@ -800,16 +796,15 @@
 
 		<point attribute="obstacle">
 			<select value="-1" t="foot" v="no"/>
-			<select value="0"  t="foot" v="yes"/>
-			<select value="360"  t="foot" v="private"/>
+			<select value="-1"  t="foot" v="private"/>
 			<select value="120"  t="foot" v="destination"/>
+			<select value="0"  t="foot" v="yes"/>
 			<select value="0"  t="foot" v="permissive"/>
 			<select value="0"  t="foot" v="designated"/>
-			<select value="0"  t="foot" v="destination"/>
 			<select value="0"  t="foot" v="official"/>
 
 			<select value="-1" t="access" v="no"/>
-			<select value="360"  t="access" v="private"/>
+			<select value="-1"  t="access" v="private"/>
 			<select value="120"  t="access" v="destination"/>
 
 			<select value="0"  t="access" v="yes"/>

--- a/routing/routing.xml
+++ b/routing/routing.xml
@@ -372,39 +372,47 @@
 			<select value="-1" t="motorcar" v="no"/>
 			<select value="-1" t="motorcar" v="agricultural"/>
 			<select value="-1" t="motorcar" v="forestry"/>
-			<select value="1"  t="motorcar" v="yes"/>
-			<select value="1"  t="motorcar" v="permissive"/>
-			<select value="1"  t="motorcar" v="designated"/>
-			<select value="1"  t="motorcar" v="destination"/>
-			<select value="1"  t="motorcar" v="customers"/>
-			<select value="1"  t="motorcar" v="official"/>
+			<select value="180"  t="motorcar" v="private"/>
+			<select value="60"  t="motorcar" v="destination"/>
+			<select value="0"  t="motorcar" v="yes"/>
+			<select value="0"  t="motorcar" v="permissive"/>
+			<select value="0"  t="motorcar" v="designated"/>
+			<select value="0"  t="motorcar" v="destination"/>
+			<select value="0"  t="motorcar" v="customers"/>
+			<select value="0"  t="motorcar" v="official"/>
 			
 			<select value="-1" t="motor_vehicle" v="no"/>
 			<select value="-1" t="motor_vehicle" v="agricultural"/>
 			<select value="-1" t="motor_vehicle" v="forestry"/>
-			<select value="1"  t="motor_vehicle" v="yes"/>
-			<select value="1"  t="motor_vehicle" v="permissive"/>
-			<select value="1"  t="motor_vehicle" v="designated"/>
-			<select value="1"  t="motor_vehicle" v="destination"/>
-			<select value="1"  t="motor_vehicle" v="customers"/>
-			<select value="1"  t="motor_vehicle" v="official"/>
+			<select value="180"  t="motor_vehicle" v="private"/>
+			<select value="60"  t="motor_vehicle" v="destination"/>
+			<select value="0"  t="motor_vehicle" v="yes"/>
+			<select value="0"  t="motor_vehicle" v="permissive"/>
+			<select value="0"  t="motor_vehicle" v="designated"/>
+			<select value="0"  t="motor_vehicle" v="destination"/>
+			<select value="0"  t="motor_vehicle" v="customers"/>
+			<select value="0"  t="motor_vehicle" v="official"/>
 
 			<select value="-1" t="vehicle" v="no"/>
 			<select value="-1" t="vehicle" v="agricultural"/>
 			<select value="-1" t="vehicle" v="forestry"/>
-			<select value="1"  t="vehicle" v="yes"/>
-			<select value="1"  t="vehicle" v="permissive"/>
-			<select value="1"  t="vehicle" v="designated"/>
-			<select value="1"  t="vehicle" v="destination"/>
-			<select value="1"  t="vehicle" v="customers"/>
+			<select value="180"  t="vehicle" v="private"/>
+			<select value="60"  t="vehicle" v="destination"/>
+			<select value="0"  t="vehicle" v="yes"/>
+			<select value="0"  t="vehicle" v="permissive"/>
+			<select value="0"  t="vehicle" v="designated"/>
+			<select value="0"  t="vehicle" v="destination"/>
+			<select value="0"  t="vehicle" v="customers"/>
 
 			<select value="-1" t="access" v="no"/>
 			<select value="-1" t="access" v="agricultural"/>
 			<select value="-1" t="access" v="forestry"/>
-			<select value="1"  t="access" v="yes"/>
-			<select value="1"  t="access" v="permissive"/>
-			<select value="1"  t="access" v="destination"/>
-			<select value="1"  t="access" v="customers"/>
+			<select value="180"  t="access" v="private"/>
+			<select value="60"  t="access" v="destination"/>
+			<select value="0"  t="access" v="yes"/>
+			<select value="0"  t="access" v="permissive"/>
+			<select value="0"  t="access" v="destination"/>
+			<select value="0"  t="access" v="customers"/>
 
 			<select value="5"   t="barrier" v="cattle_grid"/>
 			<select value="300" t="barrier" v="border_control"/>
@@ -633,23 +641,30 @@
 				<select value="-1" t="barrier" v="border_control"/>
 			</if>
 			<select value="-1" t="bicycle" v="no"/>
-			<select value="1"  t="bicycle" v="yes"/>
-			<select value="1"  t="bicycle" v="permissive"/>
-			<select value="1"  t="bicycle" v="designated"/>
-			<select value="1"  t="bicycle" v="official"/>
+			<select value="180"  t="bicycle" v="private"/>
+			<select value="60"  t="bicycle" v="destination"/>
+			<select value="0"  t="bicycle" v="yes"/>
+			<select value="0"  t="bicycle" v="permissive"/>
+			<select value="0"  t="bicycle" v="dismount"/>
+			<select value="0"  t="bicycle" v="designated"/>
+			<select value="0"  t="bicycle" v="official"/>
 
 			<select value="-1" t="vehicle" v="no"/>
 			<select value="-1" t="vehicle" v="agricultural"/>
 			<select value="-1" t="vehicle" v="forestry"/>
-			<select value="1"  t="vehicle" v="yes"/>
-			<select value="1"  t="vehicle" v="permissive"/>
-			<select value="1"  t="vehicle" v="designated"/>
+			<select value="180"  t="vehicle" v="private"/>
+			<select value="60"  t="vehicle" v="destination"/>
+			<select value="0"  t="vehicle" v="yes"/>
+			<select value="0"  t="vehicle" v="permissive"/>
+			<select value="0"  t="vehicle" v="designated"/>
 
 			<select value="-1" t="access" v="no"/>
 			<select value="-1" t="access" v="agricultural"/>
 			<select value="-1" t="access" v="forestry"/>
-			<select value="1"  t="access" v="yes"/>
-			<select value="1"  t="access" v="permissive"/>
+			<select value="180"  t="access" v="private"/>
+			<select value="60"  t="access" v="destination"/>
+			<select value="0"  t="access" v="yes"/>
+			<select value="0"  t="access" v="permissive"/>
 
 			<select value="10" t="barrier" v="cycle_barrier"/>
 			<select value="5" t="barrier"/>
@@ -696,8 +711,6 @@
 			<select value="-1" t="access" v="private"/>
 			<select value="1"  t="access" v="yes"/>
 			<select value="1"  t="access" v="permissive"/>
-
-			<select value="-1" t="crossing" v="no"/>
 
 			<select value="1" t="highway" v="motorway"/>
 			<select value="1" t="highway" v="motorway_link"/>
@@ -787,19 +800,21 @@
 
 		<point attribute="obstacle">
 			<select value="-1" t="foot" v="no"/>
-			<select value="1"  t="foot" v="yes"/>
-			<select value="1"  t="foot" v="permissive"/>
-			<select value="1"  t="foot" v="designated"/>
-			<select value="1"  t="foot" v="destination"/>
-			<select value="1"  t="foot" v="official"/>
+			<select value="0"  t="foot" v="yes"/>
+			<select value="360"  t="foot" v="private"/>
+			<select value="120"  t="foot" v="destination"/>
+			<select value="0"  t="foot" v="permissive"/>
+			<select value="0"  t="foot" v="designated"/>
+			<select value="0"  t="foot" v="destination"/>
+			<select value="0"  t="foot" v="official"/>
 
 			<select value="-1" t="access" v="no"/>
-			<select value="-1" t="access" v="private"/>
+			<select value="360"  t="access" v="private"/>
+			<select value="120"  t="access" v="destination"/>
 
-			<select value="1"  t="access" v="yes"/>
-			<select value="1"  t="access" v="permissive"/>
+			<select value="0"  t="access" v="yes"/>
+			<select value="0"  t="access" v="permissive"/>
 
-			<select value="-1" t="crossing" v="no"/>
 		</point>
 	</routingProfile>
 	<routingProfile name="geocoding" baseProfile="car" restrictionsAware="true" minDefaultSpeed="10.0" maxDefaultSpeed="10.0">


### PR DESCRIPTION
Sometimes highway lines didn't have access tags but access restricted with point barriers. Unfortunately, I found that access private and destination missed in point obstacles. Considering that ways with access=private and destination strongly deprioritized, but not avoided, I've introduced large penalties for this points. I'm not sure about exact values, at least, the longer is the alternative route, the greater they must be, but 60 and 180 seemed to be OK for motorcar (but not for foot, because 3 additional minutes for foot route doesn't change the situation).
Some examples for tests:
1) road between 2 lift gates with access=destination http://map.project-osrm.org/?z=14&center=55.457835%2C36.858187&loc=55.471386%2C36.869988&loc=55.444693%2C36.822696&hl=en&alt=0 (OsmAnd did motorcar route correctly)
2) some gates with access=private http://bit.ly/29JnhVn (motorcar and bike routes are OK, but foot route will lead through private gate until time obstacle less than 360).

Since in <point attribute="obstacle"> section value of 0 means "no penalty" for routing engine I've changed all 1-second penalties to 0.

And I've also removed rest of the <select value="-1" t="crossing" v="no"/> for the reasons described earlier https://github.com/osmandapp/OsmAnd-resources/pull/385