### PR TITLE
Improvements in roundabouts

### DIFF
--- a/voice/es/es_tts.js
+++ b/voice/es/es_tts.js
@@ -43,7 +43,7 @@ function populateDictionary(tts) {
 	// ROUNDABOUTS
 	//dictionary["prepare_roundabout"] = tts ? "Prepárate para entrar en la rotonda después de" : "prepare_roundabout.ogg";
 	dictionary["prepare_roundabout"] = tts ? "entra en la rotonda" : "prepare_roundabout.ogg";
-	dictionary["roundabout"] = tts ? "entra en la rotonda" : "roundabout.ogg";
+	dictionary["roundabout"] = tts ? "en la rotonda" : "roundabout.ogg";
 	dictionary["then"] = tts ? ", luego" : "then.ogg";
 	dictionary["and"] = tts ? " y " : "and.ogg";
 	dictionary["take"] = tts ? "toma la " : "take.ogg";
@@ -331,7 +331,7 @@ function roundabout(dist, angle, exit, streetName) {
 	if (dist == -1) {
 		return dictionary["take"] + " " + nth(exit) + " " + dictionary["exit"] + " " + turn_street(streetName);
 	} else {
-		return dictionary["after"] + " " + distance(dist) + " " + dictionary["roundabout"] + " " + dictionary["and"] + " " + dictionary["take"] + " " + nth(exit) + " " + dictionary["exit"] + " " + turn_street(streetName);
+		return dictionary["after"] + " " + distance(dist) + " " + dictionary["roundabout"] + " " + " " + dictionary["take"] + " " + nth(exit) + " " + dictionary["exit"] + " " + turn_street(streetName);
 	}
 
 }


### PR DESCRIPTION
To make the instructions shorter when approaching a roundabout I propose to change "in 450 meters enter the roundabout and take the first exit" to "in 450 meters at the roundabout take the first exit". 
In other languages ​​I don't know if it's shorter or not, but at least in Spanish it's shorter and clearer and in English it's slightly shorter