### PR TITLE
Changed pedestrian crosswalk text on Dutch TTS

### DIFF
--- a/voice/nl/nl_tts.js
+++ b/voice/nl/nl_tts.js
@@ -101,7 +101,7 @@ function populateDictionary(tts) {
 	dictionary["toll_booth"] = tts ? "tol poort" : "toll_booth.ogg";
 	// de spatie is nodig voor een betere uitspraak
 	dictionary["stop"] = tts ? "stop teken" : "stop.ogg";
-	dictionary["pedestrian_crosswalk"] = tts ? "zebra" : "pedestrian_crosswalk.ogg";
+	dictionary["pedestrian_crosswalk"] = tts ? "zebra pad" : "pedestrian_crosswalk.ogg";
 	dictionary["tunnel"] = tts ? "tunnel" : "tunnel.ogg";
 	
 	// OTHER PROMPTS


### PR DESCRIPTION
At first when there was a pedestrian crosswalk OsmAnd would notify to watch out for a zebra.
As a pedestrian crosswalk is called "zebra pad" in Dutch I changed it to "zebra pad".
As I do not know how to change the pedestrian_crosswalk.ogg sound, this is still open to be changed.