### PR TITLE
Add support for showing GPX tracks in pink

### DIFF
--- a/rendering_styles/default.render.xml
+++ b/rendering_styles/default.render.xml
@@ -133,7 +133,7 @@
 		type="string" possibleValues="germanRoadAtlas,americanRoadAtlas,highContrastRoads,boldOutline" defaultValueDescription="default"/>
 
 	<renderingProperty attr="currentTrackColor" name="Current GPX color" description="Color of the currently recording track"
-		type="string" possibleValues="red,orange,lightblue,blue,purple,translucent_red,translucent_orange,translucent_lightblue,translucent_blue,translucent_purple" defaultValueDescription="default"/>
+		type="string" possibleValues="red,orange,lightblue,blue,purple,pink,translucent_red,translucent_orange,translucent_lightblue,translucent_blue,translucent_purple,translucent_pink" defaultValueDescription="default"/>
 	<renderingProperty attr="currentTrackWidth" name="Current GPX width" description="Width of the currently recording track"
 		type="string" possibleValues="thin,medium,bold" defaultValueDescription="default"/>
 	<renderingProperty attr="legend" name="Legend" type="boolean" possibleValues="" category="ui_hidden"/>
@@ -221,11 +221,13 @@
 			<case currentTrackColor="lightblue" color="#2ec6ff"/>
 			<case currentTrackColor="blue" color="#4e4eff"/>
 			<case currentTrackColor="purple" color="#a71de1"/>
+			<case currentTrackColor="pink" color="#f52887"/>
 			<case currentTrackColor="translucent_red" color="#aaff0000"/>
 			<case currentTrackColor="translucent_orange" color="#aaff7200"/>
 			<case currentTrackColor="translucent_lightblue" color="#aa00ffff"/>
 			<case currentTrackColor="translucent_blue" color="#aa4e4eff"/>
 			<case currentTrackColor="translucent_purple" color="#aaa71de1"/>
+			<case currentTrackColor="translucent_pink" color="#aaf52887"/>
 			<case color="#ff0000">
 				<apply_if roadStyle="germanRoadAtlas" color="#aa0088"/> <!-- does not works -->
 			</case>


### PR DESCRIPTION
Pink is one of the least used colours on the map, making it a good choice for clearly showing GPX tracks. Pink was previously available in OsmAnd 2.5 but removed in 2.6.