### PR TITLE
enable survey=ground based on source:geometry input

### DIFF
--- a/obf_creation/rendering_types.xml
+++ b/obf_creation/rendering_types.xml
@@ -82,6 +82,11 @@
 	<type tag="note_tag" value="yes" minzoom="12" notosm="true"/>
 	<type tag="depth" additional="text" minzoom="12"/>
 <!--	<entity_convert pattern="tag_transform" from_tag="comment" to_tag1="note"/>-->
+	
+	<type tag="survey" value="ground" minzoom="13" additional="true" notosm="true" />
+	<entity_convert pattern="tag_transform" from_tag="source:geometry" from_value="GPS" to_tag1="survey" to_value1="ground" apply_to="way" poi="false" />
+	<entity_convert pattern="tag_transform" from_tag="source:geometry" from_value="mapillary" to_tag1="survey" to_value1="ground" apply_to="way" poi="false" />
+	<entity_convert pattern="tag_transform" from_tag="source:geometry" from_value="survey" to_tag1="survey" to_value1="ground" apply_to="way" poi="false" />
 
 	<!-- additional -->
 	<type tag="oneway" value="yes" minzoom="15" additional="true" poi="false"/>


### PR DESCRIPTION
Alternative solution would be:

	<type tag="source:geometry" value="GPS" minzoom="13" additional="true" />
	<type tag="source:geometry" value="mapillary" minzoom="13" additional="true" />
	<type tag="source:geometry" value="survey" minzoom="13" additional="true" />

If country specific restriction preferred:

         if_region_name="$thailand"