### PR TITLE
Revised text attributes and size of natural=valley

### DIFF
--- a/obf_creation/rendering_types.xml
+++ b/obf_creation/rendering_types.xml
@@ -4355,7 +4355,7 @@
 		<entity_convert pattern="tag_transform" from_tag="water:temperature" to_tag1="temperature" map="no"/>
 		<type tag="natural" value="geyser" minzoom="10" />
 		<type tag="natural" value="stone" minzoom="10" />
-		<type tag="natural" value="valley" minzoom="10" />
+		<type tag="natural" value="valley" minzoom="8" />
 		<entity_convert pattern="tag_transform" from_tag="tourism" from_value="valley" to_tag1="natural" to_value1="valley"/>
 		<entity_convert pattern="tag_transform" from_tag="natural" from_value="gully" to_tag1="natural" to_value1="valley"/>
 		<entity_convert pattern="tag_transform" from_tag="natural" from_value="valley" if_tag1="waterway"/>

--- a/rendering_styles/default.render.xml
+++ b/rendering_styles/default.render.xml
@@ -5399,7 +5399,16 @@
 					<case minzoom="16" textSize="12" tag="natural" value="cave_entrance" textOrder="236"/>
 					<case minzoom="14" textSize="12" tag="natural" value="ridge" textOnPath="true" textDy="0" textOrder="43"/>
 					<case minzoom="16" textSize="12" tag="natural" value="cliff" textOnPath="true" textHaloRadius="3" textDy="0" textOrder="43"/>
-					<case minzoom="13" textSize="12" tag="natural" value="valley" textOnPath="true" textOrder="44" textDy="0"/>
+					<switch tag="natural" value="valley" textOnPath="true" textColor="#356B25" textHaloRadius="3" textDy="0" textOrder="10">
+						<case minzoom="15" textSize="22" />
+						<case minzoom="14" textSize="20" />
+						<case minzoom="13" textSize="18" />
+						<case minzoom="12" textSize="16" />
+						<case minzoom="11" textSize="15" />
+						<case minzoom="10" textSize="14" />
+						<case minzoom="9" textSize="13" />
+						<case minzoom="8" textSize="12" />
+					</switch>
 					<case minzoom="13" textSize="12" tag="natural" value="gorge" textOnPath="true" textOrder="44" textDy="0"/>
 					<case minzoom="13" textSize="12" tag="natural" value="couloir" textOnPath="true" textOrder="44" textDy="0"/>
 					<case minzoom="10" textSize="13" tag="region:type" value="mountain_area" textOrder="43"/>
@@ -11188,8 +11197,10 @@
 			<apply color="#99ffff00" shadowColor="#ff0000"/>
 		</switch>-->
 
-		<switch minzoom="13">
+		<switch minzoom="8" strokeWidth="0.1" color="$null">
 			<case tag="natural" value="valley"/>
+		</switch>
+		<switch>
 			<case minzoom="14" tag="waterway" value="drystream"/>
 			<apply_if maxzoom="14" strokeWidth="2"/>
 			<apply_if minzoom="15" maxzoom="16" strokeWidth="3"/>


### PR DESCRIPTION
**Revised text attributes and size of *natural=valley***

Removed rendering of polylines for valleys tagged as ways.

Valleys are rendered at z11+.

(With a separate PR, big valleys should be visible from z8+ anyway.)

Samples:
![z10](https://user-images.githubusercontent.com/8292987/32705181-5ded2eb4-c811-11e7-8a47-b4a89ce378cd.jpg)
zoom=10: none shown as this is the basemap

![z11](https://user-images.githubusercontent.com/8292987/32705180-5dd2b3d6-c811-11e7-85cd-aed87dbeb3eb.jpg)
zoom=11 (first zoom level of the detailed map)

![z12](https://user-images.githubusercontent.com/8292987/32705179-5db9c506-c811-11e7-9a9a-d145836dbb2b.jpg)
zoom=12

![z13](https://user-images.githubusercontent.com/8292987/32705175-5d523a6c-c811-11e7-863d-887f4b233879.jpg)
zoom=13

![z14](https://user-images.githubusercontent.com/8292987/32705176-5d6ba830-c811-11e7-88fa-1509d097ac64.jpg)
zoom=14

![z15](https://user-images.githubusercontent.com/8292987/32705177-5d8741a8-c811-11e7-9ff7-39e9d0be6e93.jpg)
zoom=15

![z16](https://user-images.githubusercontent.com/8292987/32705178-5d9febea-c811-11e7-83f2-1e46803e29bf.jpg)
zoom=16