### PR TITLE
Consider cyclist and pedestrian hazards in routing

### DIFF
--- a/routing/routing.xml
+++ b/routing/routing.xml
@@ -1665,6 +1665,9 @@
 			Any combination of values that we put here (into the routing.xml)
 			leads to routing errors. The above is only a compromise to minimize
 			those errors.-->
+            
+            <select value="5" t="hazard" v="cyclists"/>
+            <select value="10" t="hazard" v="dangerous_junction"/>
 			
 			<select value="9" t="crossing" v="traffic_signals"/>
 			<select value="1" t="crossing" v="uncontrolled"/>
@@ -2005,6 +2008,9 @@
 		</point>
 
 		<point attribute="obstacle">
+            <select value="5" t="hazard" v="pedestrians"/>
+            <select value="10" t="hazard" v="dangerous_junction"/>
+            
 			<select value="-1" t="foot" v="no"/>
 			<select value="-1"  t="foot" v="private"/>
 			<select value="120"  t="foot" v="destination"/>


### PR DESCRIPTION
I recently learnt about the `hazard` tag. This adds some penalty for routing via a few types of hazardous places to bicycle and pedestrian routing. Cyclists and pedestrians are usually the parties negatively affected by these types of hazards. The penalty may in some cases result in hazards being avoided if an alternative route of otherwise similar quality is available.
It can be debated whether these hazards constitute "obstacle"s in the routing sense. But often for example a hazard=cyclists will mean merging onto a high-traffic road from a shoulder or kerb that may or may not be otherwise mapped and captured by routing, or hazard=dangerous_junction often will mean crossing a high-traffic road, both of which may require time to wait. Also, I only touched `obstacle` and left `obstacle_time` untouched.
Expansion of the routing file to include other hazards is of course possible, but this could be a start.