### PR TITLE
Update routing.xml

### DIFF
--- a/routing/routing.xml
+++ b/routing/routing.xml
@@ -250,9 +250,10 @@
 
 		-60% and less => 35 seconds per height metre
 		[-17% till -60%) => 17 seconds per height metre
-		[-3% tomm -17%) => 1 seconds per height metre
+		[-3% till -17%) => 1 seconds per height metre
 		[3% till -3%) => 0 seconds per height metre
-		[3% till 17) => 1 seconds per height metre
+		[3% till 13%) => 8 seconds per height metre
+		[13% till 17) => 1 seconds per height metre
 		... etc
 
 	 A negative select value (seconds per height metre) means "impassable"
@@ -325,7 +326,8 @@
     ### Using numeric parameters in the routing engine   
 
 	 Numeric values can be used to compare to other values. For this, a `gt` (greater-then) tag is used.
-	 The `gt`-tag acts just like an if-test.
+	 The `gt`-tag acts just like an if-test. 
+	 It will also include the specified number: `<gt value1=":a" value2="3">` means `if parameter a is 3 or higher`
 
 	 For example, if the height of your car is set, you'll want to compare it with the `maxheight`-tag given to some ways. This is done with a `gt` tag:
 


### PR DESCRIPTION
there is an error in the description of the `gt` tag.
Also, since greater-than is actually implemented as greater-than-or-equals I would propose to rename the tag to `gte`. 
It is very confusing because currently it is mathematically incorrect.