### PR TITLE
Fix bug: ski routing does not take edges of decorative piste outline anymore

### DIFF
--- a/obf_creation/rendering_types.xml
+++ b/obf_creation/rendering_types.xml
@@ -5707,6 +5707,7 @@
 		<routing_type tag="aerialway" value="station" mode="register" base="true"/>
 
 
+		<entity_convert pattern="tag_transform" from_tag="area" from_value="yes" if_tag1="piste:type" to_tag1="access" to_value1="no"/>
 		<routing_type tag="piste:type" mode="register" base="true"/>
 		<routing_type tag="piste:difficulty" mode="amend" base="true"/>
 		<routing_type tag="piste:grooming" mode="amend" base="true"/>


### PR DESCRIPTION
When testing the ski routing, I noticed that ski routing would sometimes follow the outline of a ski piste - sometimes even going up onto the mountain...

![Faulty behaviour](https://user-images.githubusercontent.com/1466478/63381687-7b721f00-c399-11e9-90ba-9616b0493041.png)

This pull request adds a tag transform to add an "access=no" tag onto areas, resulting in this correct route planning:

![Correct behaviour](https://user-images.githubusercontent.com/1466478/63381742-96dd2a00-c399-11e9-878a-0b71702f8f2f.png)

Please merge at least one month before the skiing season begins ;p
