### PR TITLE
added departures_bord=* ( #9064 )

### DIFF
--- a/poi/poi_types.xml
+++ b/poi/poi_types.xml
@@ -1143,6 +1143,7 @@
 	<poi_additional name="scooter_no" tag="scooter" value="no"/>
 	<poi_additional name="truck_no" tag="truck" value="no"/>
 	<poi_additional name="brushless_no" tag="brushless" value="no"/>
+	<poi_additional name="departures_board_no" tag="departures_board" value="no"/>
 	<poi_additional name="passenger_information_display_no" tag="passenger_information_display" value="no"/>
 	<poi_additional name="generator_output_electricity_no" tag="generator_output_electricity" value="no"/>
 	<poi_additional name="dispensing_no" tag="dispensing" value="no"/>
@@ -1957,6 +1958,12 @@
 					</poi_additional_category>
 					<poi_additional_category name="bench">
 						<poi_additional name="bench_yes" tag="bench" value="yes"/>
+					</poi_additional_category>
+					<poi_additional_category name="departures_board">
+						<poi_additional name="departures_board_yes" tag="departures_board" value="yes"/>
+						<poi_additional name="departures_board_delay" tag="departures_board" value="delay"/>
+						<poi_additional name="departures_board_realtime" tag="departures_board" value="realtime"/>
+						<poi_additional name="departures_board_timetable" tag="departures_board" value="timetable"/>
 					</poi_additional_category>
 					<poi_additional name="passenger_information_display_yes" tag="passenger_information_display" value="yes"/>
 				</poi_type>


### PR DESCRIPTION
I added recognizing of the key departures_board, as it allows more filtering betweeen different kinds of departures boards at public transport locations. Its usage increases over 100.000 by now.