### PR TITLE
Improve text size and related order for region:type=mountain_area

### DIFF
--- a/obf_creation/rendering_types.xml
+++ b/obf_creation/rendering_types.xml
@@ -4331,12 +4331,12 @@
 		<entity_convert pattern="tag_transform" from_tag="natural" from_value="bedrock" to_tag1="natural" to_value1="bare_rock"/>
 		<entity_convert pattern="tag_transform" from_tag="natural" from_value="rock" to_tag1="natural" to_value1="bare_rock" apply_to="way"/>
 		<entity_convert pattern="tag_transform" from_tag="natural" from_value="rocks" to_tag1="natural" to_value1="bare_rock"/>
-		<type tag="natural" value="ridge" minzoom="10" />
+		<type tag="natural" value="ridge" minzoom="6" />
 		<entity_convert pattern="tag_transform" from_tag="natural" from_value="arete" to_tag1="natural" to_value1="ridge"/>
 		<type tag="natural" value="saddle" minzoom="10" nameTags="ele" />
 		<entity_convert pattern="tag_transform" from_tag="natural" from_value="waterfall" to_tag1="waterway"/>
 		<type tag="natural" value="cape" minzoom="10" />
-		<type tag="natural" value="volcano" minzoom="10" nameTags="ele" />
+		<type tag="natural" value="volcano" minzoom="6" nameTags="ele" />
 		<entity_convert pattern="tag_transform" from_tag="volcano" from_value="yes" to_tag1="natural" to_value1="volcano"/>
 		<type tag="natural" value="crater" minzoom="10" />
 		<type tag="natural" value="cave_entrance" minzoom="10" nameTags="ele" />
@@ -4360,14 +4360,14 @@
 		<entity_convert pattern="tag_transform" from_tag="water:temperature" to_tag1="temperature" map="no"/>
 		<type tag="natural" value="geyser" minzoom="10" />
 		<type tag="natural" value="stone" minzoom="10" />
-		<type tag="natural" value="valley" minzoom="8" />
+		<type tag="natural" value="valley" minzoom="6" />
 		<entity_convert pattern="tag_transform" from_tag="tourism" from_value="valley" to_tag1="natural" to_value1="valley"/>
 		<entity_convert pattern="tag_transform" from_tag="natural" from_value="gully" to_tag1="natural" to_value1="valley"/>
 		<entity_convert pattern="tag_transform" from_tag="natural" from_value="valley" if_tag1="waterway"/>
 		<entity_convert pattern="tag_transform" from_tag="natural" from_value="gully" if_tag1="waterway"/>
 		<type tag="natural" value="gorge" minzoom="10" />
 		<type tag="natural" value="couloir" minzoom="10" />
-		<type tag="region:type" value="mountain_area" minzoom="10" />
+		<type tag="region:type" value="mountain_area" minzoom="6" />
 		<entity_convert pattern="tag_transform" from_tag="natural" from_value="massif" to_tag1="region:type" to_value1="mountain_area"/>
 		<entity_convert pattern="tag_transform" from_tag="natural" from_value="mountain_range" to_tag1="region:type" to_value1="mountain_area"/>
 		<type tag="natural" value="tree" minzoom="17" />

--- a/rendering_styles/default.render.xml
+++ b/rendering_styles/default.render.xml
@@ -5403,7 +5403,7 @@
 						<apply_if minzoom="15" engine_v1="true" textDy="-1"/>
 					</case>
 					<case minzoom="16" textSize="12" tag="natural" value="cave_entrance" textOrder="236"/>
-					<case minzoom="14" textSize="12" tag="natural" value="ridge" textOnPath="true" textDy="0" textOrder="43"/>
+					<case minzoom="6" textSize="12" tag="natural" value="ridge" textOnPath="true" textDy="0" textOrder="43"/>
 					<case minzoom="16" textSize="12" tag="natural" value="cliff" textOnPath="true" textHaloRadius="3" textDy="0" textOrder="43"/>
 					<switch tag="natural" value="valley" textOnPath="true" textColor="#356B25" textHaloRadius="3" textDy="0" textOrder="10">
 						<case minzoom="15" textSize="22" />
@@ -5417,7 +5417,16 @@
 					</switch>
 					<case minzoom="13" textSize="12" tag="natural" value="gorge" textOnPath="true" textOrder="44" textDy="0"/>
 					<case minzoom="13" textSize="12" tag="natural" value="couloir" textOnPath="true" textOrder="44" textDy="0"/>
-					<case minzoom="10" textSize="13" tag="region:type" value="mountain_area" textOrder="43"/>
+					<switch tag="region:type" value="mountain_area" textHaloRadius="5" textOrder="130" textDy="0">
+						<case minzoom="12" textSize="20" />
+						<case minzoom="11" textSize="18" />
+						<case minzoom="10" textSize="15" />
+						<case minzoom="8" textSize="13" />
+						<case minzoom="7" textSize="10" />
+						<case minzoom="6" textSize="8" />
+					  <apply_if moreDetailed="true" textOrder="33"/>
+					  <apply_if maxzoom="10" moreDetailed="true" textOrder="6"/> <!-- Only if region:type is available at z10- -->
+					</switch>
 					<case minzoom="14" textSize="12" tag="waterway" value="drystream" textOnPath="true" textOrder="77" textDy="0"/>
 					<case minzoom="16" textSize="12" tag="waterway" value="rapids" textOnPath="true"/>
 					<case minzoom="15" textSize="12" tag="natural" value="saddle" nameTag="" nameTag2="ele"/>

--- a/rendering_styles/topo.render.xml
+++ b/rendering_styles/topo.render.xml
@@ -2021,7 +2021,7 @@
 						<case minzoom="13" textSize="13"/>
 					</case>
 					<case minzoom="16" textSize="12" tag="natural" value="cave_entrance" textOrder="236"/>
-					<case minzoom="14" textSize="12" tag="natural" value="ridge" textItalic="false" textOnPath="true" textOrder="43"/>
+					<case minzoom="6" textSize="12" tag="natural" value="ridge" textItalic="false" textOnPath="true" textOrder="43"/>
 					<switch minzoom="13">
 						<case tag="natural" value="valley"/>
 						<case tag="waterway" value="drystream"/>
@@ -2032,7 +2032,14 @@
 					<case minzoom="15" textSize="12" tag="natural" value="saddle" nameTag="" nameTag2="ele"/>
 					<case minzoom="13" textSize="12" tag="natural" value="gorge" textOnPath="true" textOrder="44" textDy="0"/>
 					<case minzoom="13" textSize="12" tag="natural" value="couloir" textOnPath="true" textOrder="44" textDy="0"/>
-					<case minzoom="10" textSize="13" tag="region:type" value="mountain_area" textOrder="43"/>
+					<switch tag="region:type" value="mountain_area" textHaloRadius="5" textOrder="33" textDy="0">
+						<case minzoom="12" textSize="20" />
+						<case minzoom="11" textSize="18" />
+						<case minzoom="10" textSize="15" />
+						<case minzoom="8" textSize="13" />
+						<case minzoom="7" textSize="10" />
+						<case minzoom="6" textSize="8" />
+					</switch>
 					<case minzoom="13" textSize="14" tag="natural" value="crater" textColor="#4e0d0d"/>
 					<case minzoom="14" textSize="12" tag="mountain_pass" value="yes" nameTag="" nameTag2="ele" textBold="false"/>
 					<case minzoom="14" textSize="12" tag="mountain_pass" value="yes" nameTag="ele" textBold="false"/>


### PR DESCRIPTION
**Improve text size and related order for *region:type=mountain_area***

Edit: this part is superseded by the subsequent note (see. "Code revised.").

_________________

After this modification, *region:type=mountain_area* will be rendered starting at z11+ (before it was rendered only at z13+).

This PR should be complemented in order to also allow showing this feature at z8, z9 and z10. I do not know of how to do it, even if *rendering_types.xml* is correctly set. Notice that even now that *rendering_types.xml* sets z10+, *region:type=mountain_area* is not rendered at that zoom.

Samples after this code is merged, all related to [this wide feature](http://www.openstreetmap.org/relation/2506537):

![z11](https://user-images.githubusercontent.com/8292987/32702403-f45e2bc6-c7e6-11e7-8ec2-96acaaf81d18.jpg)
Text shown at z11

![z10](https://user-images.githubusercontent.com/8292987/32702404-f4765228-c7e6-11e7-8749-dab0b7b0e3a1.jpg)
Text not shown at z10, even if it should be

![z9](https://user-images.githubusercontent.com/8292987/32702402-f4419902-c7e6-11e7-9595-50f1d111a0f5.jpg)
Text not shown at z9, even if it should be

The following image shows the zoom level this feature is currently rendered (without this code):
![before](https://user-images.githubusercontent.com/8292987/32702583-a17c4dd6-c7e9-11e7-8066-71e7a62fd79a.jpg)
