### PR TITLE
Bidirectional navigation on junction=circular with oneway=no

### DIFF
--- a/routing/routing.xml
+++ b/routing/routing.xml
@@ -1067,6 +1067,8 @@
 			<select value="1" t="oneway" v="yes"/>
 			<select value="1" t="oneway" v="1"/>
 			<select value="-1" t="oneway" v="-1"/>
+            <!-- Following line because junction=circular is converted to roundabout, but is not necessarily oneway=yes -->
+            <select value="0" t="oneway" v="no"/>
 			<select value="1" t="roundabout" v="yes"/>
 			<select value="1" t="junction" v="roundabout"/>
 		</way>
@@ -2027,6 +2029,8 @@
 			<select value="1" t="oneway" v="yes"/>
 			<select value="1" t="oneway" v="1"/>
 			<select value="-1" t="oneway" v="-1"/>
+            <!-- Following line because junction=circular is converted to roundabout, but is not necessarily oneway=yes -->
+            <select value="0" t="oneway" v="no"/>
 			<select value="1" t="roundabout" v="yes"/>
 			<select value="1" t="junction" v="roundabout"/>
 		</way>


### PR DESCRIPTION
See https://github.com/osmandapp/OsmAnd/issues/13497

This solves only the first part of the issue by allowing navigation over such road segments, counter-clockwise.
Navigation instructions are still to be done (and too complicated for me)

Assumed it to be extremely unlikely for cars to encounter such situations, hence didn't implement it for those