### PR TITLE
Revised text attributes and size of natural=ridge and natural=arete

### DIFF
--- a/rendering_styles/default.render.xml
+++ b/rendering_styles/default.render.xml
@@ -5403,7 +5403,15 @@
 						<apply_if minzoom="15" engine_v1="true" textDy="-1"/>
 					</case>
 					<case minzoom="16" textSize="12" tag="natural" value="cave_entrance" textOrder="236"/>
-					<case minzoom="6" textSize="12" tag="natural" value="ridge" textOnPath="true" textDy="0" textOrder="43"/>
+					<switch tag="natural" value="ridge" textOnPath="true" textDy="0" textOrder="43">
+						<case minzoom="17" textSize="20" />
+						<case minzoom="16" textSize="18" />
+						<case minzoom="15" textSize="16" />
+						<case minzoom="14" textSize="14" />
+						<case moreDetailed="true" minzoom="13" textSize="13" />
+						<case moreDetailed="true" minzoom="12" textSize="11" />
+						<case moreDetailed="true" minzoom="6" textSize="10" textHaloRadius="5" />
+					</switch>
 					<case minzoom="16" textSize="12" tag="natural" value="cliff" textOnPath="true" textHaloRadius="3" textDy="0" textOrder="43"/>
 					<switch tag="natural" value="valley" textOnPath="true" textColor="#356B25" textHaloRadius="3" textDy="0" textOrder="43">
 						<case minzoom="17" textSize="20" />
@@ -10526,13 +10534,7 @@
 			<apply minzoom="17" maxzoom="17" strokeWidth_2="4:4" pathEffect_2="1_9"/>
 			<apply minzoom="18" strokeWidth_2="5.5:5.5" pathEffect_2="1_13"/>
 		</switch>
-		<case minzoom="11" tag="natural" value="ridge" color="#666666" color_2="#000000">
-			<case maxzoom="11" strokeWidth="0.4"/>
-			<case maxzoom="12" strokeWidth="0.5"/>
-			<case maxzoom="13" strokeWidth="0.8" strokeWidth_2="1.1:1.1" pathEffect_2="1_23"/>
-			<case maxzoom="14" strokeWidth="1" strokeWidth_2="1.5:1.5" pathEffect_2="1_27"/>
-			<case maxzoom="15" strokeWidth="1.3:1.3" strokeWidth_2="1.7:1.7" pathEffect_2="1_32"/>
-			<case minzoom="16" strokeWidth="1.5:1.5" strokeWidth_2="1.8:1.8" pathEffect_2="1_37"/>
+		<case minzoom="6" tag="natural" value="ridge" color="#666666" color_2="#000000" strokeWidth="0.3">
 			<apply_if nightMode="true" color="#666666" color_2="#999999"/>
 		</case>
 		<switch minzoom="11">


### PR DESCRIPTION
**Revised text attributes and size of *natural=ridge* and *natural=arete***

Now polylines are rendered only from zoom 6 to zoom 10; in order to show them at these zooms, the maps provided with Osmand shall be complemented with a specific layer (as the one attached [here](https://github.com/osmandapp/OsmAnd-resources/pull/458#issuecomment-345872380)).

Removed rendering of polylines from zoom 11 on (as done with [valleys](https://github.com/osmandapp/OsmAnd-resources/pull/459)).