### PR TITLE
Support foldable barriers, treat identical to removable

### DIFF
--- a/obf_creation/rendering_types.xml
+++ b/obf_creation/rendering_types.xml
@@ -3491,6 +3491,7 @@
 		<entity_convert pattern="tag_transform" from_tag="barrier" from_value="wall" if_tag1="wall" if_value1="castle_wall" to_tag1="barrier" to_value1="castle_wall" poi="no"/>
 		<entity_convert pattern="tag_transform" from_tag="building" from_value="castle_wall" to_tag1="barrier" to_value1="castle_wall" poi="no"/>
 		<type tag="barrier" value="bollard" minzoom="15" />
+		<entity_convert pattern="tag_transform" from_tag="bollard" from_value="foldable" to_tag1="bollard" to_value1="removable"/>
 		<type tag="barrier" value="cycle_barrier" minzoom="14" />
 		<type tag="barrier" value="motorcycle_barrier" minzoom="14" />
 		<type tag="barrier" value="block" minzoom="14" />


### PR DESCRIPTION
[`bollard=foldable`](https://taginfo.openstreetmap.org/tags/bollard=foldable) is rapidly increasing in numbers since it's addition to the [wiki](https://wiki.openstreetmap.org/wiki/Key%3Abollard). 
I propose identical treatment (via tag transform) as many foldable ones are still mapped as removable and the implications for routing is alike: only with proper key you can remove/fold the barrier and proceed.