### PR TITLE
traffic_signals:arrow=no was missing

### DIFF
--- a/poi/poi_types.xml
+++ b/poi/poi_types.xml
@@ -1126,6 +1126,7 @@
 	<poi_additional name="service_repair_no" tag="service:repair" value="no" no_edit="true"/>
 	<poi_additional name="traffic_signals_sound_no" tag="traffic_signals:sound" value="no"/>
 	<poi_additional name="traffic_signals_vibration_no" tag="traffic_signals:vibration" value="no"/>
+	<poi_additional name="traffic_signals_arrow_no" tag="traffic_signals:arrow" value="no"/>
 	<poi_additional name="pump_no" tag="pump" value="no"/>
 	<poi_additional name="button_operated_no" tag="button_operated" value="no"/>
 	<poi_additional name="handrail_no" tag="handrail" value="no"/>


### PR DESCRIPTION
OsmAnd recognises traffic_signals:vibration=yes/no and traffic_signals:arrow=yes, which is very useful, but "traffic_signals:arrow=no" was missing until now.