### PR TITLE
refined values for elevation in bicycle mode

### DIFF
--- a/routing/routing.xml
+++ b/routing/routing.xml
@@ -727,8 +727,17 @@
 			<if param="height_obstacles">
 
 				<gt value1="-100" value2=":incline">
-                	                <select value="-1"/>
-                        	</gt>
+					<select value="1000" t="surface" v="cobblestone"/>
+                                        <select value="800" t="surface" v="paved"/>
+                                        <select value="800" t="surface" v="asphalt"/>
+                                        <select value="800" t="surface" v="concrete"/>
+                                        <select value="1000" t="osmand_highway_integrity_brouting_low" v="yes"/>
+                                        <select value="1000" t="highway" v="path"/>
+                                        <select value="1000" t="highway" v="track"/>
+                                        <select value="1000" t="highway" v="footway"/>
+                                        <select value="800"/>
+				</gt>
+
 				<!-- Above: Downhill between 100 and 60 is so steep that it should probably
 				be excluded in any case, even in hilly mode and for paved roads.-->
 

--- a/routing/routing.xml
+++ b/routing/routing.xml
@@ -1058,7 +1058,10 @@
 			leads to routing errors. The above is only a compromise to minimize
 			those errors.-->
 			
-			<select value="9" t="crossing" v="traffic_signals"/>
+			<if param="driving_style_speed">
+				<select value="8" t="crossing" v="traffic_signals"/>
+			</if>
+			<select value="11" t="crossing" v="traffic_signals"/>
 			<select value="1" t="crossing" v="uncontrolled"/>
 			<select value="3" t="crossing" v="unmarked"/>
 			<select value="1" t="crossing" v="island"/>
@@ -1071,6 +1074,9 @@
 			to apply any penalty. So it would make no sense to just apply a high
 			penalty on some cases. -->
 			<select value="5" t="crossing" v="island;traffic_signals"/>
+			<if param="driving_style_speed">
+				<select value="11" t="highway" v="traffic_signals"/>
+			</if>
 			<select value="19" t="highway" v="traffic_signals"/>
 			<select value="55"  t="highway" v="steps"/>
 			<select value="15"  t="bicycle" v="dismount"/>

--- a/routing/routing.xml
+++ b/routing/routing.xml
@@ -725,30 +725,41 @@
 		<way attribute="obstacle_srtm_alt_speed">
 			<if param="height_obstacles">
 				<gt value1="-100" value2=":incline">
+					<select value="-1" t="surface" v="cobblestone"/>
 					<select value="-1" t="osmand_highway_integrity_brouting_low" v="yes"/>
 					<select value="-1" t="highway" v="path"/>
 					<select value="-1" t="highway" v="track"/>
+					<select value="-1" t="highway" v="footway"/>
 				</gt>
 				<gt value1="-25" value2=":incline">
+					<select value="170" t="surface" v="cobblestone"/>
+					<select value="1" t="surface" v="paved"/>
+					<select value="1" t="surface" v="asphalt"/>
+					<select value="1" t="surface" v="concrete"/>
 					<select value="180" t="osmand_highway_integrity_brouting_low" v="yes"/>
 					<select value="180" t="highway" v="path"/>
 					<select value="170" t="highway" v="track"/>
+					<select value="180" t="highway" v="footway"/>
 				</gt>
 				<gt value1="-17" value2=":incline">
+					<select value="140" t="surface" v="cobblestone"/>
+					<select value="1" t="surface" v="paved"/>
+					<select value="1" t="surface" v="asphalt"/>
+					<select value="1" t="surface" v="concrete"/>
 					<select value="150" t="osmand_highway_integrity_brouting_low" v="yes"/>
 					<select value="150" t="highway" v="path"/>
 					<select value="140" t="highway" v="track"/>
+					<select value="150" t="highway" v="footway"/>
 				</gt>
 				<gt value1="-9" value2=":incline">
+					<select value="1" t="surface" v="paved"/>
+					<select value="1" t="surface" v="asphalt"/>
+					<select value="1" t="surface" v="concrete"/>
 					<select value="30" t="osmand_highway_integrity_brouting_low" v="yes"/>
 					<select value="30" t="highway" v="path"/>
 					<select value="25" t="highway" v="track"/>
 				</gt>
-				<gt value1="-3" value2=":incline">
-					<select value="2" t="osmand_highway_integrity_brouting_low" v="yes"/>
-					<select value="2" t="highway" v="path"/>
-					<select value="2" t="highway" v="track"/>
-				</gt>
+
 				<if param="relief_smoothness_factor_more_plains">
 					<gt value1="4" value2=":incline">
 						<select value="5"/>

--- a/routing/routing.xml
+++ b/routing/routing.xml
@@ -723,90 +723,157 @@
 		</way>
 
 		<way attribute="obstacle_srtm_alt_speed">
+
 			<if param="height_obstacles">
+
 				<gt value1="-100" value2=":incline">
-					<select value="-1" t="surface" v="cobblestone"/>
-					<select value="-1" t="osmand_highway_integrity_brouting_low" v="yes"/>
-					<select value="-1" t="highway" v="path"/>
-					<select value="-1" t="highway" v="track"/>
-					<select value="-1" t="highway" v="footway"/>
+                	                <select value="-1"/>
+                        	</gt>
+				<!-- Above: Downhill between 100 and 60 is so steep that it should probably
+				be excluded in any case, even in hilly mode and for paved roads.-->
+
+				<gt value1="-60" value2=":incline">
+					<select value="400" t="surface" v="cobblestone"/>
+                                        <select value="300" t="surface" v="paved"/>
+                                        <select value="300" t="surface" v="asphalt"/>
+                                        <select value="300" t="surface" v="concrete"/>
+                                        <select value="400" t="osmand_highway_integrity_brouting_low" v="yes"/>
+                                        <select value="400" t="highway" v="path"/>
+                                        <select value="400" t="highway" v="track"/>
+                                        <select value="400" t="highway" v="footway"/>
+                                        <select value="330"/>
 				</gt>
-				<gt value1="-25" value2=":incline">
-					<select value="170" t="surface" v="cobblestone"/>
-					<select value="1" t="surface" v="paved"/>
-					<select value="1" t="surface" v="asphalt"/>
-					<select value="1" t="surface" v="concrete"/>
-					<select value="180" t="osmand_highway_integrity_brouting_low" v="yes"/>
-					<select value="180" t="highway" v="path"/>
-					<select value="170" t="highway" v="track"/>
-					<select value="180" t="highway" v="footway"/>
-				</gt>
-				<gt value1="-17" value2=":incline">
-					<select value="140" t="surface" v="cobblestone"/>
-					<select value="1" t="surface" v="paved"/>
-					<select value="1" t="surface" v="asphalt"/>
-					<select value="1" t="surface" v="concrete"/>
-					<select value="150" t="osmand_highway_integrity_brouting_low" v="yes"/>
-					<select value="150" t="highway" v="path"/>
-					<select value="140" t="highway" v="track"/>
-					<select value="150" t="highway" v="footway"/>
-				</gt>
-				<gt value1="-9" value2=":incline">
-					<select value="1" t="surface" v="paved"/>
-					<select value="1" t="surface" v="asphalt"/>
-					<select value="1" t="surface" v="concrete"/>
-					<select value="30" t="osmand_highway_integrity_brouting_low" v="yes"/>
-					<select value="30" t="highway" v="path"/>
-					<select value="25" t="highway" v="track"/>
+				<!-- Lines above: This is still so steep, that a high penalty makes sense in any mode, and
+                                even on paved surface. Maybe the values need some refinement.-->
+
+				<gt value1="-40" value2=":incline">
+                                        <select value="200" t="surface" v="cobblestone"/>
+					<select value="100" t="surface" v="paved"/>
+                                        <select value="100" t="surface" v="asphalt"/>
+                                        <select value="100" t="surface" v="concrete"/>
+                                        <select value="200" t="osmand_highway_integrity_brouting_low" v="yes"/>
+                                        <select value="200" t="highway" v="path"/>
+                                        <select value="200" t="highway" v="track"/>
+                                        <select value="200" t="highway" v="footway"/>
+                                        <select value="150"/>
 				</gt>
 
+				<gt value1="-25" value2=":incline">
+					<select value="140" t="surface" v="cobblestone"/>
+					<select value="40" t="surface" v="paved"/>
+					<select value="40" t="surface" v="asphalt"/>
+					<select value="40" t="surface" v="concrete"/>
+					<select value="150" t="osmand_highway_integrity_brouting_low" v="yes"/>
+					<select value="150" t="highway" v="path"/>
+					<select value="150" t="highway" v="track"/>
+					<select value="150" t="highway" v="footway"/>
+                                        <select value="60"/>
+				</gt>
+
+				<gt value1="-20" value2=":incline">
+					<select value="40" t="surface" v="cobblestone"/>
+					<select value="1" t="surface" v="paved"/>
+					<select value="1" t="surface" v="asphalt"/>
+					<select value="1" t="surface" v="concrete"/>
+					<select value="80" t="osmand_highway_integrity_brouting_low" v="yes"/>
+					<select value="80" t="highway" v="path"/>
+					<select value="80" t="highway" v="track"/>
+                                        <select value="1"/>
+				</gt>
+
+				<gt value1="-9" value2=":incline">
+					<select value="0.1" t="surface" v="paved"/>
+					<select value="0.1" t="surface" v="asphalt"/>
+					<select value="0.1" t="surface" v="concrete"/>
+					<select value="30" t="osmand_highway_integrity_brouting_low" v="yes"/>
+					<select value="30" t="highway" v="path"/>
+					<select value="30" t="highway" v="track"/>
+                                        <select value="0.1"/>
+				</gt>
+
+
+			
 				<if param="relief_smoothness_factor_more_plains">
 					<gt value1="4" value2=":incline">
+						<select value="3"/>
+					</gt>
+					<gt value1="8" value2=":incline">
 						<select value="5"/>
 					</gt>
-					<gt value1="7" value2=":incline">
-						<select value="7"/>
-					</gt>
 					<gt value1="15" value2=":incline">
-						<select value="9"/>
+						<select value="35"/>
 					</gt>
 					<gt value1="25" value2=":incline">
-						<select value="12"/>
+						<select value="120"/>
 					</gt>
-					<select value="4"/>
-				</if>
-				<if param="relief_smoothness_factor_hills">
-					<gt value1="4" value2=":incline">
-						<select value="2.5"/>
+					<gt value1="30" value2=":incline">
+						<select value="240"/>
 					</gt>
-					<gt value1="7" value2=":incline">
-						<select value="3.5"/>
-					</gt>
-					<gt value1="15" value2=":incline">
-						<select value="4.5"/>
-					</gt>
-					<gt value1="25" value2=":incline">
-						<select value="6"/>
+					<gt value1="35" value2=":incline">
+						<select value="480"/>
 					</gt>
 					<select value="1"/>
 				</if>
 
-				<gt value1="4" value2=":incline">
-					<select value="3.5"/>
-				</gt>
-				<gt value1="7" value2=":incline">
-					<select value="4.5"/>
-				</gt>
-				<gt value1="15" value2=":incline">
-					<select value="6"/>
-				</gt>
-				<gt value1="25" value2=":incline">
-					<select value="8"/>
-				</gt>
-				<select value="1.5"/>
+				<if param="relief_smoothness_factor_hills">
+
+					<gt value1="1" value2=":incline">
+						<select value="0.1"/>
+					</gt>
+					<gt value1="8" value2=":incline">
+						<select value="0.3"/>
+					</gt>
+					<gt value1="15" value2=":incline">
+						<select value="4"/>
+					</gt>
+					<gt value1="25" value2=":incline">
+						<select value="70"/>
+					</gt>
+					<!-- Incline above 25 per cent should get a high penalty, even
+					in hills mode: The steepest incline at the Tour de France in
+					2015 was 27 per cent. That was the peak value, while the
+					average value of that incline was 10 per cent. Most 
+					famous Tour de France inclines only have average values
+					of 10 to 15 per cent.
+					The higher inclines need much higher penalties, because 
+					they could appear only once in a longer route. So if you really want
+					to make a difference for this one incline, it needs a high (single)
+					penalty. An incline of 10 per cent can appear many times, and will
+					get a penalty many times, so even a low penalty can make a difference.-->
+
+					<gt value1="30" value2=":incline">
+						<select value="140"/>
+					</gt>
+
+					<gt value1="35" value2=":incline">
+						<select value="280"/>
+					</gt>
+					<select value="0.1"/>
+				</if>
+
+					<gt value1="4" value2=":incline">
+						<select value="2"/>
+					</gt>
+					<gt value1="8" value2=":incline">
+						<select value="4"/>
+					</gt>
+					<gt value1="15" value2=":incline">
+						<select value="30"/>
+					</gt>
+					<gt value1="25" value2=":incline">
+						<select value="90"/>
+					</gt>
+					<gt value1="30" value2=":incline">
+						<select value="180"/>
+					</gt>
+					<gt value1="35" value2=":incline">
+						<select value="360"/>
+					</gt>
+					<select value="1"/>
+
+
 			</if>
 		</way>
-
 		<way attribute="priority">
 			<select value="0.1" t="bicycle" v="private"/>
 			<select value="0.2" t="bicycle" v="destination"/>

--- a/routing/routing.xml
+++ b/routing/routing.xml
@@ -1047,9 +1047,9 @@
 				<select value="-1" t="barrier" v="border_control"/>
 			</if>
 			<if param="driving_style_safety">
-				<select value="16" t="crossing" v="traffic_signals"/>
-				<select value="16" t="crossing" v="island;traffic_signals"/>
-				<select value="27" t="highway" v="traffic_signals"/>
+				<select value="22" t="crossing" v="traffic_signals"/>
+				<select value="22" t="crossing" v="island;traffic_signals"/>
+				<select value="22" t="highway" v="traffic_signals"/>
 			</if>
 			<!-- Lines above: These values are only a workaround. They apply until 
 			one issue is resolved: The triple counting of traffic lights at main
@@ -1059,9 +1059,9 @@
 			those errors.-->
 			
 			<if param="driving_style_speed">
-				<select value="8" t="crossing" v="traffic_signals"/>
+				<select value="9" t="crossing" v="traffic_signals"/>
 			</if>
-			<select value="11" t="crossing" v="traffic_signals"/>
+			<select value="14" t="crossing" v="traffic_signals"/>
 			<select value="1" t="crossing" v="uncontrolled"/>
 			<select value="3" t="crossing" v="unmarked"/>
 			<select value="1" t="crossing" v="island"/>
@@ -1077,7 +1077,7 @@
 			<if param="driving_style_speed">
 				<select value="11" t="highway" v="traffic_signals"/>
 			</if>
-			<select value="19" t="highway" v="traffic_signals"/>
+			<select value="16" t="highway" v="traffic_signals"/>
 			<select value="55"  t="highway" v="steps"/>
 			<select value="15"  t="bicycle" v="dismount"/>
 			<select value="240" t="route" v="ferry"/>

--- a/routing/routing.xml
+++ b/routing/routing.xml
@@ -750,51 +750,49 @@
 					<select value="2" t="highway" v="track"/>
 				</gt>
 				<if param="relief_smoothness_factor_more_plains">
-					<gt value1="3" value2=":incline">
-						<select value="2"/>
+					<gt value1="4" value2=":incline">
+						<select value="5"/>
 					</gt>
 					<gt value1="7" value2=":incline">
+						<select value="7"/>
+					</gt>
+					<gt value1="15" value2=":incline">
+						<select value="9"/>
+					</gt>
+					<gt value1="25" value2=":incline">
 						<select value="12"/>
 					</gt>
-					<gt value1="13" value2=":incline">
-						<select value="30"/>
-					</gt>
-					<gt value1="25" value2=":incline">
-						<select value="50"/>
-					</gt>
-					<select value="74"/>
+					<select value="4"/>
 				</if>
 				<if param="relief_smoothness_factor_hills">
-					<gt value1="0" value2=":incline">
-						<select value="128"/>
-					</gt>
-					<gt value1="3" value2=":incline">
-						<select value="64"/>
+					<gt value1="4" value2=":incline">
+						<select value="2.5"/>
 					</gt>
 					<gt value1="7" value2=":incline">
-						<select value="17"/>
+						<select value="3.5"/>
 					</gt>
-					<gt value1="13" value2=":incline">
-						<select value="10"/>
+					<gt value1="15" value2=":incline">
+						<select value="4.5"/>
 					</gt>
 					<gt value1="25" value2=":incline">
-						<select value="8"/>
+						<select value="6"/>
 					</gt>
-					<select value="2"/>
+					<select value="1"/>
 				</if>
-				<gt value1="3" value2=":incline">
-					<select value="2"/>
+
+				<gt value1="4" value2=":incline">
+					<select value="3.5"/>
 				</gt>
 				<gt value1="7" value2=":incline">
-					<select value="8"/>
+					<select value="4.5"/>
 				</gt>
-				<gt value1="13" value2=":incline">
-					<select value="16"/>
+				<gt value1="15" value2=":incline">
+					<select value="6"/>
 				</gt>
 				<gt value1="25" value2=":incline">
-					<select value="32"/>
+					<select value="8"/>
 				</gt>
-				<select value="48"/>
+				<select value="1.5"/>
 			</if>
 		</way>
 


### PR DESCRIPTION
Dear all,

I have improved the values for the elevation mode and added them to the routing.xml. I did many hours of virtual testing in Vienna, Berlin and Hamburg. Before, the elevation mode sometimes would suggest a bad route, just to save 5 or 10 height meters. Now, it is more balanced (especially if we consider the "noise" that is in the elevation data). Also, now you get a clearer diffence between the three elevation modes (most leveled really suggesting the route with least elevation, etc).

The revision is based on one main thought: If you have to climb 1000 meters, it is very bad at 13 per cent incline, but still quite bad at 3 per cent incline. You still have to climb these 1000 meters (so also with 3 per cent incline, it is a good idea to take a longer detour to avoid them). According to my tests, the emphasis should first be on avoiding the height meters, and after that on reducing the incline. Even with the new values, a high incline can double or triple the penalty (in some cases even more than that). So first, height meters are avoided. But if they cannot be avoided, the routing engine will still heavily prefer a route where these height meters are better 'distributed" over the whole route (so, same height to climb, but less incline). 

I will do some further testing, but please do already include this into the routing.xml, because according to my thourough testing, it is a big step forward.

If someone else wants to do some testing: A good starting point for a "calibration" are these two routes

a) From Marktgasse 21 (Vienna) to ORF-Zentrum (Kueniglberg, Venna). In safety mode on the last uphill section, the routing should take Wattmanngasse (residential) not the Maxingstrasse (tertiary). The routing over Maxingstrasse is supposed to have 7 height meters less (that could also just be noise in the data). Only to save 7 metres, it does not make sense to go 500 metres uphill on a tertiary road without a bike path (this only makes sense in "speed" mode).  If the routing takes Maxingstrasse in "safety" mode, this is a sign that the elevation gets too much weight compared to the other OSM data.

b) From the public swimming pool in Huetteldorf (Vienna) to Langenlebarn Volksschule. In "most leveled", the routing should make a detour that has an additional 13,5 kilometres, but at the same time has 164 height meters LESS. (This does not apply in "fast" mode). This route is good for checking the routing engine's preferences, because all three main alternatives have their shortcomings: The shortest route has a long part over secondary and tertiary road without any bike path. A slightly longer route is much safer, but has more elevation and a 4km section of track with unknown surface. And then there is the third alternative that is very safe and very flat, but much longer. 

Greetings from Berlin,

Malte