### PR TITLE
WiP: Rendering highway=turning_circle and highway=turning_loop

### DIFF
--- a/icons/svg/transport/turning_loop.svg
+++ b/icons/svg/transport/turning_loop.svg
@@ -1,0 +1,204 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.0"
+   width="580"
+   height="580"
+   id="svg2"
+   sodipodi:version="0.32"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="turning_loop.svg"
+   inkscape:output_extension="org.inkscape.output.svg.inkscape">
+  <metadata
+     id="metadata10">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <cc:license
+           rdf:resource="http://web.resource.org/cc/PublicDomain" />
+        <dc:language>en</dc:language>
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     inkscape:window-height="1026"
+     inkscape:window-width="1920"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     guidetolerance="10.0"
+     gridtolerance="10.0"
+     objecttolerance="10.0"
+     borderopacity="1.0"
+     bordercolor="#666666"
+     pagecolor="#ffffff"
+     id="base"
+     showgrid="false"
+     inkscape:zoom="0.70710678"
+     inkscape:cx="858.3925"
+     inkscape:cy="108.2779"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:current-layer="svg2"
+     inkscape:window-maximized="1" />
+  <defs
+     id="defs4">
+    <clipPath
+       id="clipoutline2"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         d="M 55.8,12 L 56.56,12.16 C 65.4,9.22 85.24,20.8 80.82,31.12 C 79.7,32.74 79.89,35.62 81.24,37.43 L 56.43,62.25 C 55.04,60.86 51.95,60.89 50.53,62.25 L 9.5,101.63 C 5.76,105.22 8.7,108.27 10.28,109.88 L 17.64,117.24 C 19.25,118.84 23.5,121 26.52,117.8 L 65.24,76.99 C 66.59,75.57 66.6,72.52 65.24,71.12 C 65.24,71.12 65.25,71.1 65.24,71.1 L 90.15,46.2 C 92.78,48.57 95.263827,48.774854 97.62,48.13 C 102.17057,46.884568 104.70725,51.336643 107.43,54.59 L 106.2,55.8 C 104.38,57.64 104.55,60.74 106.59,62.78 C 108.63,64.82 111.74,64.99 113.56,63.17 L 121.7,55.04 C 123.52,53.2 123.35,50.1 121.3,48.07 C 119.46,46.22 116.79,45.98 114.93,47.3 C 109.35,41.04 112.28,40.1 104.92,31.95 L 91.13,17.86 C 81.2,8.12 68.3,8.13 55.8,12 z"
+         id="outline2" />
+    </clipPath>
+    <clipPath
+       id="clipoutline1"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         d="M 22.42,17.2 L 35.38,30.15 L 32.88,38.93 L 24.1,41.43 L 11.14,28.47 L 5.28,34.33 L 20.17,55.79 L 37.73,52.45 L 99.36,118.07 C 108.8,127.58 121.53,113.32 112.7,105.2 L 46.85,42.92 L 50.86,25.16 L 28.72,10.89 L 22.42,17.2 z M 103.48,109.17 C 105.16,107.49 107.88,107.49 109.56,109.17 C 111.24,110.85 111.24,113.57 109.56,115.25 C 107.88,116.92 105.16,116.92 103.48,115.25 C 101.8,113.57 101.8,110.85 103.48,109.17 z"
+         id="outline1" />
+    </clipPath>
+    <inkscape:perspective
+       sodipodi:type="inkscape:persp3d"
+       inkscape:vp_x="0 : 290 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_z="580 : 290 : 1"
+       inkscape:persp3d-origin="290 : 193.33333 : 1"
+       id="perspective12" />
+    <style
+       type="text/css"
+       id="style6">
+   
+    .fil0 {fill:#EF7900}
+   
+  </style>
+    <inkscape:perspective
+       id="perspective6807"
+       inkscape:persp3d-origin="29.116032 : 19.410688 : 1"
+       inkscape:vp_z="58.232063 : 29.116032 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 29.116032 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       id="perspective6954"
+       inkscape:persp3d-origin="290 : 193.33333 : 1"
+       inkscape:vp_z="580 : 290 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 290 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <marker
+       viewBox="0 0 10 10"
+       refY="5"
+       refX="10"
+       orient="auto"
+       markerWidth="4"
+       markerUnits="strokeWidth"
+       markerHeight="3"
+       id="ArrowStart">
+      <path
+         id="path2295"
+         d="M 10 0 L 0 5 L 10 10 z" />
+    </marker>
+    <marker
+       viewBox="0 0 10 10"
+       refY="5"
+       refX="0"
+       orient="auto"
+       markerWidth="4"
+       markerUnits="strokeWidth"
+       markerHeight="3"
+       id="ArrowEnd">
+      <path
+         id="path2292"
+         d="M 0 0 L 10 5 L 0 10 z" />
+    </marker>
+    <inkscape:perspective
+       id="perspective7597"
+       inkscape:persp3d-origin="178.5405 : 158.483 : 1"
+       inkscape:vp_z="357.08099 : 237.7245 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 237.7245 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <defs
+       id="defs9">
+      <inkscape:perspective
+         inkscape:vp_z="744.09448 : 526.18109 : 1"
+         sodipodi:type="inkscape:persp3d"
+         inkscape:vp_x="0 : 526.18109 : 1"
+         inkscape:vp_y="0 : 1000 : 0"
+         inkscape:persp3d-origin="372.04724 : 350.78739 : 1"
+         id="perspective10" />
+    </defs>
+    <sodipodi:namedview
+       inkscape:document-units="px"
+       inkscape:cx="-81.428571"
+       showgrid="false"
+       inkscape:zoom="0.35"
+       borderopacity="1.0"
+       pagecolor="#ffffff"
+       inkscape:cy="520"
+       bordercolor="#666666"
+       inkscape:pageshadow="2"
+       inkscape:window-height="1110"
+       inkscape:pageopacity="0.0"
+       inkscape:window-y="-4"
+       inkscape:window-width="1600"
+       inkscape:current-layer="layer1"
+       inkscape:window-x="-4"
+       id="base-9" />
+  </defs>
+  <g
+     id="g1327"
+     transform="translate(0.5,-0.5)">
+    <path
+       d="M 66.275,1.768 C 24.94,1.768 1.704,23.139 1.704,66.804 l 0,450.123 c 0,40.844 20.894,62.229 62.192,62.229 l 452.024,0 c 41.307,0 62.229,-20.316 62.229,-62.229 l 0,-450.123 c 0,-42.601 -20.922,-65.036 -63.522,-65.036 -0.003,0 -448.494,-0.143 -448.352,0 z"
+       style="fill:#111111;stroke:#eeeeee;stroke-width:3.40799999"
+       id="path1329"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     id="g2319"
+     transform="translate(879.29125,36.805119)">
+    <path
+       id="path2323"
+       style="fill:#ffffff;stroke:none"
+       d="" />
+  </g>
+  <g
+     id="g2325"
+     transform="translate(879.29125,36.805119)">
+    <path
+       id="path2329"
+       style="fill:#ffffff;stroke:none"
+       d="" />
+  </g>
+  <path
+     style="fill:#ffffff"
+     d="m 284.35414,248.16016 -3.1095,33.59179 19.9658,0 -3.1095,-33.59179 z m -6.219,75.31054 -3.1095,53.75 32.4038,0 -3.1095,-53.75 z m -6.219,99.46875 -3.1095,55.75 44.8418,0 -3.1095,-55.75 z"
+     id="polygon15"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="ccccccccccccccc" />
+  <path
+     sodipodi:nodetypes="scssscsccscscczcsssscccsccscccs"
+     d="m 550.858,185.7595 c 0,-14.442 -7.83,-28.016 -23.271,-40.345 -13.518,-10.793 -32.607,-20.398 -56.738,-28.547 -48.445,-16.36 -112.672,-25.37 -180.849,-25.37 -68.176,0 -132.402,9.01 -180.847,25.37 -24.131,8.149 -43.221,17.753 -56.74,28.547 -15.441,12.329 -23.271,25.902 -23.271,40.345 0,14.081 7.898,34.967 45.525,54.51 23.525,12.219 45.03943,22.188 84.53861,29.102 L 72.372,472.5075 c -2.550707,5.96705 13.49,12.749 19.457,15.15 1.425,0.573 2.896,0.845 4.343,0.845 4.613,0 8.98,-2.76 10.807,-7.302 l 85.916,-213.527 c 2.401,-5.967 6.15262,-16.81416 2.53994,-18.82975 -3.61268,-2.01559 -2.59647,-1.85453 -7.22118,-2.85732 -35.17327,-6.0091 -64.89042,-14.98318 -86.24741,-26.07549 -20.810373,-10.80856 -32.27104,-23.07504 -32.27104,-34.53935 0,-32.53389 90.4766,-68.78492 220.30474,-68.78492 129.82904,0 220.30564,36.25103 220.30564,68.78492 0,11.21146 -11.01501,23.24421 -31.01774,33.87995 -20.65394,10.98318 -49.56618,19.96909 -83.8827,26.10006 -2.58414,0.52832 -0.56575,0.40414 -2.55773,0.74254 -2.44451,0.10869 -3.83209,3.33527 -3.63434,5.28297 0.61808,6.08776 4.70281,14.08225 5.86582,17.80037 l 85.313,212.02302 c 1.828,4.542 6.193,7.302 10.807,7.302 1.447,0 2.92,-0.271 4.344,-0.845 5.967,-2.401 22.00677,-9.185 19.457,-15.15 l -87.39775,-204.444 c 87.6251,-16.389 123.25575,-46.666 123.25575,-82.304 z"
+     id="path21"
+     inkscape:connector-curvature="0"
+     style="fill:#ffffff" />
+  <ellipse
+     style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.80000001;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     id="path4168"
+     cx="291.75"
+     cy="179.25"
+     rx="58.75"
+     ry="11.25" />
+</svg>

--- a/obf_creation/rendering_types.xml
+++ b/obf_creation/rendering_types.xml
@@ -1700,6 +1700,7 @@
 		<type tag="highway" value="bus_stop" minzoom="14"/>
 		<entity_convert pattern="tag_transform" from_tag="highway" from_value="bus_stop" if_tag1="public_transport" if_value1="platform"/> <!-- Remove highway=bus_stop (obsolete tag) if used with p_t=platform -->
 		<type tag="highway" value="turning_circle" minzoom="16"/>
+		<type tag="highway" value="turning_loop" minzoom="16"/>
 		<type tag="highway" value="emergency_access_point" minzoom="16"/>
 		<type tag="highway" value="speed_camera" minzoom="15"/>
 		<type tag="highway" value="milestone" nameTags="distance" minzoom="15"/>

--- a/rendering_styles/default.render.xml
+++ b/rendering_styles/default.render.xml
@@ -7296,6 +7296,14 @@
 					<apply_if nightMode="true" shield=""/>
 					<apply_if moreDetailed="false" maxzoom="15" icon=""/>
 				</case>
+				<case minzoom="16" tag="highway" value="turning_circle" icon="highway_turning_circle" shield="highway_turning_circle_shield">
+					<apply_if nightMode="true" shield=""/>
+					<apply_if moreDetailed="false" maxzoom="16" icon=""/>
+				</case>
+				<case minzoom="16" tag="highway" value="turning_loop" icon="highway_turning_loop" shield="highway_turning_loop_shield">
+					<apply_if nightMode="true" shield=""/>
+					<apply_if moreDetailed="false" maxzoom="16" icon=""/>
+				</case>
 				<case minzoom="18" tag="noexit" value="yes" icon="highway_noexit" iconVisibleSize="12"/>
 				<switch minzoom="14">
 					<case tag="ford" value="yes"/>


### PR DESCRIPTION
Contrary to a highway=mini_roundabout, the turning_circle and turning_loop are not rendered in OsmAnd. See this issue for more details on this topic: osmandapp/Osmand/issues/6237

**This pull request is a work in progress**

Current status:
* [x] Updating the [obf export](https://github.com/osmandapp/OsmAnd-resources/compare/master...siduenho:patch-1#diff-9f147a86fcc6b9151b17cf840bf4a500) to include turning_loops in addition to the already exported turning_circles
* [x] Create or use an already existing icon for highway=turning_circle
  * the already existing (https://github.com/osmandapp/OsmAnd-resources/blob/master/icons/svg/transport/turning_circle.svg) can be used
* [x] Create or use an already existing icon for highway=turning_loop
  * Added a [new icon for the turning_loop](https://github.com/siduenho/OsmAnd-resources/blob/c06214f56fc7064fed104a0c908fe268e2362087/icons/svg/transport/turning_loop.svg)
* [ ] Updating the default renderer
  * [x] Created the blueprint in order to display the turning_circle and turning_loop
  * [ ] Update the blueprint to use the correct icon names and shield names
* [ ] Generate icons and shields for svgs of both icons
  * turning_circle seems to be there as a png already, but the files are called "turning_circle.png". Shouldn't this be "transport_turning_circle.png"?
  * [ ] The icons should have a meaningful color (a quick test with the already existing [turning_circle.png](https://github.com/siduenho/OsmAnd-resources/blob/master/rendering_styles/style-icons/drawable-hdpi/mm_turning_circle.png) shows, that this icon will be white inside OsmAnd. Maybe the blue used for the [mini_roundabout](https://github.com/osmandapp/OsmAnd-resources/blob/master/rendering_styles/style-icons/drawable-xxhdpi/mm_highway_mini_roundabout.png) is a good solution? 


Is there something else, I've missed?

**Please feel free to help me out. I don't know how to do the open tasks.**