### PR TITLE
Put service roads below links

### DIFF
--- a/rendering_styles/default.render.xml
+++ b/rendering_styles/default.render.xml
@@ -3472,12 +3472,12 @@
 						<apply_if layer="-1" order="62" orderByDensity="84"/>
 						<apply_if additional="layer=-2" order="41" orderByDensity="84"/>
 					</case>
-					<case tag="highway" value="motorway_link" order="71">
-						<apply_if layer="1" order="94"/>
-						<apply_if additional="layer=2" order="124"/>
-						<apply_if additional="layer=3" order="152"/>
-						<apply_if layer="-1" order="49" orderByDensity="71"/>
-						<apply_if additional="layer=-2" order="25" orderByDensity="71"/>
+					<case tag="highway" value="motorway_link" order="72">
+						<apply_if layer="1" order="95"/>
+						<apply_if additional="layer=2" order="125"/>
+						<apply_if additional="layer=3" order="153"/>
+						<apply_if layer="-1" order="50" orderByDensity="72"/>
+						<apply_if additional="layer=-2" order="26" orderByDensity="72"/>
 					</case>
 					<case tag="highway" value="trunk" order="83">
 						<apply_if layer="1" order="106"/>
@@ -3486,12 +3486,12 @@
 						<apply_if layer="-1" order="61" orderByDensity="83"/>
 						<apply_if additional="layer=-2" order="40" orderByDensity="83"/>
 					</case>
-					<case tag="highway" value="trunk_link" order="70">
-						<apply_if layer="1" order="93"/>
-						<apply_if additional="layer=2" order="123"/>
-						<apply_if additional="layer=3" order="151"/>
-						<apply_if layer="-1" order="48" orderByDensity="70"/>
-						<apply_if additional="layer=-2" order="24" orderByDensity="70"/>
+					<case tag="highway" value="trunk_link" order="71">
+						<apply_if layer="1" order="94"/>
+						<apply_if additional="layer=2" order="124"/>
+						<apply_if additional="layer=3" order="152"/>
+						<apply_if layer="-1" order="49" orderByDensity="71"/>
+						<apply_if additional="layer=-2" order="25" orderByDensity="71"/>
 					</case>
 					<case tag="highway" value="primary" order="82">
 						<apply_if layer="1" order="105"/>
@@ -3500,12 +3500,12 @@
 						<apply_if layer="-1" order="60"  orderByDensity="82"/>
 						<apply_if additional="layer=-2" order="39"  orderByDensity="82"/>
 					</case>
-					<case tag="highway" value="primary_link" order="69">
-						<apply_if layer="1" order="92"/>
-						<apply_if additional="layer=2" order="122"/>
-						<apply_if additional="layer=3" order="150"/>
-						<apply_if layer="-1" order="47"/>
-						<apply_if additional="layer=-2" order="23"/>
+					<case tag="highway" value="primary_link" order="70">
+						<apply_if layer="1" order="93"/>
+						<apply_if additional="layer=2" order="123"/>
+						<apply_if additional="layer=3" order="151"/>
+						<apply_if layer="-1" order="48"/>
+						<apply_if additional="layer=-2" order="24"/>
 					</case>
 					<case tag="highway" value="secondary" order="81">
 						<apply_if layer="1" order="104"/>
@@ -3514,12 +3514,12 @@
 						<apply_if layer="-1" order="59"/>
 						<apply_if additional="layer=-2" order="38"/>
 					</case>
-					<case tag="highway" value="secondary_link" order="68">
-						<apply_if layer="1" order="91"/>
-						<apply_if additional="layer=2" order="121"/>
-						<apply_if additional="layer=3" order="149"/>
-						<apply_if layer="-1" order="46"/>
-						<apply_if additional="layer=-2" order="22"/>
+					<case tag="highway" value="secondary_link" order="69">
+						<apply_if layer="1" order="92"/>
+						<apply_if additional="layer=2" order="122"/>
+						<apply_if additional="layer=3" order="150"/>
+						<apply_if layer="-1" order="47"/>
+						<apply_if additional="layer=-2" order="23"/>
 					</case>
 					<case tag="highway" value="tertiary" order="80">
 						<apply_if layer="1" order="103"/>
@@ -3528,12 +3528,12 @@
 						<apply_if layer="-1" order="58"/>
 						<apply_if additional="layer=-2" order="37"/>
 					</case>
-					<case tag="highway" value="tertiary_link" order="67">
-						<apply_if layer="1" order="90"/>
-						<apply_if additional="layer=2" order="120"/>
-						<apply_if additional="layer=3" order="148"/>
-						<apply_if layer="-1" order="45"/>
-						<apply_if additional="layer=-2" order="21"/>
+					<case tag="highway" value="tertiary_link" order="68">
+						<apply_if layer="1" order="91"/>
+						<apply_if additional="layer=2" order="121"/>
+						<apply_if additional="layer=3" order="149"/>
+						<apply_if layer="-1" order="46"/>
+						<apply_if additional="layer=-2" order="22"/>
 					</case>
 					<case tag="highway" value="road" order="79">
 						<apply_if layer="1" order="102"/>
@@ -3556,19 +3556,19 @@
 						<apply_if layer="-1" order="56"/>
 						<apply_if additional="layer=-2" order="35"/>
 					</case>
-					<case tag="highway" value="service" order="77">
-						<apply_if layer="1" order="100"/>
-						<apply_if additional="layer=2" order="130"/>
-						<apply_if additional="layer=3" order="158"/>
-						<apply_if layer="-1" order="55"/>
-						<apply_if additional="layer=-2" order="34"/>
+					<case tag="highway" value="service" order="67">
+						<apply_if layer="1" order="90"/>
+						<apply_if additional="layer=2" order="120"/>
+						<apply_if additional="layer=3" order="148"/>
+						<apply_if layer="-1" order="45"/>
+						<apply_if additional="layer=-2" order="21"/>
 					</case>
-					<case tag="highway" value="busway" order="77">
-						<apply_if layer="1" order="100"/>
-						<apply_if additional="layer=2" order="130"/>
-						<apply_if additional="layer=3" order="158"/>
-						<apply_if layer="-1" order="55"/>
-						<apply_if additional="layer=-2" order="34"/>
+					<case tag="highway" value="busway" order="67">
+						<apply_if layer="1" order="90"/>
+						<apply_if additional="layer=2" order="120"/>
+						<apply_if additional="layer=3" order="148"/>
+						<apply_if layer="-1" order="45"/>
+						<apply_if additional="layer=-2" order="21"/>
 					</case>
 					<case tag="highway" value="living_street" order="77">
 						<apply_if layer="1" order="100"/>


### PR DESCRIPTION
Did some reordering to show service roads below links, for a better look as links rarely end up on a service road, also to make it look like the default OSM style a little more.
Before change:
![Screenshot_627](https://user-images.githubusercontent.com/42336759/153067607-3f9d22e7-fa25-4da2-8497-ad742731f00a.png)

After change:
![Screenshot_626](https://user-images.githubusercontent.com/42336759/153067662-e4c4835c-6940-49dd-b51f-fcfcc5725a4f.png)

OSM carto:
![Screenshot_625](https://user-images.githubusercontent.com/42336759/153067735-81932b43-f12f-49e7-86fa-0f610163fde3.png)

