### PR TITLE
Fixed small error in documentation

### DIFF
--- a/routing/routing.xml
+++ b/routing/routing.xml
@@ -336,7 +336,7 @@
 		<select value="-1" t="maxweight" />
  	</gt>
 
-	To call a value, use either ':' or '$' as prefix. Use ':' for the parameters that you defined and '$' for tags loaded from the obf-file (the file containing the data from OSM). (Note: actually it doesn't matter which symbol is used. ':height' and '$height' will both call the same parameter. But for clarity, stick to this idiom).
+	To call a value, use either ':' or '$' as prefix. Use ':' for the parameters that you defined and '$' for tags loaded from the obf-file (the file containing the data from OSM).
 
 	The `type` gives a hint on how to parse the values. If the type is `height`, '1' will be interpreted as '1 meter'.
 	For a type `height`, '1' will be interpreted as one ton (1000 kg)


### PR DESCRIPTION
As vshcherb mentioned, it _does_ matter if you use `$` or `:` to call variables. This was noted incorrectly - which is now removed.