### PR TITLE
More-equal treatment for all non-active railways (approach 2)

### DIFF
--- a/rendering_styles/default.render.xml
+++ b/rendering_styles/default.render.xml
@@ -3838,9 +3838,11 @@
 							<apply_if additional="layer=3" order="167"/>
 						</switch>
 						<switch>
+							<case tag="railway" value="abandoned"/>
 							<case tag="railway" value="construction"/>
+							<case tag="railway" value="disused"/>
 							<case tag="railway" value="preserved"/>
-							<apply_if moreDetailed="false" maxzoom="18" order="-1"/>
+							<apply_if moreDetailed="false" maxzoom="16" order="-1"/>
 						</switch>
 						<apply_if subwayMode="false" baseAppMode="car" layer="-1" minzoom="9" maxzoom="18" order="-1"/>
 						<apply_if subwayMode="false" baseAppMode="bicycle" layer="-1" minzoom="9" maxzoom="18" order="-1"/>


### PR DESCRIPTION
This is an alternative approach to fix https://github.com/osmandapp/OsmAnd/issues/14391
First approach under #826

This differs from 826 in that all not-in-use railways will still be visible up to zoom level 16 (which means on my screen that you're about 400m away from it and still see it on your display, if your position is centered).
To compare, currently disused/abandoned railways will be visible on your screen up to a distance of about 1.5km (from which distance you'd probably not be able to distinguish any railway, even if it'd be on an embankment with no trees blocking the view around it)

On the other hand, it still fixes the issue that disused, preserved and construction railways (which can all look the same in real life) are rendered at completely different zoom levels. Currently a disused/abandoned railway is rendered at 1.5km distance, while a construction/preserved railway is rendered only when you are within 40 meter (and zoomed in accordingly), practically meaning you'd be walking over the construction site before you see it.

Only affects users who have not set the 'more details' option
