### PR TITLE
Allow cyclists to use living_streets

### DIFF
--- a/obf_creation/rendering_types.xml
+++ b/obf_creation/rendering_types.xml
@@ -1463,7 +1463,6 @@
 		<!-- According to https://wiki.openstreetmap.org/wiki/OSM_tags_for_routing/Access-Restrictions -->
 		<entity_convert pattern="tag_transform" from_tag="highway" from_value="living_street" if_region_name="russia,austria,belarus,hungary,poland,romania,slovakia,ukraine" if_not_tag1="motorcar" to_tag1="highway" to_value1="living_street" to_tag2="motorcar" to_value2="destination"/>
 		<entity_convert pattern="tag_transform" from_tag="highway" from_value="living_street" if_region_name="russia,austria,belarus,brazil,hungary,poland,romania,slovakia,ukraine" if_not_tag1="hgv" to_tag1="highway" to_value1="living_street" to_tag2="hgv" to_value2="destination"/>
-		<entity_convert pattern="tag_transform" from_tag="highway" from_value="living_street" if_region_name="russia,ukraine" if_not_tag1="bicycle" to_tag1="highway" to_value1="living_street" to_tag2="bicycle" to_value2="destination"/>
 
 		<type tag="highway" value="pedestrian" minzoom="12" nameTags="ref,int_ref"/>
 		<type tag="highway" value="cycleway" minzoom="12" nameTags="ref,int_ref"/>


### PR DESCRIPTION
I dotn't want to discuss, should osmand strictly obey rules or not,  but set bicycle=destination on highway=living_street is really not a good idea. Alternative route will probably go via alongside footways, highway=service+living_street=yes or via main roads.

Here is an example http://bit.ly/29zjXqk (inconvenient route with 2 left turns, but osmand did something weird https://www.dropbox.com/s/cqtjcmltvkbnxei/weird_route.png?dl=0).