### PR TITLE
OBF only: enable noexit=yes at lower level (14) 

### DIFF
--- a/obf_creation/rendering_types.xml
+++ b/obf_creation/rendering_types.xml
@@ -1741,7 +1741,7 @@
 		<entity_convert pattern="tag_transform" from_tag="parking_space" from_value="disabled" if_not_tag1="amenity" if_not_value1="parking_space" to_tag1="disabled" to_value1="yes" to_tag2="amenity" to_value2="parking_space"/>
 		<entity_convert pattern="tag_transform" from_tag="wheelchair" from_value="yes" if_tag1="amenity" if_value1="parking_space" to_tag1="disabled" to_value1="yes"/>
 
-		<type tag="noexit" value="yes" minzoom="16"/>
+		<type tag="noexit" value="yes" minzoom="14"/>
 		<type tag="highway" value="motorway_junction" minzoom="13" />
 		<type tag="junction" value="yes" minzoom="13"/>
 		<entity_convert pattern="tag_transform" from_tag="junction" from_value="circular" to_tag1="junction" to_value1="roundabout" map="no" poi="no"/>


### PR DESCRIPTION
**Important:** 

- This pull request only affects the OBF generation process by including `noexit=yes` starting at zoom level 14 instead of 16.
- It will not affect any built-in map styles, because those concerned only render `noexit=yes` at zoom level 16 and 18.

**Goal:** 

Identifying dead-end at a lower zoom level in this custom ground survey plugin:
https://github.com/cmoffroad/osmand-offroad-survey-plugin

**Estimated Size increase: + 0.9%**

Based on local tests done with Germany Bayern and Berlin states.