### PR TITLE
enable source multivalue keyword search to detect ground survey

### DIFF
--- a/obf_creation/rendering_types.xml
+++ b/obf_creation/rendering_types.xml
@@ -84,15 +84,15 @@
 <!--	<entity_convert pattern="tag_transform" from_tag="comment" to_tag1="note"/>-->
 	
 	<type tag="survey" value="ground" minzoom="13" additional="true" notosm="true" />
-	<entity_convert pattern="tag_transform" from_tag="source" from_value="GPS" to_tag1="survey" to_value1="ground" apply_to="way" poi="false" />
-	<entity_convert pattern="tag_transform" from_tag="source" from_value="mapillary" to_tag1="survey" to_value1="ground" apply_to="way" poi="false" />
-	<entity_convert pattern="tag_transform" from_tag="source" from_value="survey" to_tag1="survey" to_value1="ground" apply_to="way" poi="false" />
-	<entity_convert pattern="tag_transform" from_tag="source:geometry" from_value="GPS" to_tag1="survey" to_value1="ground" apply_to="way" poi="false" />
-	<entity_convert pattern="tag_transform" from_tag="source:geometry" from_value="mapillary" to_tag1="survey" to_value1="ground" apply_to="way" poi="false" />
-	<entity_convert pattern="tag_transform" from_tag="source:geometry" from_value="survey" to_tag1="survey" to_value1="ground" apply_to="way" poi="false" />
-	<entity_convert pattern="tag_transform" from_tag="source:position" from_value="GPS" to_tag1="survey" to_value1="ground" apply_to="way" poi="false" />
-	<entity_convert pattern="tag_transform" from_tag="source:position" from_value="mapillary" to_tag1="survey" to_value1="ground" apply_to="way" poi="false" />
-	<entity_convert pattern="tag_transform" from_tag="source:position" from_value="survey" to_tag1="survey" to_value1="ground" apply_to="way" poi="false" />
+	<entity_convert pattern="tag_transform" from_tag="source" if_contains_tag1="source" if_contains_value1="GPS" to_tag1="survey" to_value1="ground" apply_to="way" poi="false" />
+	<entity_convert pattern="tag_transform" from_tag="source" if_contains_tag1="source" if_contains_value1="mapillary" to_tag1="survey" to_value1="ground" apply_to="way" poi="false" />
+	<entity_convert pattern="tag_transform" from_tag="source" if_contains_tag1="source" if_contains_value1="survey" to_tag1="survey" to_value1="ground" apply_to="way" poi="false" />
+	<entity_convert pattern="tag_transform" from_tag="source:geometry" if_contains_tag1="source:geometry" if_contains_value1="GPS" to_tag1="survey" to_value1="ground" apply_to="way" poi="false" />
+	<entity_convert pattern="tag_transform" from_tag="source:geometry" if_contains_tag1="source:geometry" if_contains_value1="mapillary" to_tag1="survey" to_value1="ground" apply_to="way" poi="false" />
+	<entity_convert pattern="tag_transform" from_tag="source:geometry" if_contains_tag1="source:geometry" if_contains_value1="survey" to_tag1="survey" to_value1="ground" apply_to="way" poi="false" />
+	<entity_convert pattern="tag_transform" from_tag="source:position" if_contains_tag1="source:position" if_contains_value1="GPS" to_tag1="survey" to_value1="ground" apply_to="way" poi="false" />
+	<entity_convert pattern="tag_transform" from_tag="source:position" if_contains_tag1="source:position" if_contains_value1="mapillary" to_tag1="survey" to_value1="ground" apply_to="way" poi="false" />
+	<entity_convert pattern="tag_transform" from_tag="source:position" if_contains_tag1="source:position" if_contains_value1="survey" to_tag1="survey" to_value1="ground" apply_to="way" poi="false" />
 
 	<!-- additional -->
 	<type tag="oneway" value="yes" minzoom="15" additional="true" poi="false"/>


### PR DESCRIPTION
Currently, the custom OBF tag survey=ground is generated when the source tag equals strictly a specific keyword.
However, source tags are allowed to use multiple values separated by semi-column (and often do): https://wiki.openstreetmap.org/wiki/Key:source

This PR enables keyword search using if_contains_tag1/if_contains_value1 combination instead of strict from_value check.