### PR TITLE
Long road shields and park rendering fix

### DIFF
--- a/rendering_styles/default.render.xml
+++ b/rendering_styles/default.render.xml
@@ -3412,16 +3412,16 @@
 				<case tag="abandoned:place" value="" order="10"/>
 				<case tag="abandoned:landuse" value="" order="10"/>
 				<case tag="landuse" value="landfill" order="6"/>
-				<case tag="man_made" value="spoil_heap"/>
+				<case tag="man_made" value="spoil_heap" order="5"/>
 
 				<case tag="man_made" value="petroleum_well"/>
 				<case tag="man_made" value="reinforced_slope"/>
 				<case tag="whitewater" value="rapid"/>
-				<case tag="leisure" value="park"/>
+				<case tag="leisure" value="park" order="5"/>
 				<case tag="landuse" value="residential" order="4"/>
 				<case tag="historic" value="quarry" order="4"/>
 				<case tag="landuse" value="quarry" order="4"/>
-				<switch order="5">
+				<switch order="6">
 					<case tag="natural" value="bay"/>
 					<case tag="natural" value="water"/>
 					<case tag="natural" value="wood"/>
@@ -4576,6 +4576,15 @@
 									</case>
 									<case textLength="6" textShield="yellow_square_6_road_shield">
 										<case additional="road_shield_shape_#SEQ=pentagon" textShield="yellow_pentagon_6_road_shield"/>
+									</case>
+									<case textLength="7" textShield="yellow_square_7_road_shield">
+										<case additional="road_shield_shape_#SEQ=pentagon" textShield="yellow_pentagon_7_road_shield"/>
+									</case>
+									<case textLength="8" textShield="yellow_square_8_road_shield">
+										<case additional="road_shield_shape_#SEQ=pentagon" textShield="yellow_pentagon_8_road_shield"/>
+									</case>
+									<case textLength="9" textShield="yellow_square_9_road_shield">
+										<case additional="road_shield_shape_#SEQ=pentagon" textShield="yellow_pentagon_9_road_shield"/>
 									</case>
 									<case textHaloColor="#ffe237" textHaloRadius="5"/>
 									<apply_if additional="road_shield_order_#SEQ=1" textOrder="$roadShieldOrder1"/>


### PR DESCRIPTION
Added length 7, 8 and 9 for yellow square shields: In France, some refs of D roads (yellow shield) can be long. Fixed it so that a shield shows correctly on those:
<img src="https://user-images.githubusercontent.com/42336759/155096712-072c07ca-ba62-4092-9cea-33703ea28169.jpg" width=300px /> <img src="https://user-images.githubusercontent.com/42336759/155096709-a8290875-eb93-4b5e-b4cc-b360e09f70f7.jpg" width=300px />

Also reordered parks to show natural polygons on top for cases where parks are mapped in detail:
<img src="https://user-images.githubusercontent.com/42336759/155097390-cdf85a29-fea0-47aa-a315-71e31ebb9366.jpg" width=300px /> <img src="https://user-images.githubusercontent.com/42336759/155097399-0413e92c-4fa5-4894-b1c7-a5b122971539.jpg" width=300px />

