### PR TITLE
Updated Japanese TTS

### DIFF
--- a/voice/ja/ja_tts.js
+++ b/voice/ja/ja_tts.js
@@ -1,0 +1,755 @@
+
+// IMPLEMENTED (X) or MISSING ( ) FEATURES, (N/A) if not needed in this language:
+//
+// (X) Basic navigation prompts: route (re)calculated (with distance and time support), turns, roundabouts, u-turns, straight/follow, arrival
+// (X) Announce nearby point names (destination / intermediate / GPX waypoint / favorites / POI)
+// (X) Attention prompts: SPEED_CAMERA; SPEED_LIMIT; BORDER_CONTROL; RAILWAY; TRAFFIC_CALMING; TOLL_BOOTH; STOP; PEDESTRIAN; MAXIMUM; TUNNEL
+// (X) Other prompts: gps lost, off route, back to route
+// (X) Street name and prepositions (onto / on / to) and street destination (toward) support
+// (X) Distance unit support (meters / feet / yard)
+// (N/A) Special grammar: (please specify which)
+var metricConst;
+var dictionary = {};
+// TODO set this as a boolena flag to determine if we need to return tts prompts or ogg file names
+var tts;
+//// STRINGS
+////////////////////////////////////////////////////////////////
+// ROUTE CALCULATED
+function populateDictionary(tts) {
+	dictionary["route_is"] = tts ? tts ? "目的地まで " : "route_is.ogg" : "route_is.ogg";
+	dictionary["route_calculate"] = tts ? "ルートを更新しました。" : "route_calculate.ogg";
+	dictionary["distance"] = tts ? "距離は " : "distance.ogg";
+
+	// LEFT/RIGHT
+	//dictionary["prepare"] = "Prepare to "
+	dictionary["after"] = tts ? "先 " : "after.ogg";
+	dictionary["in"] = tts ? "先 " : "in.ogg";
+
+	dictionary["left"] = tts ? "左方向です。" : "left.ogg";
+	dictionary["left_sh"] = tts ? "手前左方向です。" : "left_sh.ogg";
+	dictionary["left_sl"] = tts ? "斜め左方向です。" : "left_sl.ogg";
+	dictionary["right"] = tts ? "右方向です。" : "right.ogg";
+	dictionary["right_sh"] = tts ? "手前右方向です。" : "right_sh.ogg";
+	dictionary["right_sl"] = tts ? "斜め右方向です。" : "right_sl.ogg";
+	dictionary["left_keep"] = tts ? "分岐を左方向です。" : "left_keep.ogg";
+	dictionary["right_keep"] = tts ? "分岐を右方向です。" : "right_keep.ogg";
+	dictionary["left_bear"] = tts ? "左方向です。" : "left_bear.ogg";    // in English the same as left_keep, may be different in other languages
+	dictionary["right_bear"] = tts ? "右方向です。" : "right_bear.ogg";  // in English the same as right_keep, may be different in other languages
+
+	// U-TURNS
+	dictionary["make_uturn"] = tts ? "Uターンをして下さい。" : "make_uturn.ogg";
+	dictionary["make_uturn_wp"] = tts ? "可能ならUターンをして下さい" : "make_uturn_wp.ogg";
+
+	// ROUNDABOUTS
+	dictionary["prepare_roundabout"] = tts ? "ロータリーがあります。" : "prepare_roundabout.ogg";
+	//dictionary["roundabout"] = tts ? "enter the roundabout, " : "roundabout.ogg";
+	dictionary["then"] = tts ? " その先 " : "then.ogg";
+	//dictionary["and"] = tts ? "その先" : "and.ogg";
+	dictionary["take"] = tts ? "ロータリの " : "take.ogg";
+	dictionary["exit"] = tts ? "の出口です。" : "exit.ogg";
+
+	dictionary["1st"] = tts ? "いち番目 " : "1st.ogg";
+	dictionary["2nd"] = tts ? "に番目" : "2nd.ogg";
+	dictionary["3rd"] = tts ? "さん番目" : "3rd.ogg";
+	dictionary["4th"] = tts ? "よん番目" : "4th.ogg";
+	dictionary["5th"] = tts ? "ご番目" : "5th.ogg";
+	dictionary["6th"] = tts ? "ろく番目" : "6th.ogg";
+	dictionary["7th"] = tts ? "なな番目" : "7th.ogg";
+	dictionary["8th"] = tts ? "はち番目" : "8th.ogg";
+	dictionary["9th"] = tts ? "きゅう番目" : "9th.ogg";
+	dictionary["10th"] = tts ? "じゅう番目" : "10th.ogg";
+	dictionary["11th"] = tts ? "じゅういち番目" : "11th.ogg";
+	dictionary["12th"] = tts ? "じゅうに番目" : "12th.ogg";
+	dictionary["13th"] = tts ? "じゅうさん番目" : "13th.ogg";
+	dictionary["14th"] = tts ? "じゅうよん番目" : "14th.ogg";
+	dictionary["15th"] = tts ? "じゅうご番目" : "15th.ogg";
+	dictionary["16th"] = tts ? "じゅうろく番目" : "16th.ogg";
+	dictionary["17th"] = tts ? "じゅうなな番目" : "17th.ogg";
+
+	// STRAIGHT/FOLLOW
+	dictionary["go_ahead"] = tts ? "道なりに" : "go_ahead.ogg";
+	dictionary["follow"] = tts ? "道なりに " : "follow.ogg";  // "Follow the course of the road for" perceived as too chatty by many users
+
+	// ARRIVE
+	dictionary["and_arrive_destination"] = tts ? "目的地です。 " : "and_arrive_destination.ogg";
+	dictionary["reached_destination"] = tts ? "目的地です。 " : "reached_destination.ogg";
+	dictionary["and_arrive_intermediate"] = tts ? "途中の目的地です。" : "and_arrive_intermediate.ogg";
+	dictionary["reached_intermediate"] = tts ? "途中の目的地です。" : "reached_intermediate.ogg";
+
+	// NEARBY POINTS
+	dictionary["and_arrive_waypoint"] = tts ? "ウェイポイントです。" : "and_arrive_waypoint.ogg";
+	dictionary["reached_waypoint"] = tts ? "ウェイポイントです。" : "reached_waypoint.ogg";
+	dictionary["and_arrive_favorite"] = tts ? "お気に入り場所です。 " : "and_arrive_favorite.ogg";
+	dictionary["reached_favorite"] = tts ? "お気に入り場所です。 " : "reached_favorite.ogg";
+	dictionary["and_arrive_poi"] = tts ? "and pass POI " : "and_arrive_poi.ogg";
+	dictionary["reached_poi"] = tts ? "you are passing POI " : "reached_poi.ogg";
+
+// ATTENTION
+//dictionary["exceed_limit"] = "you are exceeding the speed limit "
+	dictionary["exceed_limit"] = tts ? "最高速度 " : "exceed_limit.ogg";
+	dictionary["attention"] = tts ? "ご注意下さい " : "attention.ogg";
+	dictionary["speed_camera"] = tts ? "スピードカメラ" : "speed_camera.ogg";
+	dictionary["border_control"] = tts ? "税関" : "border_control.ogg";
+	dictionary["railroad_crossing"] = tts ? "踏切" : "railroad_crossing.ogg";
+	dictionary["traffic_calming"] = tts ? "交通静穏化" : "traffic_calming.ogg";
+	dictionary["toll_booth"] = tts ? "料金所" : "toll_booth.ogg";
+	dictionary["stop"] = tts ? "一時停止標識" : "stop.ogg";
+	dictionary["pedestrian_crosswalk"] = tts ? "横断歩道" : "pedestrian_crosswalk.ogg";
+	dictionary["tunnel"] = tts ? "トンネル" : "tunnel.ogg";
+
+// OTHER PROMPTS
+	dictionary["location_lost"] = tts ? "GPS信号を失いました。" : "location_lost.ogg";
+	dictionary["location_recovered"] = tts ? "GPS信号が回復しました。" : "location_recovered.ogg";
+	dictionary["off_route"] = tts ? "ルートから外れました。" : "off_route.ogg";
+	dictionary["back_on_route"] = tts ? "ルートに復帰しました。" : "back_on_route.ogg";
+
+// STREET NAME PREPOSITIONS
+	dictionary["onto"] = tts ? "に " : "onto.ogg";
+	dictionary["on"] = tts ? "に " : "on.ogg";    // is used if you turn together with your current street, i.e. street name does not change.
+	dictionary["to"] = tts ? "方面 " : "to.ogg";
+	dictionary["toward"] = tts ? "方面 " : "toward.ogg";
+
+// DISTANCE UNIT SUPPORT
+	dictionary["meters"] = tts ? "メートル" : "meters.ogg";
+	dictionary["around_1_kilometer"] = tts ? "およそ1キロ" : "around_1_kilometer.ogg";
+	dictionary["around"] = tts ? "およそ" : "around.ogg";
+	dictionary["kilometers"] = tts ? "キロ" : "kilometers.ogg";
+
+	dictionary["feet"] = tts ? "フィート" : "feet.ogg";
+	dictionary["1_tenth_of_a_mile"] = tts ? "one tenth of a mile" : "1_tenth_of_a_mile.ogg";
+	dictionary["tenths_of_a_mile"] = tts ? "tenths of a mile" : "tenths_of_a_mile.ogg";
+	dictionary["around_1_mile"] = tts ? "about 1 mile" : "around_1_mile.ogg";
+	dictionary["miles"] = tts ? "miles" : "miles.ogg";
+	dictionary["yards"] = tts ? "yards" : "yards.ogg";
+
+// TIME SUPPORT
+	dictionary["time"] = tts ? "時間" : "jikan.ogg";
+	//dictionary["1_hour"] = tts ? "one hour " : "1_hour.ogg";
+    dictionary["hours"] = tts ? "時間" : "jikan.ogg";
+	dictionary["less_a_minute"] = tts ? "1分以内" : "ippun_inai.ogg";
+	dictionary["1_minute"] = tts ? "1分" : "ippun.ogg";
+    dictionary["2_minutes"] = tts ? "2分" : "ni_fun.ogg";
+    dictionary["3_minutes"] = tts ? "3分" : "san_pun.ogg";
+    dictionary["4_minutes"] = tts ? "4分" : "yon_pun.ogg";
+    dictionary["5_minutes"] = tts ? "5分" : "go_fun.ogg";
+    dictionary["6_minutes"] = tts ? "6分" : "roppun.ogg";
+    dictionary["7_minutes"] = tts ? "7分" : "nana_fun.ogg";
+    dictionary["8_minutes"] = tts ? "8分" : "happun.ogg";
+    dictionary["9_minutes"] = tts ? "9分" : "kyuu_fun.ogg";
+    dictionary["10_minutes"] = tts ? "10分" : "juppun.ogg";
+	dictionary["minutes"] = tts ? "分" : "minutes.ogg";
+}
+
+//// COMMAND BUILDING / WORD ORDER
+////////////////////////////////////////////////////////////////
+function setMetricConst(metrics) {
+	metricConst = metrics;
+}
+
+function setMode(mode) {
+	tts = mode;
+	populateDictionary(mode);
+}
+
+function route_new_calc(dist, timeVal) {
+	return dictionary["route_is"] + " " + distance(dist) + " " + dictionary["time"] + " " + time(timeVal) + (tts ? ". " : "");
+}
+
+function distance(dist) {
+	switch (metricConst) {
+		case "km-m":
+			if (dist < 17 ) {
+				return (tts ? Math.round(dist).toString() : ogg_dist(dist)) + " " + dictionary["meters"];
+			} else if (dist < 100) {
+				return (tts ? Math.round((dist/10.0)*10).toString() : ogg_dist((dist/10.0)*10)) + " " + dictionary["meters"];
+			} else if (dist < 1000) {
+				return (tts ? Math.round((2*dist/100.0)*50).toString() : ogg_dist((2*dist/100.0)*50)) + " " + dictionary["meters"];
+			} else if (dist < 1500) {
+				return dictionary["around_1_kilometer"];
+			} else if (dist < 10000) {
+				return dictionary["around"] + " " + (tts ? Math.round(dist/1000.0).toString() : ogg_dist(dist/1000.0)) + " " + dictionary["kilometers"];
+			} else {
+				return (tts ? Math.round(dist/1000.0).toString() : ogg_dist(dist/1000.0)) + " " + dictionary["kilometers"];
+			}
+			break;
+		case "mi-f":
+			if (dist < 160) {
+				return (tts ? Math.round((2*dist/100.0/0.3048)*50).toString() : ogg_dist((2*dist/100.0/0.3048)*5)) + " " + dictionary["feet"];
+			} else if (dist < 241) {
+				return dictionary["1_tenth_of_a_mile"];
+			} else if (dist < 1529) {
+				return tts ? Math.round(dist/161.0).toString() + " " + dictionary["tenths_of_a_mile"] : ogg_dist(dist/161.0) + " tenths_of_a_mile.ogg";
+			} else if (dist < 2414) {
+				return dictionary["around_1_mile"];
+			} else if (dist < 16093) {
+				return dictionary["around"] + " " + (tts ? Math.round(dist/1609.3).toString() : ogg_dist(dist/1609.3)) + " " + dictionary["miles"];
+			} else {
+				return (tts ? Math.round(dist/1609.3).toString() : ogg_dist(dist/1609.3)) + " " + dictionary["miles"];
+			}
+			break;
+		case "mi-m":
+			if (dist < 17) {
+				return (tts ? Math.round(dist).toString() : ogg_dist(dist)) + " " + dictionary["meters"];
+			} else if (dist < 100) {
+				return (tts ? Math.round((dist/10.0)*10).toString() : ogg_dist((dist/10.0)*10)) + " " + dictionary["meters"];
+			} else if (dist < 1300) {
+				return (tts ? Math.round((2*dist/100.0)*50).toString() : ogg_dist((2*dist/100.0)*50)) + " " + dictionary["meters"];
+			} else if (dist < 2414) {
+				return dictionary["around_1_mile"];
+			} else if (dist < 16093) {
+				return dictionary["around"] + " " + (tts ? Math.round(dist/1609.3).toString() : ogg_dist(dist/1609.3)) + " " + dictionary["miles"];
+			} else {
+				return (tts ? Math.round(dist/1609.3).toString() : ogg_dist(dist/1609.3)) + " " + dictionary["miles"];
+			}
+			break;
+		case "mi/y":
+			if (dist < 17) {
+				return (tts ? Math.round(dist/0.9144).toString() : ogg_dist(dist/0.9144)) + " " + dictionary["yards"];
+			} else if (dist < 100) {
+				return (tts ? Math.round((dist/10.0/0.9144)*10).toString() : ogg_dist((dist/10.0/0.9144)*10)) + " " + dictionary["yards"];
+			} else if (dist < 1300) {
+				return (tts ? Math.round((2*dist/100.0/0.9144)*50).toString() : ogg_dist((2*dist/10.0/0.9144)*10)) + " " + dictionary["yards"]; 
+			} else if (dist < 2414) {
+				return tts ? dictionary["around_1_mile"] : "around_1_mile.ogg";
+			} else if (dist < 16093) {
+				return dictionary["around"] + " " + (tts ? Math.round(dist/1609.3).toString() : ogg_dist(dist/1609.3)) + " " + dictionary["miles"];
+			} else {
+				return (tts ? Math.round(dist/1609.3).toString() : ogg_dist(dist/1609.3)) + " " + dictionary["miles"];
+			}
+			break;
+	}
+}
+
+function time(seconds) {
+	var minutes = Math.round(seconds/60.0);
+	if (seconds < 30) {
+		return dictionary["less_a_minute"];
+	} else if (minutes % 60 == 0 && tts) {
+		return hours(minutes);
+	} else if (tts) {
+		return hours(minutes) + " " + (minutes % 60).toString() + " " + dictionary["minutes"];
+	} else if (!tts && minutes % 60 > 0 && minutes % 60 < 11) {
+		return hours(minutes) + " " + oggMinuteUnits(minutes);
+	} else if (!tts && minutes % 60 > 11 ) {
+        return hours(minutes) + " " + (Math.floor((minutes % 60)/10.0) * 10).toString() + ".ogg" + oggMinuteUnits(minutes % 60);
+    } else if (!tts && (minutes % 60) % 10 == 0) {
+		return hours(minutes) + " " + (Math.floor(minutes/10.0)).toString() + ".ogg" + dictionary["10_minutes"];
+	}
+    else if (!tts) {
+		return hours(minutes);
+	}
+}
+
+function oggMinuteUnits(minutes) {
+    if (minutes % 60 == 1) {
+		return dictionary["1_minute"];
+	} else if (minutes % 60 == 2) {
+		return dictionary["2_minutes"];
+	} else if (minutes % 60 == 3) {
+		return dictionary["3_minutes"];
+	} else if (minutes % 60 == 4) {
+		return dictionary["4_minutes"];
+	} else if (minutes % 60 == 5) {
+		return dictionary["5_minutes"];
+	} else if (minutes % 60 == 6) {
+		return dictionary["6_minutes"];
+	} else if (minutes % 60 == 7) {
+		return dictionary["7_minutes"];
+	} else if (minutes % 60 == 8) {
+		return dictionary["8_minutes"];
+	} else if (minutes % 60 == 9) {
+		return dictionary["9_minutes"];
+	} else if (minutes % 60 == 10) {
+		return dictionary["10_minutes"];
+    }
+}
+function hours(minutes) {
+	if (minutes < 60) {
+		return "";
+	} else {
+		var hours = minutes / 60;
+        return Math.floor(hours).toString() + (!tts ? ".ogg " : " ") + dictionary["hours"]; 
+	}
+}
+
+function route_recalc(dist, seconds) {
+	return dictionary["route_calculate"] + " " + dictionary["distance"] + " " + distance(dist) + " " + dictionary["time"] + " " + time(seconds) + ". ";
+}
+
+function go_ahead(dist, streetName) {
+	if (dist == -1) {
+		return dictionary["go_ahead"];
+	} else {
+		return dictionary["follow"] + " " + distance(dist) + " " + follow_street(streetName);
+	}
+	
+// go_ahead(Dist, Street) -- ["follow", D | Sgen] :- distance(Dist) -- D, follow_street(Street, Sgen).
+// follow_street("", []).
+// follow_street(voice(["","",""],_), []).
+// follow_street(voice(["", "", D], _), ["to", D]) :- tts.
+// follow_street(Street, ["on", SName]) :- tts, Street = voice([R, S, _],[R, S, _]), assemble_street_name(Street, SName).
+// follow_street(Street, ["on", SName]) :- tts, Street = voice([R, "", _],[R, _, _]), assemble_street_name(Street, SName).
+// follow_street(Street, ["to", SName]) :- tts, not(Street = voice([R, S, _],[R, S, _])), assemble_street_name(Street, SName).
+}
+
+function follow_street(streetName) {
+	if ((streetName["toDest"] === "" && streetName["toStreetName"] === "" && streetName["toRef"] === "") || Object.keys(streetName).length == 0 || !tts) {
+		return "";
+	} else if (streetName["toStreetName"] === "" && streetName["toRef"] === "") {
+		return dictionary["to"] + " " + streetName["toDest"];
+	} else if (streetName["toRef"] === streetName["fromRef"] && streetName["toStreetName"] === streetName["fromStreetName"] || 
+			(streetName["toRef"] == streetName["fromRef"] && streetName["toStreetName"] == "")) {
+		return dictionary["on"] + " " + assemble_street_name(streetName);
+	} else if (!(streetName["toRef"] === streetName["fromRef"] && streetName["toStreetName"] === streetName["fromStreetName"])) {
+		return dictionary["to"] + " " + assemble_street_name(streetName);
+	}
+}
+
+function turn(turnType, dist, streetName) {
+	if (dist == -1) {
+		return getTurnType(turnType) + " " + turn_street(streetName);
+	} else {
+		return distance(dist) + dictionary["in"] + + " " + getTurnType(turnType) + " " + turn_street(streetName); 
+	}
+	// turn(Turn, Dist, Street) -- ["in", D, M | Sgen] :- distance(Dist) -- D, turn(Turn, M), turn_street(Street, Sgen).
+// turn(Turn, Street) -- [M | Sgen] :- turn(Turn, M), turn_street(Street, Sgen).
+}
+
+function  getTurnType(turnType) {
+	// turn("left", ).
+// turn("left_sh", ["left_sh"]).
+// turn("left_sl", ["left_sl"]).
+// turn("right", ["right"]).
+// turn("right_sh", ["right_sh"]).
+// turn("right_sl", ["right_sl"]).
+// turn("left_keep", ["left_keep"]).
+// turn("right_keep", ["right_keep"]).
+// // Note: turn("left_keep"/"right_keep",[]) is a turn type aiding lane selection, while bear_left()/bear_right() is triggered as brief "turn-after-next" preparation sounding always after a "..., then...". In some languages turn(l/r_keep) may not differ from bear_l/r:
+	switch (turnType) {
+		case "left":
+			return dictionary["left"];
+			break;
+		case "left_sh":
+			return dictionary["left_sh"];
+			break;
+		case "left_sl":
+			return dictionary["left_sl"];
+			break;
+		case "right":
+			return dictionary["right"];
+			break;
+		case "right_sh":
+			return dictionary["right_sh"];
+			break;
+		case "right_sl":
+			return dictionary["right_sl"];
+			break;
+		case "left_keep":
+			return dictionary["left_keep"];
+			break;
+		case "right_keep":
+			return dictionary["right_keep"];
+			break;
+	}
+}
+
+function then() {
+	// then -- ["then"].
+	return dictionary["then"];
+}
+
+function roundabout(dist, angle, exit, streetName) {
+	// roundabout(Dist, _Angle, Exit, Street) -- ["in", D, "roundabout", "and", "take", E, "exit" | Sgen] :- distance(Dist) -- D, nth(Exit, E), turn_street(Street, Sgen).
+// roundabout(_Angle, Exit, Street) -- ["take", E, "exit" | Sgen] :- nth(Exit, E), turn_street(Street, Sgen).
+	if (dist == -1) {
+		return dictionary["take"] + " " + nth(exit) + " " + dictionary["exit"] + " " + turn_street(streetName);
+	} else {
+		return distance(dist) + dictionary["in"] +" " + dictionary["take"] + " " + nth(exit) + " " + dictionary["exit"] + " " + turn_street(streetName);
+	}
+
+}
+
+function turn_street(streetName) {
+	// turn_street("", []).
+// turn_street(voice(["","",""],_), []).
+// turn_street(voice(["", "", D], _), ["toward", D]) :- tts.
+// turn_street(Street, ["on", SName]) :- tts, Street = voice([R, S, _],[R, S, _]), assemble_street_name(Street, SName).
+// turn_street(Street, ["on", SName]) :- tts, Street = voice([R, "", _],[R, _, _]), assemble_street_name(Street, SName).
+// turn_street(Street, ["onto", SName]) :- tts, not(Street = voice([R, S, _],[R, S, _])), assemble_street_name(Street, SName).
+	if (Object.keys(streetName).length == 0 || (streetName["toDest"] === "" && streetName["toStreetName"] === "" && streetName["toRef"] === "") || !tts) {
+		return "";
+	} else if (streetName["toStreetName"] === "" && streetName["toRef"] === "") {
+		return streetName["toDest"] + dictionary["toward"];
+	} else if (streetName["toRef"] === streetName["fromRef"] && streetName["toStreetName"] === streetName["fromStreetName"]) {
+		return assemble_street_name(streetName) + dictionary["on"];
+	} else if ((streetName["toRef"] === streetName["fromRef"] && streetName["toStreetName"] === streetName["fromStreetName"]) 
+		|| (streetName["toStreetName"] === "" && streetName["toRef"] === streetName["fromRef"])) {
+		return assemble_street_name(streetName) + dictionary["on"];
+	} else if (!(streetName["toRef"] === streetName["fromRef"] && streetName["toStreetName"] === streetName["fromStreetName"])) {
+		return assemble_street_name(streetName) + dictionary["onto"];
+	}
+	return "";
+}
+
+function assemble_street_name(streetName) {
+	// // assemble_street_name(voice([Ref, Name, Dest], [_CurrentRef, _CurrentName, _CurrentDest]), _).
+// // assemble_street_name(voice(["", Name, _], _), Name). // not necessary
+// // Next 2 lines for Name taking precedence over Dest...
+// //assemble_street_name(voice([Ref, "", Dest], _), [C1, "toward", Dest]) :- atom_concat(Ref, " ", C1).
+// //assemble_street_name(voice([Ref, Name, _], _), Concat) :- atom_concat(Ref, " ", C1), atom_concat(C1, Name, Concat).
+// // ...or next 3 lines for Dest taking precedence over Name
+// assemble_street_name(voice([Ref, Name, ""], _), Concat) :- atom_concat(Ref, " ", C1), atom_concat(C1, Name, Concat).
+// assemble_street_name(voice(["", Name, Dest], _), [C1, "toward", Dest]) :- atom_concat(Name, " ", C1).
+// assemble_street_name(voice([Ref, _, Dest], _), [C1, "toward", Dest]) :- atom_concat(Ref, " ", C1).
+	if (streetName["toDest"] === "") {
+		return streetName["toRef"] + " " + streetName["toStreetName"];
+	} else if (streetName["toRef"] === "") {
+		return streetName["toStreetName"] + " " + streetName["toDest"] + dictionary["toward"];
+	} else if (streetName["toRef"] != "") {
+		return streetName["toRef"] + " " + streetName["toDest"] + dictionary["toward"];
+	}
+}
+
+function nth(exit) {
+	switch (exit) {
+		case (1):
+			return dictionary["1st"];
+		case (2):
+			return dictionary["2nd"];
+		case (3):
+			return dictionary["3rd"];
+		case (4):
+			return dictionary["4th"];
+		case (5):
+			return dictionary["5th"];
+		case (6):
+			return dictionary["6th"];
+		case (7):
+			return dictionary["7th"];
+		case (8):
+			return dictionary["8th"];
+		case (9):
+			return dictionary["9th"];
+		case (10):
+			return dictionary["10th"];
+		case (11):
+			return dictionary["11th"];
+		case (12):
+			return dictionary["12th"];
+		case (13):
+			return dictionary["13th"];
+		case (14):
+			return dictionary["14th"];
+		case (15):
+			return dictionary["15th"];
+		case (16):
+			return dictionary["16th"];
+		case (17):
+			return dictionary["17th"];
+	}
+}
+
+function make_ut(dist, streetName) {
+	// make_ut(Dist, Street) --  ["in", D, "make_uturn" | Sgen] :- distance(Dist) -- D, turn_street(Street, Sgen).
+// make_ut(Street) -- ["make_uturn" | Sgen] :- turn_street(Street, Sgen).
+	if (dist == -1) {
+		return dictionary["make_uturn"] + " " + turn_street(streetName);
+	} else {
+		return distance(dist) + dictionary["in"] + " " + dictionary["make_uturn"] + " " + turn_street(streetName);
+	}
+}
+
+// bear_left(_Street) -- ["left_bear"].
+// bear_right(_Street) -- ["right_bear"].
+function bear_left(streetName) {
+	return dictionary["left_bear"];
+}
+
+function bear_right(streetName) {
+	return dictionary["right_bear"];
+}
+
+function prepare_make_ut(dist, streetName) {
+	// prepare_make_ut(Dist, Street) -- ["after", D, "make_uturn" | Sgen] :- distance(Dist) -- D, turn_street(Street, Sgen).
+	return distance(dist) + dictionary["after"] + " " + dictionary["make_uturn"] + " " + turn_street(streetName);
+}
+
+function prepare_turn(turnType, dist, streetName) {
+	// prepare_turn(Turn, Dist, Street) -- ["after", D, M | Sgen] :- distance(Dist) -- D, turn(Turn, M), turn_street(Street, Sgen).
+	return distance(dist) + dictionary["after"] + " " + getTurnType(turnType) + " " + turn_street(streetName);
+}
+
+function prepare_roundabout(dist, exit, streetName) {
+// prepare_roundabout(Dist, _Exit, _Street) -- ["after", D , "prepare_roundabout"] :- distance(Dist) -- D.
+	return distance(dist) dictionary["after"] + " " + dictionary["prepare_roundabout"]; 
+}
+
+// reached_destination(D) -- ["reached_destination"|Ds] :- name(D, Ds).
+
+// reached_intermediate(D) -- ["reached_intermediate"|Ds] :- name(D, Ds).
+
+// and_arrive_waypoint(D) -- ["and_arrive_waypoint"|Ds] :- name(D, Ds).
+// reached_waypoint(D) -- ["reached_waypoint"|Ds] :- name(D, Ds).
+// and_arrive_favorite(D) -- ["and_arrive_favorite"|Ds] :- name(D, Ds).
+// reached_favorite(D) -- ["reached_favorite"|Ds] :- name(D, Ds).
+// and_arrive_poi(D) -- ["and_arrive_poi"|Ds] :- name(D, Ds).
+// reached_poi(D) -- ["reached_poi"|Ds] :- name(D, Ds).
+
+// location_lost -- ["location_lost"].
+// location_recovered -- ["location_recovered"].
+// off_route(Dist) -- ["off_route", D] :- distance(Dist) -- D.
+// back_on_route -- ["back_on_route"].
+function and_arrive_destination(dest) {
+	return dictionary["and_arrive_destination"] + " " + dest;
+}
+
+function and_arrive_intermediate(dest) {
+	// and_arrive_intermediate(D) -- ["and_arrive_intermediate"|Ds] :- name(D, Ds).
+	return dictionary["and_arrive_intermediate"] + " " + dest;
+}
+
+function and_arrive_waypoint(dest) {
+	return dictionary["and_arrive_waypoint"] + " " + dest;
+}
+
+function and_arrive_favorite(dest) {
+	return dictionary["and_arrive_favorite"] + " " + dest;
+}
+
+function and_arrive_poi(dest) {
+	return dictionary["and_arrive_poi"] + " " + dest;
+}
+
+function reached_destination(dest) {
+	return dictionary["reached_destination"] + " " + dest;
+}
+
+function reached_waypoint(dest) {
+	return dictionary["reached_waypoint"] + " " + dest;
+}
+
+function reached_intermediate(dest) {
+	return dictionary["reached_intermediate"] + " " + dest;
+}
+
+function reached_favorite(dest) {
+	return dictionary["reached_favorite"] + " " + dest;
+}
+
+function reached_poi(dest) {
+	return dictionary["reached_poi"] + " " + dest;
+}
+
+function location_lost() {
+	return dictionary["location_lost"];
+}
+
+function location_recovered() {
+	return dictionary["location_recovered"];
+}
+
+function off_route(dist) {
+	return dictionary["off_route"] + " " + distance(dist);
+}
+
+function back_on_route() {
+	return dictionary["back_on_route"];
+}
+
+function make_ut_wp() {
+	// make_ut_wp -- ["make_uturn_wp"].
+	return dictionary["make_ut_wp"];
+}
+
+
+// name(D, [D]) :- tts.
+// name(_D, []) :- not(tts).
+
+// // TRAFFIC WARNINGS
+function speed_alarm(maxSpeed, speed) {
+	return dictionary["exceed_limit"] + " " + maxSpeed.toString();
+}
+
+function attention(type) {
+	return dictionary["attention"] + " " + getAttentionString(type);
+}
+
+function getAttentionString(type) {
+	switch (type) {
+		case "SPEED_CAMERA":
+			return dictionary["speed_camera"];
+			break;
+		case "SPEED_LIMIT":
+			return "";
+			break
+		case "BORDER_CONTROL":
+			return dictionary["border_control"];
+			break;
+		case "RAILWAY":
+			return dictionary["railroad_crossing"];
+			break;
+		case "TRAFFIC_CALMING":
+			return dictionary["traffic_calming"];
+			break;
+		case "TOLL_BOOTH":
+			return dictionary["toll_booth"];
+			break;
+		case "STOP":
+			return dictionary["stop"];
+			break;
+		case "PEDESTRIAN":
+			return dictionary["pedestrian_crosswalk"];
+			break;
+		case "MAXIMUM":
+			return "";
+			break;
+		case "TUNNEL":
+			return dictionary["tunnel"];
+			break;
+		default:
+			return "";
+			break;
+	}
+}
+// speed_alarm(MaxSpeed, _Speed) -- ["exceed_limit", I] :- pnumber(MaxSpeed, I).
+// attention(Type) -- ["attention", W] :- warning(Type, W).
+// warning("SPEED_CAMERA", "speed_camera").
+// warning("SPEED_LIMIT", "").
+// warning("BORDER_CONTROL", "border_control").
+// warning("RAILWAY", "railroad_crossing").
+// warning("TRAFFIC_CALMING", "traffic_calming").
+// warning("TOLL_BOOTH", "toll_booth").
+// warning("STOP", "stop").
+// warning("PEDESTRIAN", "pedestrian_crosswalk").
+// warning("MAXIMUM", "").
+// warning("TUNNEL", "tunnel").
+// warning(Type, "") :- not(Type = "SPEED_CAMERA"; Type = "SPEED_LIMIT"; Type = "BORDER_CONTROL"; Type = "RAILWAY"; Type = "TRAFFIC_CALMING"; Type = "TOLL_BOOTH"; Type = "STOP"; Type = "PEDESTRIAN"; Type = "MAXIMUM"; Type = "TUNNEL").
+
+
+
+
+// //// command main method
+// //// if you are familar with Prolog you can input specific to the whole mechanism,
+// //// by adding exception cases.
+
+// flatten(X, Y) :- flatten(X, [], Y), !.
+// flatten([], Acc, Acc).
+// flatten([X|Y], Acc, Res):- flatten(Y, Acc, R), flatten(X, R, Res).
+// flatten(X, Acc, [X|Acc]) :- version(J), J < 100, !.
+// flatten(X, Acc, [Y|Acc]) :- string(X, Y), !.
+// flatten(X, Acc, [X|Acc]).
+
+// resolve(X, Y) :- resolve_impl(X,Z), flatten(Z, Y).
+// resolve_impl([],[]).
+// resolve_impl([X|Rest], List) :- resolve_impl(Rest, Tail), ("--"(X, L) -> append(L, Tail, List); List = Tail).
+
+
+// // handling alternatives
+// [X|_Y] -- T :- (X -- T),!.
+// [_X|Y] -- T :- (Y -- T).
+
+
+// pnumber(X, Y) :- tts, !, num_atom(X, Y).
+// pnumber(X, Ogg) :- num_atom(X, A), atom_concat(A, "", Ogg).
+// // time measure
+
+
+// ////// distance measure
+// distance(Dist) -- D :- measure("km-m"), distance_km(Dist) -- D.
+// distance(Dist) -- D :- measure("mi-f"), distance_mi_f(Dist) -- D.
+// distance(Dist) -- D :- measure("mi-y"), distance_mi_y(Dist) -- D.
+// distance(Dist) -- D :- measure("mi-m"), distance_mi_m(Dist) -- D.
+
+// ////// distance measure km/m
+
+
+// ////// distance measure mi/f
+
+
+// ////// distance measure mi/y
+
+
+// ////// distance measure mi/m
+
+
+
+// interval(St, St, End, _Step) :- St =< End.
+// interval(T, St, End, Step) :- interval(Init, St, End, Step), T is Init + Step, (T =< End -> true; !, fail).
+
+// interval(X, St, End) :- interval(X, St, End, 1).
+
+// // string(Ogg, A) :- voice_generation, interval(X, 1, 19), atom_number(A, X), atom_concat(A, "", Ogg).
+// // string(Ogg, A) :- voice_generation, interval(X, 20, 95, 5), atom_number(A, X), atom_concat(A, "", Ogg).
+// // string(Ogg, A) :- voice_generation, interval(X, 100, 140, 10), atom_number(A, X), atom_concat(A, "", Ogg).
+// // string(Ogg, A) :- voice_generation, interval(X, 150, 950, 50), atom_number(A, X), atom_concat(A, "", Ogg).
+// // string(Ogg, A) :- voice_generation, interval(X, 1000, 9000, 1000), atom_number(A, X), atom_concat(A, "", Ogg).
+
+// // // dist(X, Y) :- tts, !, num_atom(X, Y).
+
+function ogg_dist(distance) {
+	if (distance == 0) {
+		return "";
+	} else if (distance < 20) {
+		return Math.floor(distance).toString() + ".ogg ";
+	} else if (distance < 1000 && (distance % 50) == 0) {
+		return (distance % 50).toString() + ".ogg ";
+	} else if (distance < 30) {
+		return "20.ogg " + ogg_dist(distance - 20);
+	} else if (distance < 40) {
+		return "30.ogg " + ogg_dist(distance - 30);
+	} else if (distance < 50) {
+		return "40.ogg " + ogg_dist(distance - 40);
+	} else if (distance < 60) {
+		return "50.ogg " + ogg_dist(distance - 50);
+	} else if (distance < 70) {
+		return "60.ogg " + ogg_dist(distance - 60);
+	} else if (distance < 80) {
+		return "70.ogg "+ ogg_dist(distance - 70);
+	} else if (distance < 90) {
+		return "80.ogg " + ogg_dist(distance - 80);
+	} else if (distance < 100) {
+		return "90.ogg " + ogg_dist(distance - 90);
+	} else if (distance < 200) {
+		return "100.ogg " + ogg_dist(distance - 100);
+	} else if (distance < 300) {
+		return "200.ogg " + ogg_dist(distance - 200);
+	} else if (distance < 400) {
+		return "300.ogg "+ ogg_dist(distance - 300);
+	} else if (distance < 500) {
+		return "400.ogg " + ogg_dist(distance - 400);
+	} else if (distance < 600) {
+		return "500.ogg " + ogg_dist(distance - 500);
+	} else if (distance < 700) {
+		return "600.ogg " + ogg_dist(distance - 600);
+	} else if (distance < 800) {
+		return "700.ogg " + ogg_dist(distance - 700);
+	} else if (distance < 900) {
+		return "800.ogg " + ogg_dist(distance - 800);
+	} else if (distance < 1000) {
+		return "900.ogg " + ogg_dist(distance - 900);
+	} else {
+		return ogg_dist(distance/1000) + "1000.ogg " + ogg_dist(distance % 1000);
+	}
+}
+
+// // // dist(0, []) :- !.
+// // // dist(X, [Ogg]) :- X < 20, !, pnumber(X, Ogg).
+// // // dist(X, [Ogg]) :- X < 1000, 0 is X mod 50, !, num_atom(X, A), atom_concat(A, "", Ogg).
+// // // dist(D, ["20"|L]) :-  D < 30, Ts is D - 20, !, dist(Ts, L).
+// // // dist(D, ["30"|L]) :-  D < 40, Ts is D - 30, !, dist(Ts, L).
+// // // dist(D, ["40"|L]) :-  D < 50, Ts is D - 40, !, dist(Ts, L).
+// // // dist(D, ["50"|L]) :-  D < 60, Ts is D - 50, !, dist(Ts, L).
+// // // dist(D, ["60"|L]) :-  D < 70, Ts is D - 60, !, dist(Ts, L).
+// // // dist(D, ["70"|L]) :-  D < 80, Ts is D - 70, !, dist(Ts, L).
+// // // dist(D, ["80"|L]) :-  D < 90, Ts is D - 80, !, dist(Ts, L).
+// // // dist(D, ["90"|L]) :-  D < 100, Ts is D - 90, !, dist(Ts, L).
+// // // dist(D, ["100"|L]) :-  D < 200, Ts is D - 100, !, dist(Ts, L).
+// // // dist(D, ["200"|L]) :-  D < 300, Ts is D - 200, !, dist(Ts, L).
+// // // dist(D, ["300"|L]) :-  D < 400, Ts is D - 300, !, dist(Ts, L).
+// // // dist(D, ["400"|L]) :-  D < 500, Ts is D - 400, !, dist(Ts, L).
+// // // dist(D, ["500"|L]) :-  D < 600, Ts is D - 500, !, dist(Ts, L).
+// // // dist(D, ["600"|L]) :-  D < 700, Ts is D - 600, !, dist(Ts, L).
+// // // dist(D, ["700"|L]) :-  D < 800, Ts is D - 700, !, dist(Ts, L).
+// // // dist(D, ["800"|L]) :-  D < 900, Ts is D - 800, !, dist(Ts, L).
+// // // dist(D, ["900"|L]) :-  D < 1000, Ts is D - 900, !, dist(Ts, L).
+// // // dist(D, ["1000"|L]):- Ts is D - 1000, !, dist(Ts, L).

--- a/voice/ja/ja_tts.js
+++ b/voice/ja/ja_tts.js
@@ -178,7 +178,7 @@ function distance(dist) {
 			} else if (dist < 241) {
 				return dictionary["1_tenth_of_a_mile"];
 			} else if (dist < 1529) {
-				return tts ? Math.round(dist/161.0).toString() + " " + dictionary["tenths_of_a_mile"] : ogg_dist(dist/161.0) + " tenths_of_a_mile.ogg";
+				return (tts ? Math.round(dist/161.0).toString() : ogg_dist((2*dist/100.0/0.3048)*5)) + " " + dictionary["tenths_of_a_mile"];
 			} else if (dist < 2414) {
 				return dictionary["around_1_mile"];
 			} else if (dist < 16093) {

--- a/voice/ja/ttsconfig.p
+++ b/voice/ja/ttsconfig.p
@@ -31,51 +31,49 @@ string('time.ogg', '時間は、').
 
 % LEFT/RIGHT
 %string('prepare.ogg', 'Prepare to ').
-string('after.ogg', 'の後、').
-string('in.ogg', 'で ').
+string('after.ogg', '先、').
+string('in.ogg', '先、').
 
-string('left.ogg', '左に曲ってください。').
-string('left_sh.ogg', '大きく左手前に曲ってください。').
-string('left_sl.ogg', '斜め左に曲ってください。').
-string('right.ogg', '右に曲ってください。').
-string('right_sh.ogg', '大きく右手前に曲ってください。').
-string('right_sl.ogg', '斜め右に曲ってください。').
-string('left_keep.ogg', '左に寄ってください。').
-string('right_keep.ogg', '右に寄ってください。').
-string('left_bear.ogg', '左に寄ってください。').   % in English the same as left_keep, may be different in other languages
-string('right_bear.ogg', '右に寄ってください。').  % in English the same as right_keep, may be different in other languages
+string('left.ogg', '左方向です。').
+string('left_sh.ogg', '手前左方向です。').
+string('left_sl.ogg', '斜め左方向です。').
+string('right.ogg', '右方向です。').
+string('right_sh.ogg', '手前右方向です。').
+string('right_sl.ogg', '斜め右方向です。').
+string('left_keep.ogg', '分岐を左方向です。').
+string('right_keep.ogg', '分岐を右方向です。').
+string('left_bear.ogg', '左方向です。').   % in English the same as left_keep, may be different in other languages
+string('right_bear.ogg', '右方向です。').  % in English the same as right_keep, may be different in other languages
 
 % U-TURNS
 string('make_uturn.ogg', 'Uターンをしてください。').
 string('make_uturn_wp.ogg', '可能ならUターンをしてください。').
 
 % ROUNDABOUTS
-string('prepare_roundabout.ogg', 'ラウンドアバウトがあります。').
-string('roundabout.ogg', 'ロータリーがあります。').
-string('then.ogg', ' そして、').
+string('prepare_roundabout.ogg', 'ロータリーがあります。').
+%string('roundabout.ogg', 'ロータリーがあります。').
+string('then.ogg', 'その先、').
 %string('and.ogg', 'and ').
 string('take.ogg', 'ロータリーの').
-string('exit.ogg', 'の出口を出てください。').
+string('exit.ogg', 'の出口です。').
 
-string('1.ogg', '1').
-string('2.ogg', '2').
-string('3.ogg', '3').
-string('4.ogg', '4').
-string('5.ogg', '5').
-string('6.ogg', '6').
-string('7.ogg', '7').
-string('8.ogg', '8').
-string('9.ogg', '9').
-string('10.ogg', '10').
-string('11.ogg', '11').
-string('12.ogg', '12').
-string('13.ogg', '13').
-string('14.ogg', '14').
-string('15.ogg', '15').
-string('16.ogg', '16').
-string('17.ogg', '17').
-
-string('th.ogg', '番目').
+string('1st.ogg', '1番目').
+string('2nd.ogg', '2番目').
+string('3rd.ogg', '3番目').
+string('4th.ogg', '4番目').
+string('5th.ogg', '5番目').
+string('6th.ogg', '6番目').
+string('7th.ogg', '7番目').
+string('8th.ogg', '8番目').
+string('9th.ogg', '9番目').
+string('10th.ogg', '10番目').
+string('11th.ogg', '11番目').
+string('12th.ogg', '12番目').
+string('13th.ogg', '13番目').
+string('14th.ogg', '14番目').
+string('15th.ogg', '15番目').
+string('16th.ogg', '16番目').
+string('17th.ogg', '17番目').
 
 % STRAIGHT/FOLLOW
 string('go_ahead.ogg', '直進してください。').
@@ -98,9 +96,9 @@ string('reached_poi.ogg', 'you are passing POI ').
 % ATTENTION
 %string('exceed_limit.ogg', 'スピードオーバーです。').
 string('exceed_limit.ogg', '制限速度 ').
-string('attention.ogg', '注意が必要です。').
+string('attention.ogg', 'ご注意下さい。').
 string('speed_camera.ogg', 'スピードカメラ ').
-string('border_control.ogg', '国境警備隊 ').
+string('border_control.ogg', '税関 ').
 string('railroad_crossing.ogg', '踏切 ').
 string('traffic_calming.ogg', '交通静穏化 ').
 string('toll_booth.ogg', '料金所 ').
@@ -109,22 +107,22 @@ string('pedestrian_crosswalk.ogg', '横断歩道 ').
 string('tunnel.ogg', 'トンネル').
 
 % OTHER PROMPTS
-string('location_lost.ogg', 'GPS信号が受信できません。').
+string('location_lost.ogg', 'GPS信号を失いました。').
 string('location_recovered.ogg', 'GPS信号が回復しました。').
 string('off_route.ogg', 'ルートから外れました。').
 string('back_on_route.ogg', 'ルートに復帰しました。').
 
 % STREET NAME PREPOSITIONS
 string('onto.ogg', 'に、').
-string('on.ogg', 'に ').
-string('to.ogg', 'まで、').
-string('toward.ogg', '向かって ').
+string('on.ogg', 'に、').
+string('to.ogg', '方面、').
+string('toward.ogg', '方面、').
 
 % DISTANCE UNIT SUPPORT
-string('meters.ogg', 'メートル、').
-string('around_1_kilometer.ogg', 'およそ、1キロ、').
+string('meters.ogg', 'メートル').
+string('around_1_kilometer.ogg', 'およそ 1キロ').
 string('around.ogg', 'およそ、').
-string('kilometers.ogg', 'キロ、').
+string('kilometers.ogg', 'キロ').
 
 string('feet.ogg', 'フィート').
 string('1_tenth_of_a_mile.ogg', 'one tenth of a mile').
@@ -183,22 +181,22 @@ assemble_street_name(voice([Ref, _, Dest], _), [C1, 'toward.ogg', Dest]) :- atom
 turn_street('', []).
 turn_street(voice(['','',''],_), []).
 turn_street(voice(['', '', D], _), ['toward.ogg', D]) :- tts.
-turn_street(Street, ['on.ogg', SName]) :- tts, Street = voice([R, S, _],[R, S, _]), assemble_street_name(Street, SName).
-turn_street(Street, ['on.ogg', SName]) :- tts, Street = voice([R, '', _],[R, _, _]), assemble_street_name(Street, SName).
-turn_street(Street, ['onto.ogg', SName]) :- tts, not(Street = voice([R, S, _],[R, S, _])), assemble_street_name(Street, SName).
+turn_street(Street, [SName, 'on.ogg']) :- tts, Street = voice([R, S, _],[R, S, _]), assemble_street_name(Street, SName).
+turn_street(Street, [SName, 'on.ogg']) :- tts, Street = voice([R, '', _],[R, _, _]), assemble_street_name(Street, SName).
+turn_street(Street, [SName, 'onto.ogg']) :- tts, not(Street = voice([R, S, _],[R, S, _])), assemble_street_name(Street, SName).
 turn_street(_Street, []) :- not(tts).
 
 follow_street('', []).
 follow_street(voice(['','',''],_), []).
 follow_street(voice(['', '', D], _), ['to.ogg', D]) :- tts.
-follow_street(Street, ['on.ogg', SName]) :- tts, Street = voice([R, S, _],[R, S, _]), assemble_street_name(Street, SName).
-follow_street(Street, ['on.ogg', SName]) :- tts, Street = voice([R, '', _],[R, _, _]), assemble_street_name(Street, SName).
-follow_street(Street, ['to.ogg', SName]) :- tts, not(Street = voice([R, S, _],[R, S, _])), assemble_street_name(Street, SName).
+follow_street(Street, [SName, 'on.ogg']) :- tts, Street = voice([R, S, _],[R, S, _]), assemble_street_name(Street, SName).
+follow_street(Street, [SName, 'on.ogg']) :- tts, Street = voice([R, '', _],[R, _, _]), assemble_street_name(Street, SName).
+follow_street(Street, [SName, 'to.ogg']) :- tts, not(Street = voice([R, S, _],[R, S, _])), assemble_street_name(Street, SName).
 follow_street(_Street, []) :- not(tts).
 
-prepare_turn(Turn, Dist, Street) -- [D, 'after.ogg', M | Sgen] :- distance(Dist) -- D, turn(Turn, M), turn_street(Street, Sgen).
-turn(Turn, Dist, Street) -- [D, 'in.ogg', M | Sgen] :- distance(Dist) -- D, turn(Turn, M), turn_street(Street, Sgen).
-turn(Turn, Street) -- [M | Sgen] :- turn(Turn, M), turn_street(Street, Sgen).
+prepare_turn(Turn, Dist, Street) -- [D, 'after.ogg', M | Sgen] :- distance(Dist) -- D, turn_street(Street, Sgen), turn(Turn, M). 
+turn(Turn, Dist, Street) -- [D, 'in.ogg', M | Sgen] :- distance(Dist) -- D, turn_street(Street, Sgen), turn(Turn, M).
+turn(Turn, Street) -- [M | Sgen] :- turn_street(Street, Sgen), turn(Turn, M).
 
 prepare_make_ut(Dist, Street) -- [D, 'after.ogg', 'make_uturn.ogg' | Sgen] :- distance(Dist) -- D, turn_street(Street, Sgen).
 make_ut(Dist, Street) --  [D, 'in.ogg', 'make_uturn.ogg' | Sgen] :- distance(Dist) -- D, turn_street(Street, Sgen).
@@ -206,7 +204,7 @@ make_ut(Street) -- ['make_uturn.ogg' | Sgen] :- turn_street(Street, Sgen).
 make_ut_wp -- ['make_uturn_wp.ogg'].
 
 prepare_roundabout(Dist, _Exit, _Street) -- [D, 'after.ogg', 'prepare_roundabout.ogg'] :- distance(Dist) -- D.
-roundabout(Dist, _Angle, Exit, Street) -- [D, 'in.ogg', 'roundabout.ogg', 'take.ogg', E, 'exit.ogg' | Sgen] :- distance(Dist) -- D, nth(Exit, E), turn_street(Street, Sgen).
+roundabout(Dist, _Angle, Exit, Street) -- [D, 'in.ogg', 'take.ogg', E, 'exit.ogg' | Sgen] :- distance(Dist) -- D, nth(Exit, E), turn_street(Street, Sgen).
 roundabout(_Angle, Exit, Street) -- ['take.ogg', E, 'exit.ogg' | Sgen] :- nth(Exit, E), turn_street(Street, Sgen).
 
 go_ahead -- ['go_ahead.ogg'].


### PR DESCRIPTION
After using OsmAnd with the TTS voice in Japanese, I've noticed a few mistakes that I have now corrected in the ttsconfig.p file.

First of all, the prepositions "at", "in", "onto", "toward", etc. in Japanese go at the end of the word they're referring to. Previously the TTS placed them at the beginning of each word, which is ungrammatical.

Then, the 17 lines for each ordinal numbers (1st to 17th) had the ordinal (the 'st' in first, for example) detached from each number. This caused a situation in which English lines were used for the Japanese TTS, which in turn produced situations like "1st." being read as "いちストーンドット"　(1 stone dot). Using the previous detached ordinal, I was not able to get consistent behaviour from my device's TTS. This has been corrected by attaching 番目 (the 'th') to each number.

In turns and roundabouts, the instructions have been made significantly shorter and concise, following the example of most other navigation softwares with Japanese TTS, using e.g. 右方向 (みぎほうこう） to signal a right turn instead of the previous sentences (e.g. 右に曲がって下さい).

There is some initial work done for TTS routing in JavaScript, which is loosely based on the English JS file and incorporates all of the previously mentioned corrections.