### PR TITLE
Improve visibility of mountain huts if moreDetailed="true"

### DIFF
--- a/rendering_styles/default.render.xml
+++ b/rendering_styles/default.render.xml
@@ -2545,6 +2545,10 @@
 				<case tag="attraction" value="train"/>
 				<case tag="attraction" value="log_flume"/>
 				<case tag="building" value="no" order="-1"/>
+				<switch moreDetailed="true" order="10" ignorePolygonArea="true" ignorePolygonAsPointArea="true">
+					<case tag="tourism" value="alpine_hut"/>
+					<case tag="tourism" value="wilderness_hut"/>
+				</switch>
 				<case tag="amenity" value="place_of_worship" ignorePolygonAsPointArea="true">
 					<apply_if moreDetailed="true" ignorePolygonArea="true"/>
 				</case>
@@ -5884,6 +5888,7 @@
 					<case minzoom="15" tag="tourism" value="lean_to"/>
 					<case minzoom="14" tag="tourism" value="wilderness_hut"/>
 					<case minzoom="15" tag="amenity" value="shelter"/>
+					<apply_if minzoom="15" moreDetailed="true" textOrder="43"/>
 					<apply_if engine_v1="true" textDy="5"/>
 					<apply_if nightMode="true" textHaloColor="#55234ca7"/>
 				</switch>
@@ -6802,6 +6807,7 @@
 						<case tag="tourism" value="lean_to" icon="lean_to"/>
 						<case tag="tourism" value="wilderness_hut" icon="wilderness_hut"/>
 						<apply shield="blue_round_shield"/>
+						<apply_if minzoom="14" moreDetailed="true" iconOrder="43" iconVisibleSize="9" intersectionSizeFactor="0.7"/>
 						<apply_if minzoom="15" additional="drinking_water=yes" icon_2="drinking_water_yes_map"/>
 						<apply_if minzoom="15" additional="drinking_water=no" icon_2="drinking_water_no_map"/>
 						<apply_if nightMode="true" shield="blue_round_night_shield"/>
@@ -7293,6 +7299,7 @@
 						<case minzoom="13" tag="tourism" value="wilderness_hut" icon="wilderness_hut"/>
 						<case minzoom="16" tag="amenity" value="shelter" icon="amenity_shelter"/>
 						<case minzoom="15" tag="leisure" value="summer_camp" icon="summer_camp"/>
+						<apply_if minzoom="14" moreDetailed="true" iconOrder="43" iconVisibleSize="9" intersectionSizeFactor="0.7"/>
 						<apply_if minzoom="16" additional="drinking_water=yes" icon_2="drinking_water_yes_map"/>
 						<apply_if minzoom="16" additional="drinking_water=no" icon_2="drinking_water_no_map"/>
 					</switch>


### PR DESCRIPTION
**Improve visibility of mountain huts if moreDetailed="true"**

Mountain huts are reference buildings within undeveloped zones (typically in the mountains) and should be rendered at wide zooms.

With this PR, *alpine_hut* and *wilderness_hut* will be most probably rendered at z14+ or z15+ (before, some *alpine_hut* like [Rifugio Rino Olmo]( https://www.openstreetmap.org/way/120656176) was rendered at z18+).

This proposal is based on the comparison of Osmand with classic 1:50000 – 1:25000 touristic and topographic paper maps, that usually show these features.

I tried to reuse a similar design pattern to [Tweak place_of_worship order](https://github.com/osmandapp/OsmAnd-resources/commit/10184e1501f759724d184f1ab01f5b35fe7f52e4#diff-aa68e561bc04596c485828a0f39f460c).