### PR TITLE
Added poi_pump_status_out_of_order and poi_pump_status_missing_beam

### DIFF
--- a/poi/phrases/en/phrases.xml
+++ b/poi/phrases/en/phrases.xml
@@ -3072,7 +3072,9 @@
 	<string name="poi_pump_style_historic">Pump style: historic</string>
 	<string name="poi_pump_status_ok">Pump status: ok</string>
 	<string name="poi_pump_status_broken">Pump status: broken</string>
+	<string name="poi_pump_status_out_of_order">Pump status: out of order</string>
 	<string name="poi_pump_status_locked">Pump status: locked</string>
+	<string name="poi_pump_status_missing_beam">Pump status: missing beam</string>
 
 	<string name="poi_payment_troika_yes">Troika</string>
 	<string name="poi_payment_troika_no">Troika card not accepted</string>


### PR DESCRIPTION
Added:
<string name="poi_pump_status_out_of_order">Pump status: out of order</string>
<string name="poi_pump_status_missing_beam">Pump status: missing beam</string>