### PR TITLE
Remove needless comma in sk/ttsconfig.p

### DIFF
--- a/voice/sk/ttsconfig.p
+++ b/voice/sk/ttsconfig.p
@@ -25,7 +25,7 @@ language('sk').
 % ROUTE CALCULATED
 string('route_is.ogg', 'Cesta je dlhá ').
 string('route_calculate.ogg', 'Cesta prepočítaná').
-string('distance.ogg', ', vzdialenosť ').
+string('distance.ogg', 'vzdialenosť ').
 
 % LEFT/RIGHT
 string('after.ogg', 'čoskoro o ').


### PR DESCRIPTION
Commit 205bb4b added commas when concatenating distance.ogg so it does not need to contain the comma a second time.