### PR TITLE
Improving public transport

### DIFF
--- a/routing/routing.xml
+++ b/routing/routing.xml
@@ -2087,7 +2087,7 @@
 
 
 		<point attribute="obstacle">
-			<select value="30" t="time" v="stop"/>
+			<select value="60" t="time" v="stop"/>
 			<select value="150" t="time" v="change"/>
 			<select value="150" t="time" v="boarding"/>
 		</point>
@@ -2102,7 +2102,7 @@
 			<select value="0" t="route" v="subway">
 				<if param="avoid_subway"/>
 			</select>
-			<select value="60"  t="route" v="subway"/>
+			<select value="50"  t="route" v="subway"/>
 		
 			<select value="0" t="route" v="monorail">
 				<if param="avoid_subway"/>
@@ -2128,7 +2128,7 @@
 			<select value="0" t="route" v="bus">
 				<if param="avoid_bus"/>
 			</select>
-			<select value="30"  t="route" v="bus"/>
+			<select value="$maxspeed"  t="route" v="bus"/>
 
 			<select value="0" t="route" v="trolleybus">
 				<if param="avoid_bus"/>


### PR DESCRIPTION
I think changing these parameters will achieve better routing times in public transport.

Changing bus speed to "$maxspeed" https://github.com/osmandapp/Osmand/issues/6827 will be fixed. With "$maxspeed" route time on urban routes does not change as long as the proposed change of time per stop is maintained (60 seconds per stop).

Changing time per stop improves time routes. 60 seconds per stop is more accurate for buses, subways and trains.

Changing subway speed improves time routes in subways. Default  speed in Osmand is 60km/ for subways with 30 seconds per stop. 50 km/h and 60 seconds per stop give more accurate times.

