### PR TITLE
Do not ignore barriers when choosing shortest way.

### DIFF
--- a/routing/routing.xml
+++ b/routing/routing.xml
@@ -418,9 +418,6 @@
 			<select value="0"  t="access" v="yes"/>
 			<select value="0"  t="access" v="permissive"/>
 			<select value="0"  t="access" v="customers"/>
-			<if param="short_way">
-				<select value="0"/>
-			</if>
 
 			<select value="5"   t="barrier" v="cattle_grid"/>
 			<select value="300" t="barrier" v="border_control"/>


### PR DESCRIPTION
With barriers not listed in the routing.xml file, we must get to the rule <select value="-1" t="barrier"/> even for shortest way, it is crucial for the "obstacle" section to work properly.
This should fix issue #3095, which is a serious problem.
It will probably regress #1778, which will need a different solution.