### PR TITLE
Added poi_pump_status_out_of_order and poi_pump_status_missing_beam

### DIFF
--- a/poi/phrases/be/phrases.xml
+++ b/poi/phrases/be/phrases.xml
@@ -2664,7 +2664,9 @@
     <string name="poi_pump_style_historic">Стыль помпы: гістарычная</string>
     <string name="poi_pump_status_ok">Стан помпы: працуе</string>
     <string name="poi_pump_status_broken">Стан помпы: зламаная</string>
+    <string name="poi_pump_status_out_of_order">Стан помпы: не функцыянуе</string>
     <string name="poi_pump_status_locked">Стан помпы: замкнёная</string>
+    <string name="poi_pump_status_missing_beam">Стан помпы: адсутнічае рычаг</string>
     <string name="poi_payment_troika_yes">Тройка</string>
     <string name="poi_payment_troika_no">Карткі Тройка не прымаюцца</string>
     <string name="poi_telescope">Тэлескоп</string>


### PR DESCRIPTION
Added:
<string name="poi_pump_status_out_of_order">Стан помпы: не функцыянуе</string>
<string name="poi_pump_status_missing_beam">Стан помпы: адсутнічае рычаг</string>