### PR TITLE
enable survey=ground based on source after being removed from ignored…

### DIFF
--- a/obf_creation/rendering_types.xml
+++ b/obf_creation/rendering_types.xml
@@ -84,6 +84,9 @@
 <!--	<entity_convert pattern="tag_transform" from_tag="comment" to_tag1="note"/>-->
 	
 	<type tag="survey" value="ground" minzoom="13" additional="true" notosm="true" />
+	<entity_convert pattern="tag_transform" from_tag="source" from_value="GPS" to_tag1="survey" to_value1="ground" apply_to="way" poi="false" />
+	<entity_convert pattern="tag_transform" from_tag="source" from_value="mapillary" to_tag1="survey" to_value1="ground" apply_to="way" poi="false" />
+	<entity_convert pattern="tag_transform" from_tag="source" from_value="survey" to_tag1="survey" to_value1="ground" apply_to="way" poi="false" />
 	<entity_convert pattern="tag_transform" from_tag="source:geometry" from_value="GPS" to_tag1="survey" to_value1="ground" apply_to="way" poi="false" />
 	<entity_convert pattern="tag_transform" from_tag="source:geometry" from_value="mapillary" to_tag1="survey" to_value1="ground" apply_to="way" poi="false" />
 	<entity_convert pattern="tag_transform" from_tag="source:geometry" from_value="survey" to_tag1="survey" to_value1="ground" apply_to="way" poi="false" />


### PR DESCRIPTION
I have used so far `source:geometry` and `source:position` to detect a ground survey (survey=ground) however members of my local OSM community do not want to migrate existing e.g source=GPS tagging because it is commonly used in Garmin implementations.

After the source tag is removed from the ignore tag list during the OBF preparation process:
https://github.com/osmandapp/OsmAnd-tools/pull/429

These new rules for `source` should work fine and I will then submit a new PR to remove rules for `source:geometry` & `source:position`.