### PR TITLE
Show text label for natural=rock

### DIFF
--- a/rendering_styles/default.render.xml
+++ b/rendering_styles/default.render.xml
@@ -5586,6 +5586,7 @@
 						<case minzoom="18" tag="natural" value="tree" textSize="11" textDy="5" textOrder="252"/>
 						<case minzoom="18" tag="natural" value="stone" textSize="11" textDy="4"/>
 						<case minzoom="17" tag="natural" value="rock" textSize="11" textDy="4"/>
+						<case minzoom="16" tag="natural" value="bare_rock" textSize="11" textDy="4"/>
 						<case minzoom="9" tag="natural" value="reef"/>
 						<case minzoom="13" tag="natural" value="shoal"/>
 						<apply_if engine_v1="false" textDy="0"/>


### PR DESCRIPTION
**Show text label for *natural=rock* in case of ways/polygons (and not only for nodes).**

As *natural=rock* is converted to *natural=bare_rock* for "way" in *rendering_types.xml*, the text label for *natural=bare_rock* is added.

Notice that this change does not yet add "natural_stone" icon to "bare_rock", just assuming that this is really wanted (otherwise,  `<case minzoom="17" tag="natural" value="bare_rock"/>` shall also be added before `<apply icon="natural_stone" shield="stone_shield"/>`).