### PR TITLE
Added share_taxi=yes

### DIFF
--- a/poi/poi_types.xml
+++ b/poi/poi_types.xml
@@ -2014,6 +2014,9 @@
 			</poi_filter>
 			<poi_filter name="public_transport" top="true">
 				<poi_type name="public_transport_platform" tag="public_transport" value="platform" excluded_poi_additional_category="payment_type,fee,shelter_type,tactile_paving,opening_hours">
+					<poi_additional_category name="share_taxi">
+						<poi_additional name="share_taxi_yes" tag="share_taxi" value="yes"/>
+					</poi_additional_category>
 					<poi_additional_category name="covered" icon="covered_yes">
 						<poi_additional name="covered_yes" tag="covered" value="yes"/>
 						<poi_additional name="covered_booth" tag="covered" value="booth"/>


### PR DESCRIPTION
The key share_taxi=yes is listed on https://wiki.openstreetmap.org/wiki/Key:psv and is in the wiki called "uncommon", beause it's not really a vehicle type, but it is used (actual over 22000 times) at public transport platforms to show that there stop shared taxis which are usually operated on demand. Because of the frequent usage, I added it so that people can see when this tag is used on a pt platform. That's also why it put it below the pt=platform category. It's not really a vehicle class, so it does not completely fit into the access category.