### PR TITLE
New tags, rendering and routing changes

### DIFF
--- a/obf_creation/rendering_types.xml
+++ b/obf_creation/rendering_types.xml
@@ -3107,6 +3107,7 @@
 		<type tag="railway" value="funicular" minzoom="13" />
 		<type tag="railway" value="halt" minzoom="12" order="10"/>
 		<type tag="railway" value="level_crossing" minzoom="15" />
+        <type tag="railway" value="tram_level_crossing" minzoom="15" />
 		<type tag="railway" value="light_rail" minzoom="11"/>
 		<type tag="railway" value="monorail" minzoom="13" />
 		<type tag="railway" value="narrow_gauge" minzoom="13" />
@@ -3120,6 +3121,8 @@
 		<type tag="public_transport" value="stop_area" minzoom="13" nameTags="name" relation="true"/>
 		<type tag="railway" value="subway_entrance" minzoom="13" order="1" nameTags="name" />
 		<type tag="with_exits" value="yes" minzoom="13" additional="true" poi="false" notosm="true"/> <!-- osmand internal tag -->
+        
+        <type tag="embedded_rails" value="tram" minzoom="15" />
 
 		<entity_convert pattern="tag_transform" from_tag="railway:preserved" from_value="yes" to_tag1="railway" to_value1="preserved"/>
 
@@ -3711,6 +3714,10 @@
 		<type tag="man_made" value="works" minzoom="15" />
 		<type tag="man_made" value="embankment" minzoom="15" />
 		<type tag="embankment" value="yes" minzoom="14" />
+        <type tag="cutting" value="yes" minzoom="14" />
+        <entity_convert pattern="tag_transform" from_tag="cutting" from_value="both" to_tag1="cutting" to_value1="yes"/>
+        <entity_convert pattern="tag_transform" from_tag="cutting" from_value="left" to_tag1="cutting" to_value1="yes"/>
+        <entity_convert pattern="tag_transform" from_tag="cutting" from_value="right" to_tag1="cutting" to_value1="yes"/>
 
 		<type tag="man_made" value="beacon" minzoom="15" />
 		<type tag="man_made" value="chimney" minzoom="15" />

--- a/rendering_styles/default.render.xml
+++ b/rendering_styles/default.render.xml
@@ -11770,6 +11770,7 @@
 			<case tag="man_made" value="dyke"/>
 			<case engine_v1="true" tag="man_made" value="embankment"/>
 			<case tag="embankment" value="yes"/>
+            <case tag="cutting" value="yes"/>
 			<apply_if minzoom="15" maxzoom="15" strokeWidth__1="7:7" pathEffect__1="1_11" />
 			<apply_if minzoom="16" maxzoom="16" strokeWidth__1="11:11" pathEffect__1="1_16"/>
 			<apply_if minzoom="17" maxzoom="17" strokeWidth__1="13:13" pathEffect__1="1_21"/>

--- a/routing/routing.xml
+++ b/routing/routing.xml
@@ -1530,6 +1530,7 @@
 			<select value="200" t="ford"/>
 			<select value="25" t="railway" v="crossing"/>
 			<select value="25" t="railway" v="level_crossing"/>
+            <select value="5" t="railway" v="tram_level_crossing"/>
 		</point>
 
 		<point attribute="obstacle">


### PR DESCRIPTION
1. Adding to obf tag "cutting" for rendering as well as some tags which can be useful for routing
2. Add render style for "cutting" tag (the same style as for "embankment"="yes")
3. Add new tag for tram rails and highway crossing ("tram_level_crossing") as an obstacle for bikes