### PR TITLE
Add bicycle=official

### DIFF
--- a/obf_creation/rendering_types.xml
+++ b/obf_creation/rendering_types.xml
@@ -138,6 +138,7 @@
 	<type tag="bicycle" value="permissive" minzoom="13" additional="true" poi="false"/>
 	<type tag="bicycle" value="destination" minzoom="13" additional="true" poi="false"/>
 	<type tag="bicycle" value="designated" minzoom="12" additional="true" poi="false"/>
+	<entity_convert pattern="tag_transform" from_tag="bicycle" from_value="official" to_tag1="bicycle" to_value1="designated"/>
 	<type tag="fee" value="yes" minzoom="13" additional="true" poi="false"/>
 	<type tag="boat" value="no" minzoom="10" additional="true" poi="false"/>
 	<type tag="boat" value="private" minzoom="10" additional="true" poi="false"/>


### PR DESCRIPTION
Paths with bicycle=official should be rendered the same way as ones with bicycle=designated.