### PR TITLE
Remove outdated crossing values from rendering_types.xml

### DIFF
--- a/obf_creation/rendering_types.xml
+++ b/obf_creation/rendering_types.xml
@@ -1718,26 +1718,17 @@
 		<entity_convert pattern="tag_transform" from_tag="highway" from_value="elevator" to_tag1="elevator" to_value1="yes" map="no" routing="no"/>
 
 		<type tag="crossing" value="uncontrolled" minzoom="15" additional="true" />
-		<entity_convert pattern="tag_transform" from_tag="crossing" from_value="island;uncontrolled" to_tag1="crossing" to_value1="uncontrolled"/>
-		<entity_convert pattern="tag_transform" from_tag="crossing" from_value="island; uncontrolled" to_tag1="crossing" to_value1="uncontrolled"/>
-		<entity_convert pattern="tag_transform" from_tag="crossing" from_value="uncontrolled;island" to_tag1="crossing" to_value1="uncontrolled"/>
-		<entity_convert pattern="tag_transform" from_tag="crossing" from_value="uncontrolled; island" to_tag1="crossing" to_value1="uncontrolled"/>
-		<entity_convert pattern="tag_transform" from_tag="crossing" from_value="uncontrolled,zebra" to_tag1="crossing" to_value1="uncontrolled"/>
+		<entity_convert pattern="tag_transform" from_tag="crossing" from_value="zebra" to_tag1="crossing" to_value1="uncontrolled"/>
 		<entity_convert pattern="tag_transform" from_tag="crossing" from_value="marked" to_tag1="crossing" to_value1="uncontrolled"/>
 		<type tag="crossing" value="traffic_signals" minzoom="15" additional="true" />
 		<entity_convert pattern="tag_transform" from_tag="crossing" from_value="island;traffic_signals" to_tag1="crossing" to_value1="traffic_signals"/>
-		<entity_convert pattern="tag_transform" from_tag="crossing" from_value="controlled" to_tag1="crossing" to_value1="traffic_signals"/>
 		<entity_convert pattern="tag_transform" from_tag="crossing" from_value="traffic_signals;island" to_tag1="crossing" to_value1="traffic_signals"/>
+        <entity_convert pattern="tag_transform" from_tag="crossing" from_value="controlled" to_tag1="crossing" to_value1="traffic_signals"/>
 		<entity_convert pattern="tag_transform" from_tag="crossing" from_value="traffic_lights" to_tag1="crossing" to_value1="traffic_signals"/>
 		<entity_convert pattern="tag_transform" from_tag="crossing" from_value="pedestrian_signals" to_tag1="crossing" to_value1="traffic_signals"/>
-		<entity_convert pattern="tag_transform" from_tag="crossing" from_value="pedestrian_signal" to_tag1="crossing" to_value1="traffic_signals"/>
-		<entity_convert pattern="tag_transform" from_tag="crossing" from_value="signals" to_tag1="crossing" to_value1="traffic_signals"/>
 		<entity_convert pattern="tag_transform" from_tag="crossing" from_value="flashing_lights" to_tag1="crossing" to_value1="traffic_signals"/>
-		<entity_convert pattern="tag_transform" from_tag="crossing" from_value="traffic_signals; island" to_tag1="crossing" to_value1="traffic_signals"/>
 		<entity_convert pattern="tag_transform" from_tag="crossing" from_value="traffic_signal" to_tag1="crossing" to_value1="traffic_signals"/>
-		<entity_convert pattern="tag_transform" from_tag="crossing" from_value="pedestrian signals" to_tag1="crossing" to_value1="traffic_signals"/>
 		<type tag="crossing" value="unmarked" minzoom="15" additional="true" />
-		<entity_convert pattern="tag_transform" from_tag="crossing" from_value="unmarked;island" to_tag1="crossing" to_value1="unmarked"/>
 		<entity_convert pattern="tag_transform" from_tag="crossing:light" from_value="traffic_signals" to_tag1="crossing:light" to_value1="yes"/>
 		<entity_convert pattern="tag_transform" from_tag="crossing:supervision" from_value="automatic" to_tag1="crossing:supervision" to_value1="yes"/>
 


### PR DESCRIPTION
Remove transformations of some 'crossing' values from rendering_types.xml that no longer exist in the OSM database or are really negligible.