### PR TITLE
Add hierarchical evaluation of oneway roads

### DIFF
--- a/routing/routing.xml
+++ b/routing/routing.xml
@@ -531,6 +531,18 @@
 		</way>
 
 		<way attribute="oneway">
+			<select value="1" t="oneway:motorcar" v="yes"/>
+			<select value="0" t="oneway:motorcar" v="no"/>
+			<select value="-1" t="oneway:motorcar" v="-1"/>
+			
+			<select value="1" t="oneway:motor_vehicle" v="yes"/>
+			<select value="0" t="oneway:motor_vehicle" v="no"/>
+			<select value="-1" t="oneway:motor_vehicle" v="-1"/>
+
+			<select value="1" t="oneway:vehicle" v="yes"/>
+			<select value="0" t="oneway:vehicle" v="no"/>
+			<select value="-1" t="oneway:vehicle" v="-1"/>
+
 			<select value="1" t="oneway" v="yes"/>
 			<select value="1" t="oneway" v="1"/>
 			<select value="-1" t="oneway" v="-1"/>
@@ -1026,6 +1038,12 @@
 			<select value="0" t="cycleway" v="opposite"/>
 			<select value="0" t="oneway:bicycle" v="no"/>
 			<select value="1" t="oneway:bicycle" v="yes"/>
+			<select value="-1" t="oneway:bicycle" v="-1"/>
+			
+			<select value="1" t="oneway:vehicle" v="yes"/>
+			<select value="0" t="oneway:vehicle" v="no"/>
+			<select value="-1" t="oneway:vehicle" v="-1"/>
+
 			<select value="1" t="oneway" v="yes"/>
 			<select value="1" t="oneway" v="1"/>
 			<select value="-1" t="oneway" v="-1"/>


### PR DESCRIPTION
Also check oneway:vehicle, oneway:motor_vehicle values, e.g. for cases when a road would be marked oneway=no, oneway:motor_vehicle=yes, which currently wouldn't work in OsmAnd (would wrongly return 'road is both ways' in car mode). Also, there are cases that have no 'oneway', but e.g. oneway:motor_vehicle=yes only.