### PR TITLE
sidewalk=separate => sidewalk=no

### DIFF
--- a/obf_creation/rendering_types.xml
+++ b/obf_creation/rendering_types.xml
@@ -2100,6 +2100,7 @@
 		<entity_convert pattern="tag_transform" from_tag="sidewalk" from_value="right" to_tag1="sidewalk" to_value1="yes"/>
 		<type tag="sidewalk" value="no" minzoom="15" additional="true"/>
 		<entity_convert pattern="tag_transform" from_tag="sidewalk" from_value="none" to_tag1="sidewalk" to_value1="no"/>
+		<entity_convert pattern="tag_transform" from_tag="sidewalk" from_value="separate" to_tag1="sidewalk" to_value1="no"/>
 	</category>
 
 	<category name="surface">


### PR DESCRIPTION
`sidewalk=separate` is used if a highway does have a sidewalk, but it is mapped as a separate way. Osmand should treat this way as if it doesn't have a sidewalk. Only this way correct routing is possible (at least if the penalty for `sidewalk=no` is high enough).