### PR TITLE
Revised rendering of natural=valley

### DIFF
--- a/rendering_styles/default.render.xml
+++ b/rendering_styles/default.render.xml
@@ -5405,15 +5405,14 @@
 					<case minzoom="16" textSize="12" tag="natural" value="cave_entrance" textOrder="236"/>
 					<case minzoom="6" textSize="12" tag="natural" value="ridge" textOnPath="true" textDy="0" textOrder="43"/>
 					<case minzoom="16" textSize="12" tag="natural" value="cliff" textOnPath="true" textHaloRadius="3" textDy="0" textOrder="43"/>
-					<switch tag="natural" value="valley" textOnPath="true" textColor="#356B25" textHaloRadius="3" textDy="0" textOrder="10">
-						<case minzoom="15" textSize="22" />
-						<case minzoom="14" textSize="20" />
-						<case minzoom="13" textSize="18" />
-						<case minzoom="12" textSize="16" />
-						<case minzoom="11" textSize="15" />
-						<case minzoom="10" textSize="14" />
-						<case minzoom="9" textSize="13" />
-						<case minzoom="8" textSize="12" />
+					<switch tag="natural" value="valley" textOnPath="true" textColor="#356B25" textHaloRadius="3" textDy="0" textOrder="43">
+						<case minzoom="17" textSize="20" />
+						<case minzoom="16" textSize="18" />
+						<case minzoom="15" textSize="16" />
+						<case minzoom="14" textSize="14" />
+						<case moreDetailed="true" minzoom="13" textSize="13" />
+						<case moreDetailed="true" minzoom="12" textSize="11" />
+						<case moreDetailed="true" minzoom="6" textSize="10" textHaloRadius="5" />
 					</switch>
 					<case minzoom="13" textSize="12" tag="natural" value="gorge" textOnPath="true" textOrder="44" textDy="0"/>
 					<case minzoom="13" textSize="12" tag="natural" value="couloir" textOnPath="true" textOrder="44" textDy="0"/>


### PR DESCRIPTION
Revised rendering of *natural=valley* using a similar pattern to [*natural=ridge* and *natural=arete*](https://github.com/osmandapp/OsmAnd-resources/pull/470).