### PR TITLE
Fix for waterway and bridge orders in LightRS style

### DIFF
--- a/rendering_styles/LightRS.render.xml
+++ b/rendering_styles/LightRS.render.xml
@@ -464,7 +464,7 @@
 			<case tag="railway" value="station" order="5"/>
 			<case tag="public_transport" value="" order="5" ignorePolygonAsPointArea="true"/>
 			<case tag="barrier" value="city_wall"/>
-			<case tag="man_made" value="bridge"/>
+			<case tag="man_made" value="bridge" order="10"/>
 		</switch>
 		<switch objectType="3" cycle="true" point="false" addPoint="true" order="5">
 			<case tag="area:highway" value="primary"/>
@@ -534,7 +534,7 @@
 			<case tag="railway" value="station"/>
 
 			<case layer="1" tag="waterway" value="" order="68"/>
-			<case tag="waterway" value="" order="4">
+			<case tag="waterway" value="" order="9">
 				<apply_if additional="tunnel=yes" order="-1"/>
 			</case>
 			<case tag="waterway" value="waterfall"/>

--- a/rendering_styles/LightRS.render.xml
+++ b/rendering_styles/LightRS.render.xml
@@ -534,7 +534,7 @@
 			<case tag="railway" value="station"/>
 
 			<case layer="1" tag="waterway" value="" order="68"/>
-			<case tag="waterway" value="" order="9">
+			<case tag="waterway" value="" order="4">
 				<apply_if additional="tunnel=yes" order="-1"/>
 			</case>
 			<case tag="waterway" value="waterfall"/>


### PR DESCRIPTION
I made a mistake in the previous pull-request. And now I correct it. Revert order for waterway and add order="10" for bridge area without cycle="true"