### PR TITLE
Add support for camp_pitch

### DIFF
--- a/obf_creation/rendering_types.xml
+++ b/obf_creation/rendering_types.xml
@@ -4107,6 +4107,7 @@
 		<type tag="tourism" value="aquarium" minzoom="15" />
 		<type tag="tourism" value="cabin" minzoom="15" />
 		<entity_convert pattern="tag_transform" from_tag="tourism" from_value="hut" to_tag1="tourism" to_value1="cabin"/>
+		<type tag="tourism" value="camp_pitch" minzoom="12" order="80" />
 		<type tag="tourism" value="camp_site" minzoom="11" order="80" />
 		<entity_convert pattern="tag_transform" from_tag="tourism" from_value="camping" to_tag1="tourism" to_value1="camp_site"/>
 		<entity_convert pattern="tag_transform" from_tag="maxtents" to_tag1="capacity:tents"/>


### PR DESCRIPTION
This adds support for the newly approved camp_pitch tag, which is for individual camps within a camp_site. Currently camp_pitch is not included in the OBF file, so disappears from the map.