### PR TITLE
Add barrier=sump_buster

### DIFF
--- a/routing/routing.xml
+++ b/routing/routing.xml
@@ -796,6 +796,7 @@
 			<select value="-1" t="barrier" v="turnstile"/>
 			<select value="-1" t="barrier" v="bus_trap"/>
 			<select value="-1" t="barrier" v="cycle_barrier"/>
+			<select value="-1" t="barrier" v="sump_buster"/>
 	  
 			<if param="short_way">
 				<select value="0" t="barrier" v="cattle_grid"/>


### PR DESCRIPTION
Currently cars are being routed over this: https://www.openstreetmap.org/node/412369141 That should not be possible.

OSM wiki: https://wiki.openstreetmap.org/wiki/Tag:barrier%3Dsump_buster

This is what they look like around my place: http://stavangerphotobytanty.blogspot.com/2008/07/sporsluse.html