### PR TITLE
junction=circular can have oneway=no

### DIFF
--- a/obf_creation/rendering_types.xml
+++ b/obf_creation/rendering_types.xml
@@ -1755,7 +1755,7 @@
 		<type tag="highway" value="motorway_junction" minzoom="13" />
 		<type tag="junction" value="yes" minzoom="13"/>
 		<entity_convert pattern="tag_transform" from_tag="junction" from_value="circular" to_tag1="junction" to_value1="roundabout" map="no" poi="no"/>
-		<entity_convert pattern="tag_transform" from_tag="junction" from_value="roundabout" to_tag1="oneway" to_value1="yes" poi="no" routing="no"/>
+		<entity_convert pattern="tag_transform" from_tag="junction" from_value="roundabout" to_tag1="oneway" to_value1="yes" if_not_tag1="oneway" poi="no" routing="no"/>
 
 		<type tag="highway" value="bus_stop" minzoom="14"/>
 		<entity_convert pattern="tag_transform" from_tag="highway" from_value="bus_stop" if_tag1="public_transport" if_value1="platform"/> <!-- Remove highway=bus_stop (obsolete tag) if used with p_t=platform -->


### PR DESCRIPTION
Since `junction=circular` is first turned into `junction=roundabout`, do not convert roundabouts to `oneway=yes` if it's explicitly tagged `oneway=no`. (The other case, a `junction=roundabout` with `oneway=no` would make no sense)

This may fix issue https://github.com/osmandapp/OsmAnd/issues/13497 (at least partially; I don't know how the voice navigation will be)