### PR TITLE
Convert crossing=marked to uncontrolled

### DIFF
--- a/obf_creation/rendering_types.xml
+++ b/obf_creation/rendering_types.xml
@@ -1716,6 +1716,7 @@
 		<entity_convert pattern="tag_transform" from_tag="crossing" from_value="uncontrolled;island" to_tag1="crossing" to_value1="uncontrolled"/>
 		<entity_convert pattern="tag_transform" from_tag="crossing" from_value="uncontrolled; island" to_tag1="crossing" to_value1="uncontrolled"/>
 		<entity_convert pattern="tag_transform" from_tag="crossing" from_value="uncontrolled,zebra" to_tag1="crossing" to_value1="uncontrolled"/>
+		<entity_convert pattern="tag_transform" from_tag="crossing" from_value="marked" to_tag1="crossing" to_value1="uncontrolled"/>
 		<type tag="crossing" value="traffic_signals" minzoom="15" additional="true" />
 		<entity_convert pattern="tag_transform" from_tag="crossing" from_value="island;traffic_signals" to_tag1="crossing" to_value1="traffic_signals"/>
 		<entity_convert pattern="tag_transform" from_tag="crossing" from_value="controlled" to_tag1="crossing" to_value1="traffic_signals"/>


### PR DESCRIPTION
iD editor invented its own needless duplicate tag and is polluting the OSM database with it. Let's convert it to the proper value to recognize this type of crossing.