### PR TITLE
Correct German words: Strasse and Fusgänger

### DIFF
--- a/voice/de/de_tts.js
+++ b/voice/de/de_tts.js
@@ -70,7 +70,7 @@ function populateDictionary(tts) {
 	
 	// STRAIGHT/FOLLOW
 	dictionary["go_ahead"] = tts ? "Weiter geradeaus" : "go_ahead.ogg";
-	dictionary["follow1"] = tts ? "Dem Strassenverlauf" : "follow1.ogg";
+	dictionary["follow1"] = tts ? "Dem Straßenverlauf" : "follow1.ogg";
 	dictionary["follow2"] = tts ? "folgen" : "follow2.ogg";
 	
 	// ARRIVE
@@ -98,7 +98,7 @@ function populateDictionary(tts) {
 	dictionary["traffic_calming"] = tts ? "Verkehrsberuhigung" : "traffic_calming.ogg";
 	dictionary["toll_booth"] = tts ? "Mautstelle" : "toll_booth.ogg";
 	dictionary["stop"] = tts ? "Stoppschild" : "stop.ogg";
-	dictionary["pedestrian_crosswalk"] = tts ? "Fusgängerübergang" : "pedestrian_crosswalk.ogg";
+	dictionary["pedestrian_crosswalk"] = tts ? "Fußgängerübergang" : "pedestrian_crosswalk.ogg";
 	dictionary["tunnel"] = tts ? "Tunnel" : "tunnel.ogg";
 	
 	// OTHER PROMPTS


### PR DESCRIPTION
* Strasse is ok in Swiss German and in Liechtenstein, but nowhere else. [Straße](https://de.wiktionary.org/wiki/Stra%C3%9Fe) is the more common spelling.
* Fusgänger is a misspelling of [Fußgänger](https://de.wikipedia.org/wiki/Fu%C3%9Fg%C3%A4nger%C3%BCbergang).