### PR TITLE
Added the keys manufacturer=* and model=*, and three keys which are u…

### DIFF
--- a/poi/poi_types.xml
+++ b/poi/poi_types.xml
@@ -90,6 +90,8 @@
 	<poi_additional name="operator_type_cooperative" tag="operator:type" value="cooperative"/>
 	<poi_additional name="owner" tag="owner" type="text" order="92"/>
 	<poi_additional name="brand" tag="brand" type="text" order="93"/>
+	<poi_additional name="manufacturer" tag="manufacturer" type="text"/>
+	<poi_additional name="model_type" tag="model" type="text"/>
 	<poi_additional name="vhf" tag="vhf" type="text"/>
 	<poi_additional_category name="fee" icon="fee_yes">
 		<poi_additional name="fee_yes" tag="fee" value="yes"/>
@@ -437,6 +439,8 @@
 	<poi_additional name="payment_yandexmoney_no" tag="payment:yandexmoney" value="no"/>
 	<poi_additional name="payment_troika_no" tag="payment:troika" value="no"/>
 	<poi_additional name="payment_contactless_no" tag="payment:contactless" value="no"/>
+	<poi_additional name="payment_calling_cards_no" tag="payment:calling_cards" value="no"/>
+	<poi_additional name="payment_reverse_charge_calls_no" tag="payment:reverse_charge_calls" value="no"/>
 	<poi_additional name="description_payment" tag="description:payment" type="text"/>
 
 	<poi_additional_category name="payment_type">
@@ -499,6 +503,8 @@
 		<poi_additional name="payment_yandexmoney_yes" tag="payment:yandexmoney" value="yes"/>
 		<poi_additional name="payment_troika_yes" tag="payment:troika" value="yes"/>
 		<poi_additional name="payment_contactless_yes" tag="payment:contactless" value="yes"/>
+		<poi_additional name="payment_calling_cards_yes" tag="payment:calling_cards" value="yes"/>
+		<poi_additional name="payment_reverse_charge_calls_yes" tag="payment:reverse_charge_calls" value="yes"/>
 	</poi_additional_category>
 
 	<poi_additional name="internet_access_fee_yes" tag="internet_access:fee" value="yes"/>
@@ -3984,6 +3990,10 @@
 				</poi_additional_category>
 			</poi_type>
 			<poi_type name="telephone" tag="amenity" value="telephone" excluded_poi_additional_category="payment_type,internet_access_type,wheelchair_accessibility,opening_hours">
+				<poi_additional_category name="callable">
+					<poi_additional name="callable_yes" tag="callable" value="yes"/>
+					<poi_additional name="callable_no" tag="callable" value="no"/>
+				</poi_additional_category>
 				<poi_additional_category name="sms">
 					<poi_additional name="sms_yes" tag="sms" value="yes"/>
 					<poi_additional name="sms_no" tag="sms" value="no"/>


### PR DESCRIPTION
…sed mainly for public telephones

Hi,
I added the until now missing keys "manufacturer" (is very often used, to show the manufacturer of an object) and the text-key "model".

Also, I added two payment methods which are documented and tagged on public telephones, and also the key "callable" which is used on public phones.