### PR TITLE
Update routing.xml

### DIFF
--- a/routing/routing.xml
+++ b/routing/routing.xml
@@ -853,10 +853,8 @@
 <!--				<select value="0.6" t="surface" v="wood"/>-->
 			</if>
 			
-			<select value="1.0" t="segregated" v="yes"/>
 			<select value="1.0" t="bicycle" v="dismount"/>
 			<select value="1.0" t="cycleway" v="sidepath"/>
-			<select value="0.3" t="footway" v="sidewalk"/>
 			<!-- Following lines: I would suggest to change
 			the order, according to the following scheme:
 			
@@ -904,9 +902,9 @@
 			downgraded now.-->
 
 			<select value="0.1" t="sac_scale" v="mountain_hiking"/>
-			<select value="0.9" t="class:bicycle:mtb" v="3"/>
-			<select value="0.8" t="class:bicycle:mtb" v="2"/>
-			<select value="0.7" t="class:bicycle:mtb" v="1"/>
+			<select value="0.5" t="class:bicycle:mtb" v="3"/>
+			<select value="0.3" t="class:bicycle:mtb" v="2"/>
+			<select value="0.2" t="class:bicycle:mtb" v="1"/>
 			<select value="0.1" t="class:bicycle:mtb" v="-1"/>
 			<select value="0.3" t="mtb:scale" v="1"/>
 			<select value="0.2" t="mtb:scale" v="2"/>
@@ -931,6 +929,8 @@
 			<select value="1.6" t="cycleway" v="opposite_track"/>
 			<select value="0.9" t="cycleway" v="shared"/>
 			<select value="0.9" t="cycleway" v="shared_lane"/>
+			<select value="0.3" t="footway" v="sidewalk"/>
+			<select value="1.0" t="segregated" v="yes"/>
 
 			<select value="1.0" t="highway" v="primary"/>
 			<select value="1.0" t="highway" v="secondary"/>


### PR DESCRIPTION
I would suggest to move the footway=sidewalk further down, because there were cases when a cycleway was marked with this tag, like in this case: https://github.com/osmandapp/Osmand/issues/4461 With the change, Osmand will first check if it is cycleway=track (etc), and only downgrade sidewalks, if not cycleway tag was found.

I have also moved segregated=yes further down.

Additionally, I would suggest to downgrade mountainbike tracks. Even if mountainbike enthousiasts think that a way gets 3 points (for mountainbiking), it might still be terrible for normal cycling! Those mountainbike tags are quite subjective anyway (do the easy tracks get many points or the horribly difficult ones? That is not clear at all. So, I would treat any MTB track with caution in a general bicycle router).