### PR TITLE
Add some specific payment:xxx_contactless tags

### DIFF
--- a/poi/poi_types.xml
+++ b/poi/poi_types.xml
@@ -440,6 +440,11 @@
 	<poi_additional name="payment_yandexmoney_no" tag="payment:yandexmoney" value="no"/>
 	<poi_additional name="payment_troika_no" tag="payment:troika" value="no"/>
 	<poi_additional name="payment_contactless_no" tag="payment:contactless" value="no"/>
+    <poi_additional name="payment_american_express_contactless_no" tag="payment:american_express_contactless" value="no"/>
+    <poi_additional name="payment_girocard_contactless_no" tag="payment:girocard_contactless" value="no"/>
+    <poi_additional name="payment_maestro_contactless_no" tag="payment:maestro_contactless" value="no"/>
+    <poi_additional name="payment_mastercard_contactless_no" tag="payment:mastercard_contactless" value="no"/>
+    <poi_additional name="payment_visa_contactless_no" tag="payment:visa_contactless" value="no"/>
 	<poi_additional name="payment_calling_cards_no" tag="payment:calling_cards" value="no"/>
 	<poi_additional name="payment_reverse_charge_calls_no" tag="payment:reverse_charge_calls" value="no"/>
 	<poi_additional name="description_payment" tag="description:payment" type="text"/>
@@ -504,6 +509,11 @@
 		<poi_additional name="payment_yandexmoney_yes" tag="payment:yandexmoney" value="yes"/>
 		<poi_additional name="payment_troika_yes" tag="payment:troika" value="yes"/>
 		<poi_additional name="payment_contactless_yes" tag="payment:contactless" value="yes"/>
+        <poi_additional name="payment_american_express_contactless_yes" tag="payment:american_express_contactless" value="yes"/>
+        <poi_additional name="payment_girocard_contactless_yes" tag="payment:girocard_contactless" value="yes"/>
+        <poi_additional name="payment_maestro_contactless_yes" tag="payment:maestro_contactless" value="yes"/>
+        <poi_additional name="payment_mastercard_contactless_yes" tag="payment:mastercard_contactless" value="yes"/>
+        <poi_additional name="payment_visa_contactless_yes" tag="payment:visa_contactless" value="yes"/>
 		<poi_additional name="payment_calling_cards_yes" tag="payment:calling_cards" value="yes"/>
 		<poi_additional name="payment_reverse_charge_calls_yes" tag="payment:reverse_charge_calls" value="yes"/>
 	</poi_additional_category>


### PR DESCRIPTION
Some objects do accept contactless payment, but ony for some cards. For example, some ciagrette vending machines do only accept girocard contactless payment. For this, some specific payment:xxx_contactless keys were created and they are used already/documented in the wiki. So I added them here.