### PR TITLE
Make the track dash style patterns more consistent with OSM Mapnik

### DIFF
--- a/rendering_styles/Touring-view_(more-contrast-and-details).render.xml
+++ b/rendering_styles/Touring-view_(more-contrast-and-details).render.xml
@@ -957,20 +957,20 @@
 						<filter minzoom="14" pathEffect_5="15_4.5"/>
 					</filter>
 					<filter additional="tracktype=grade3">
+						<filter minzoom="12" maxzoom="13" pathEffect_5="7_3"/>
+						<filter minzoom="14" pathEffect_5="10.5_4.5"/>
+					</filter>
+					<filter additional="tracktype=grade4">
 						<filter minzoom="12" maxzoom="13" pathEffect_5="5_3"/>
 						<filter minzoom="14" pathEffect_5="7.5_4.5"/>
 					</filter>
-					<filter additional="tracktype=grade4">
-						<filter minzoom="12" maxzoom="13" pathEffect_5="4_3_2_3"/>
-						<filter minzoom="14" pathEffect_5="6_4.5_3_4.5"/>
-					</filter>
 					<filter additional="tracktype=grade5">
-						<filter minzoom="12" maxzoom="13" pathEffect_5="2_3"/>
-						<filter minzoom="14" pathEffect_5="3_4.5"/>
+						<filter minzoom="12" maxzoom="13" pathEffect_5="2_4"/>
+						<filter minzoom="14" pathEffect_5="3_6"/>
 					</filter>
 					<filter>
-						<filter minzoom="12" maxzoom="13" pathEffect_5="4_2"/>
-						<filter minzoom="14" pathEffect_5="6_3"/>
+						<filter minzoom="12" maxzoom="13" pathEffect_5="4_3_2_3"/>
+						<filter minzoom="14" pathEffect_5="6_4.5_3_4.5"/>
 					</filter>
 					<groupFilter>
 						<filter baseAppMode="pedestrian">

--- a/rendering_styles/default.render.xml
+++ b/rendering_styles/default.render.xml
@@ -1105,7 +1105,7 @@
 	<renderingConstant name="trackWithSurfaceStrokeWidth" value="1:1"/>
 	<renderingConstant name="trackLowZoomStrokeWidth" value="0.7"/>
 	<renderingConstant name="trackLowZoomStrokeWidth2" value="1.1"/>
-	<renderingConstant name="trackPathEffect" value="7_2"/>
+	<renderingConstant name="trackPathEffect" value="4_3_2_3"/>
 	<renderingConstant name="trackBridgeWidth" value="4:2.5"/>
 	<renderingConstant name="trackBridgeInnerWidth" value="3:2"/>
 	<renderingConstant name="trackTunnelPathEffect" value="3_3"/>
@@ -10530,12 +10530,17 @@
 						<apply_if additional="ice_road=yes" minzoom="11" strokeWidth_4="2:2"/>
 						<apply color_4="$null" color_5="$trackColor" pathEffect_5="$trackPathEffect"/>
 						<apply>
-							<!-- Dash pattern: solid(100%), long-dashed(77%), short-dashed(63%), dash-dotted(50%), dotted(50%), dotted2(40%), short-dashed-narrow-spaced(66%) for not-specified -->
+							<!-- Dash pattern: grade1      = solid (100%)
+							                   grade2      = long-dashed (77%)
+									   grade3      = mid-dashed (70%)
+									   grade4      = short-dashed (57%)
+									   grade5      = dotted (33%)
+									   unspecified = mixed (66%) -->
 							<case additional="tracktype=grade1" pathEffect_5=""/>
 							<case additional="tracktype=grade2" pathEffect_5="10_3"/>
-							<case additional="tracktype=grade3" pathEffect_5="5_3"/>
-							<case additional="tracktype=grade4" pathEffect_5="4_3_2_3"/>
-							<case additional="tracktype=grade5" pathEffect_5="2_3"/>
+							<case additional="tracktype=grade3" pathEffect_5="7_3"/>
+							<case additional="tracktype=grade4" pathEffect_5="4_3"/>
+							<case additional="tracktype=grade5" pathEffect_5="2_4"/>
 							<apply_if maxzoom="13" pathEffect_5=""/>
 						</apply>
 					</case>

--- a/rendering_styles/topo.render.xml
+++ b/rendering_styles/topo.render.xml
@@ -509,7 +509,7 @@
 	<renderingConstant name="trackBridgeWidth" value="6:3.5"/>
 	<renderingConstant name="trackBridgeInnerWidth" value="4:3"/>
 	<renderingConstant name="trackTunnelPathEffect" value="3_3"/>
-	<renderingConstant name="trackPathEffect" value=""/>
+	<renderingConstant name="trackPathEffect" value="4_3_2_3"/>
 
 	<renderingAttribute name="trackPathHighwayOnewayArrowsColor">
 		<case nightMode="true" attrColorValue="#ffffff"/>
@@ -4907,12 +4907,17 @@
 							<apply_if minzoom="15" strokeWidth_4="2.6:2.6"/>
 							<apply color_4="$null" color_5="$trackColor" pathEffect_5="$trackPathEffect"/>
 							<apply_if surfaceIntegrity="false">
-								<!-- Dash pattern: solid(100%), long-dashed(77%), short-dashed(63%), dash-dotted(50%), dotted(50%), dotted2(40%), short-dashed-narrow-spaced(66%) for not-specified -->
-								<case additional="tracktype=grade1" pathEffect_5=""/>
+							  <!-- Dash pattern: grade1      = solid (100%)
+							                     grade2      = long-dashed (77%)
+									     grade3      = mid-dashed (70%)
+									     grade4      = short-dashed (57%)
+									     grade5      = dotted (33%)
+									     unspecified = mixed (66%) -->
+							        <case additional="tracktype=grade1" pathEffect_5=""/>
 								<case additional="tracktype=grade2" pathEffect_5="10_3"/>
-								<case additional="tracktype=grade3" pathEffect_5="5_3"/>
-								<case additional="tracktype=grade4" pathEffect_5="4_3_2_3"/>
-								<case additional="tracktype=grade5" pathEffect_5="2_3"/>
+								<case additional="tracktype=grade3" pathEffect_5="7_3"/>
+								<case additional="tracktype=grade4" pathEffect_5="4_3"/>
+								<case additional="tracktype=grade5" pathEffect_5="2_4"/>
 								<apply_if minzoom="12" maxzoom="13" pathEffect_5=""/>
 							</apply_if>
 							<apply_if surfaceIntegrity="true">


### PR DESCRIPTION
For the styles "default" (from which most others are derived), "topo"
and "touring".

Addresses https://github.com/osmandapp/OsmAnd/issues/12953

Rendering of same location as in #12953 with updated rendering files installed:

![osmand-new-Screenshot_20211007-194909_OsmAnd+](https://user-images.githubusercontent.com/10631760/137111489-01aa88dd-5db2-4130-a2d8-8eaeeadba80b.png)
