### PR TITLE
added recycling:small_electrical_appliances

### DIFF
--- a/poi/poi_types.xml
+++ b/poi/poi_types.xml
@@ -3790,6 +3790,7 @@
 					<poi_additional name="recycling_magazines" tag="recycling:magazines" value="yes"/>
 					<poi_additional name="recycling_paper_packaging" tag="recycling:paper_packaging" value="yes"/>
 					<poi_additional name="recycling_small_appliances" tag="recycling:small_appliances" value="yes"/>
+					<poi_additional name="recycling_small_electrical_appliances" tag="recycling:small_electrical_appliances" value="yes"/>
 					<poi_additional name="recycling_wood" tag="recycling:wood" value="yes"/>
 					<poi_additional name="recycling_books" tag="recycling:books" value="yes"/>
 					<poi_additional name="recycling_shoes" tag="recycling:shoes" value="yes"/>


### PR DESCRIPTION
recycling:small_electrical_applicances is documented in https://wiki.openstreetmap.org/wiki/Tag:amenity%3Drecycling and it's a bit more precise than just recycling:small_appliances. 

recycling:small_electrical_applicances gets more and more used when people want to add the information that there is the possibility to recycle these things.