### PR TITLE
improved some translations

### DIFF
--- a/poi/phrases/de/phrases.xml
+++ b/poi/phrases/de/phrases.xml
@@ -886,7 +886,7 @@
     <string name="poi_recycling_paper">Papier</string>
     <string name="poi_recycling_clothes">Altkleider</string>
     <string name="poi_recycling_cans">Dosen</string>
-    <string name="poi_recycling_glass_bottles">Glasflaschen</string>
+    <string name="poi_recycling_glass_bottles">Glasflaschen, Konservengläser</string>
     <string name="poi_recycling_plastic">Plastik</string>
     <string name="poi_recycling_scrap_metal">Altmetall</string>
     <string name="poi_recycling_batteries">Batterien</string>
@@ -1333,7 +1333,7 @@
     <string name="poi_smoking_yes">Erlaubt</string>
     <string name="poi_smoking_separated">In einem separaten Raum</string>
     <string name="poi_traffic_signals_sound_yes">ja</string>
-    <string name="poi_traffic_signals_sound_no">nein</string>
+    <string name="poi_traffic_signals_sound_no">Signalton: nein</string>
     <string name="poi_rescue_station">Rettungsstation</string>
     <string name="poi_mini_roundabout">Mini-Kreisverkehr</string>
     <string name="poi_railway_crossing">Bahnübergang</string>
@@ -3801,11 +3801,11 @@
     <string name="poi_sms_no">nein</string>
     <string name="poi_video_yes">ja</string>
     <string name="poi_video_no">nein</string>
-    <string name="poi_traffic_signals_sound_locate">Nur wenn Gehen erlaubt ist</string>
+    <string name="poi_traffic_signals_sound_locate">Nur zum Auffinden</string>
     <string name="poi_tactile_paving_contrasted">Farblich abgestochen</string>
     <string name="poi_tactile_paving_incorrect">Irreführend</string>
-    <string name="poi_covered_booth">Unterstand</string>
-    <string name="poi_booth">Unterstandsart</string>
+    <string name="poi_covered_booth">Kabine</string>
+    <string name="poi_booth">Kabinentyp</string>
     <string name="poi_tactile_paving_primitive">Primitiv</string>
     <string name="poi_seamark_water_level_part_submerged">Wasserstand: teilweise überflutet</string>
     <string name="poi_seamark_water_level_submerged">Wasserstand: überflutet</string>


### PR DESCRIPTION
improved the translation of what "booth" means in german; furthermore, the meaning of "recycling:glass_bottles" goes a bit further. The translation of "traffic_signals_locate" was wrong, and in the translation of "traffic_signals_sound_no" there was missing a word for understanding it.