### PR TITLE
Penalty for traffic lights

### DIFF
--- a/routing/routing.xml
+++ b/routing/routing.xml
@@ -777,7 +777,7 @@
 			<select value="25" t="barrier" v="toll_booth"/>
 			<select value="25" t="barrier"/>
 			<select value="10" t="traffic_calming"/>
-			<select value="30" t="highway" v="traffic_signals"/>
+			<select value="10" t="highway" v="traffic_signals"/>
 			<select value="1"  t="crossing" v="unmarked"/>
 			<select value="5"  t="crossing" v="uncontrolled"/>
 			<select value="15" t="highway" v="crossing"/>


### PR DESCRIPTION
Changing delay for traffic signals to 10/15 seconds OsmAnd calculates more accurate times.

Related https://github.com/osmandapp/OsmAnd/issues/6539#issuecomment-810153187

I have calculated some city routes and compared with real time (driving with my car without traffic jams) and with other navigation softwares (real time and other navigation softwares are similar in time. Two examples:

From https://www.openstreetmap.org/#map=19/40.42446/-3.71176 to https://www.openstreetmap.org/#map=19/40.43502/-3.71932    1.3 km
Other softwares: 3 min
OsmAnd (30 seconds per traffic light): 10 min
OsmAnd (10 seconds per traffic light): 4 min

From https://www.openstreetmap.org/#map=19/40.41940/-3.69275 to https://www.openstreetmap.org/directions?from=40.41937%2C-3.69276&to=#map=18/40.47888/-3.68574   6,8 km
Other softwares: 12 min
OsmAnd (30 seconds per traffic light): 23 min
OsmAnd (10 seconds per traffic light): 17 min