### PR TITLE
Respect use_sidepath for bicycle, foot and horse

### DIFF
--- a/routing/routing.xml
+++ b/routing/routing.xml
@@ -1110,7 +1110,7 @@
 			<select value="1"  t="cycleway:bicycle" v="designated"/>
 			<select value="1"  t="bicycle" v="destination"/>
 			<select value="1"  t="bicycle" v="official"/>
-			<select value="1"  t="bicycle" v="use_sidepath"/>
+			<select value="-1"  t="bicycle" v="use_sidepath"/>
 			<select value="1"  t="bicycle" v="dismount"/>
 			<if param="driving_style_safety">
 				<select value="-1" t="highway" v="trunk"/>
@@ -1393,7 +1393,6 @@
 	  		<!--	<select value="0.05" t="access" v="private"/>-->
 			<select value="0.3" t="indoor" v="yes"/>
 			<select value="0.1" t="barrier" v="debris"/>
-			<select value="0.1" t="bicycle" v="use_sidepath"/>
 
 			<if param="avoid_unpaved">
 				<select value="0.3" t="osmand_highway_integrity_brouting" v="3"/>
@@ -1838,7 +1837,7 @@
 			<select value="1"  t="foot" v="designated"/>
 			<select value="1"  t="foot" v="destination"/>
 			<select value="1"  t="foot" v="official"/>
-			<select value="1"  t="foot" v="use_sidepath"/>
+			<select value="-1"  t="foot" v="use_sidepath"/>
 
 			<select value="-1" t="access" v="no"/>
 			<if param="allow_private">
@@ -1972,7 +1971,6 @@
 			<select value="1" t="foot" v="designated"/>
 			<select value="1.2" t="sidewalk" v="yes"/>
 			<select value="0.9" t="sidewalk" v="no"/>
-			<select value="0.1" t="foot" v="use_sidepath"/>
 
 			<if param="avoid_tunnels">
 				<select value="0.02" t="tunnel" v="yes"/>
@@ -2146,7 +2144,7 @@
 			<select value="1"  t="horse" v="designated"/>
 			<select value="1"  t="horse" v="destination"/>
 			<select value="1"  t="horse" v="official"/>
-			<select value="1"  t="horse" v="use_sidepath"/>
+			<select value="-1"  t="horse" v="use_sidepath"/>
 			
 			<if param="carriage_restrictions">
 				<select value="-1" t="carriage" v="no"/>


### PR DESCRIPTION
When `use_sidepath` is in use, routing should not be an option for the specific traffic. I don't know if this breaks any tests or if tests should be added to assert this behaviour.