### PR TITLE
Observe maxwidth:physical limit on roads

### DIFF
--- a/routing/routing.xml
+++ b/routing/routing.xml
@@ -508,6 +508,9 @@
 			<select value="-1" t="maxwidth">
 				<gt value1=":width" value2="$maxwidth" type="length"/>
 			</select>
+			<select value="-1" t="maxwidth:physical">
+				<gt value1=":width" value2="$maxwidth:physical" type="length"/>
+			</select>
 			<select value="-1" t="width">
 				<gt value1=":width" value2="$width" type="length"/>
 			</select>


### PR DESCRIPTION
Make the car profile observe maxwidth:physical tag set on roads and do not allow too narrow roads. See https://wiki.openstreetmap.org/wiki/Key:maxwidth:physical .

Will this work with the variable as "$maxwidth:physical", with the ":" character, which may have special effect in the declaration?