### PR TITLE
New elements for a wheelchair routing

### DIFF
--- a/obf_creation/rendering_types.xml
+++ b/obf_creation/rendering_types.xml
@@ -5991,5 +5991,10 @@
 		<routing_type tag="osmand_ele_decline_7" mode="amend"/>
 		<routing_type tag="osmand_ele_decline_11" mode="amend"/>
 		<routing_type tag="traffic_signals:direction" mode="amend"/>
+		
+		<routing_type tag="kerb" mode="amend"/>
+		<routing_type tag="kerb:height" mode="amend" base="true" type="length"/>
+		<routing_type tag="obstacle:wheelchair" mode="amend"/>
+		<routing_type tag="incline" mode="amend"/>
 	</category>
 </osmand_types>


### PR DESCRIPTION
Add elements in the ".obf" file for the wheelchair routing, in particular the kerb nodes its height, the elements mapped as obstacles for wheelchair and the incline tag.