### PR TITLE
Adjust trunk and trunk_link priority

### DIFF
--- a/routing/routing.xml
+++ b/routing/routing.xml
@@ -678,8 +678,8 @@
 			<select value="1.1" t="highway" v="motorway"/>
 			<!-- make links slightly smaller so in connections they will not be used -->
 			<select value="1.05" t="highway" v="motorway_link"/>
-			<select value="1" t="highway" v="trunk"/>
-			<select value="0.95" t="highway" v="trunk_link"/>
+			<select value="1.05" t="highway" v="trunk"/>
+			<select value="1.0" t="highway" v="trunk_link"/>
 			<!-- generally linking larger towns. -->
 			<select value="1.0" t="highway" v="primary"/>
 			<select value="0.95" t="highway" v="primary_link"/>


### PR DESCRIPTION
This fixes routing not using trunk_link roads at the intersections of trunk and primary roads.
The short trunk_link segments were being skipped even though they are shorter and the preferred route of travel.