### PR TITLE
Equal treatment for all non-active railways

### DIFF
--- a/rendering_styles/default.render.xml
+++ b/rendering_styles/default.render.xml
@@ -3838,9 +3838,11 @@
 							<apply_if additional="layer=3" order="167"/>
 						</switch>
 						<switch>
+							<case tag="railway" value="abandoned"/>
 							<case tag="railway" value="construction"/>
+							<case tag="railway" value="disused"/>
 							<case tag="railway" value="preserved"/>
-							<apply_if moreDetailed="false" maxzoom="18" order="-1"/>
+                            <apply_if moreDetailed="false" maxzoom="18" order="-1"/>
 						</switch>
 						<apply_if subwayMode="false" baseAppMode="car" layer="-1" minzoom="9" maxzoom="18" order="-1"/>
 						<apply_if subwayMode="false" baseAppMode="bicycle" layer="-1" minzoom="9" maxzoom="18" order="-1"/>


### PR DESCRIPTION
To my surprise, railways that are almost completely gone (abandoned=no more rails) or not in use (disused) are rendered at zoom levels up to 14, while a railway that is being constructed (i.e. at least as visible as abandoned, or more, in real life) or preserved (i.e. similar or better than "disused" railways) are hidden until zoom level 19.
This makes the treatment of all non-active railways equal