### PR TITLE
Fix 3-4 hours in sk_tts.js

### DIFF
--- a/voice/sk/sk_tts.js
+++ b/voice/sk/sk_tts.js
@@ -281,7 +281,7 @@ function hours(minutes) {
 	} else if (minutes < 180) {
 		return dictionary["hours2"];
 	} else if (minutes < 300) {
-		return Math.floor(minutes/60).toString() + (!tts ? ".ogg " : " ") + dictionary["3_4_hours"];
+		return Math.floor(minutes/60).toString() + (!tts ? ".ogg " : " ") + dictionary["hours3_4"];
 	} else if (tts) {
 		return Math.floor(minutes/60).toString() + " " + dictionary["hours5"];
 	} else if (!tts && minutes < 21 * 60) {


### PR DESCRIPTION
It seems this typos slipped in at the conversion from prolog. The string is named "hours3_4".

Other than this, the conversion seems OK, and the file is working beautifully in OsmAnd 3.3. Thanks for doing the manual conversion for all languages!