### PR TITLE
Avoid routing over proposed roads

### DIFF
--- a/routing/routing.xml
+++ b/routing/routing.xml
@@ -72,8 +72,10 @@
 
 		<way attribute="access">
 			<select value="-1" t="osmand_change" v="delete"/>
+			<select value="-1" t="highway" v="proposed"/>
 			<select value="-1" t="highway" v="construction"/>
 			<select value="-1" t="construction" v="yes"/>
+
 			<select value="-1" t="highway" v="motorway">
 				<if param="avoid_motorway"/>
 			</select>
@@ -517,6 +519,10 @@
 
 		<way attribute="access">
 			<select value="-1" t="osmand_change" v="delete"/>
+			<select value="-1" t="highway" v="proposed"/>
+			<select value="-1" t="highway" v="construction"/>
+			<select value="-1" t="construction" v="yes"/>
+
 			<if param="allow_motorway">
 				<select value="-1" t="access" v="no"/>
 				<select value="-1" t="access" v="private"/>
@@ -545,8 +551,6 @@
 			are not explicitly allowed by the user.-->
 			<select value="-1" t="highway" v="elevator"/>
 
-			<select value="-1" t="highway" v="construction"/>
-			<select value="-1" t="construction" v="yes"/>
 			<select value="-1" t="bicycle" v="no"/>
 			<select value="1"  t="bicycle" v="yes"/>
 			<select value="1"  t="bicycle" v="permissive"/>
@@ -1151,6 +1155,10 @@
 
 		<way attribute="access">
 			<select value="-1" t="osmand_change" v="delete"/>
+			<select value="-1" t="highway" v="proposed"/>
+			<select value="-1" t="highway" v="construction"/>
+			<select value="-1" t="construction" v="yes"/>
+
 			<if param="avoid_motorway">
 				<select value="-1" t="highway" v="motorway"/>
 				<select value="-1" t="highway" v="motorway_link"/>


### PR DESCRIPTION
We should probably not route over highway=proposed roads even if they have explicit access tags. There is no road yet (even not partly constructed) so no means of transport can pass yet.
See https://groups.google.com/d/msg/osmand/0O0hvbVaXCg/4v3YKl-DBwAJ with a real world example https://www.openstreetmap.org/way/263684442 .

We don't want to eliminate higway=proposed objects before creating the obf file as we do render planned objects in OsmAnd (based on user setting).