### PR TITLE
enable noexit=yes at lower level (14)

### DIFF
--- a/obf_creation/rendering_types.xml
+++ b/obf_creation/rendering_types.xml
@@ -1741,7 +1741,7 @@
 		<entity_convert pattern="tag_transform" from_tag="parking_space" from_value="disabled" if_not_tag1="amenity" if_not_value1="parking_space" to_tag1="disabled" to_value1="yes" to_tag2="amenity" to_value2="parking_space"/>
 		<entity_convert pattern="tag_transform" from_tag="wheelchair" from_value="yes" if_tag1="amenity" if_value1="parking_space" to_tag1="disabled" to_value1="yes"/>
 
-		<type tag="noexit" value="yes" minzoom="16"/>
+		<type tag="noexit" value="yes" minzoom="14"/>
 		<type tag="highway" value="motorway_junction" minzoom="13" />
 		<type tag="junction" value="yes" minzoom="13"/>
 		<entity_convert pattern="tag_transform" from_tag="junction" from_value="circular" to_tag1="junction" to_value1="roundabout" map="no" poi="no"/>


### PR DESCRIPTION
Identifying dead-end at a lower zoom level (14 instead of 16) would be very useful for ground survey planning.