### PR TITLE
Fix for waterway order in LightRS style

### DIFF
--- a/rendering_styles/LightRS.render.xml
+++ b/rendering_styles/LightRS.render.xml
@@ -534,7 +534,7 @@
 			<case tag="railway" value="station"/>
 
 			<case layer="1" tag="waterway" value="" order="68"/>
-			<case tag="waterway" value="" order="9">
+			<case tag="waterway" value="" order="4">
 				<apply_if additional="tunnel=yes" order="-1"/>
 			</case>
 			<case tag="waterway" value="waterfall"/>


### PR DESCRIPTION
Default order for waterway is 9, and it more than bridge order and other