### PR TITLE
Add rule for road shield colouring for Irish N roads

### DIFF
--- a/obf_creation/rendering_types.xml
+++ b/obf_creation/rendering_types.xml
@@ -963,6 +963,14 @@
 		<entity_convert pattern="tag_transform" from_tag="route_road_*_ref" if_region_name="$gb,$isle-of-man,$jersey" if_starts_with_tag1="route_road_*_ref" if_starts_with_value1="a" to_tag1="route_road_*_ref" to_tag2="route_road_*_shield_color" to_value2="green" to_tag3="route_road_*_shield_order" to_value3="2" to_tag4="route_road_*_shield_text_color" to_value4="yellow" seq="1:10" apply_to="way" notosm="true"/>
 		<entity_convert pattern="tag_transform" from_tag="route_road_*_ref" if_region_name="$gb,$isle-of-man,$jersey" if_starts_with_tag1="route_road_*_ref" if_starts_with_value1="m" to_tag1="route_road_*_ref" to_tag2="route_road_*_shield_color" to_value2="blue" seq="1:10" apply_to="way" notosm="true"/>
 
+		<entity_convert pattern="tag_transform" from_tag="route_road_*_ref"
+				if_region_name="$ireland"
+				if_starts_with_tag1="route_road_*_ref" if_starts_with_value1="n"
+				to_tag1="route_road_*_ref"
+				to_tag2="route_road_*_shield_color" to_value2="green"
+				to_tag3="route_road_*_shield_order" to_value3="2"
+				to_tag4="route_road_*_shield_text_color" to_value4="yellow"
+				seq="1:10" apply_to="way" notosm="true"/>
 		<entity_convert pattern="tag_transform" from_tag="route_road_*_ref" if_region_name="$ireland" if_tag1="route_road_*_network" if_value1="n" to_tag1="route_road_*_ref" to_tag2="route_road_*_shield_color" to_value2="green" to_tag3="route_road_*_shield_order" to_value3="2" to_tag4="route_road_*_shield_text_color" to_value4="yellow" seq="1:10" apply_to="way" notosm="true"/>
 		<entity_convert pattern="tag_transform" from_tag="route_road_*_ref" if_region_name="$ireland" if_tag1="route_road_*_network" if_value1="m" to_tag1="route_road_*_ref" to_tag2="route_road_*_shield_color" to_value2="blue" to_tag3="route_road_*_shield_order" to_value3="2" seq="1:10" apply_to="way" notosm="true"/>
 		<entity_convert pattern="tag_transform" from_tag="route_road_*_ref" if_region_name="$ireland" if_tag1="route_road_*_network" if_value1="r" to_tag1="route_road_*_ref" to_tag2="route_road_*_shield_color" to_value2="white" to_tag3="route_road_*_shield_order" to_value3="2" seq="1:10" apply_to="way" notosm="true"/>


### PR DESCRIPTION
This makes the National roads in Ireland have the correct label colours.
Fixes https://github.com/osmandapp/OsmAnd/issues/15937

This is my first time interacting with the OsmAnd projects. I appreciate any feedback about these changes, and also about how to test this change properly.

I was not able to verify this exact code change. When testing my changes, I had to omit the line `if_region_name="$ireland"`, otherwise the shield colouring would not apply.
That being said, I tested with that line omitted, by following the documentation at https://osmand.net/docs/technical/map-creation/create-offline-maps-yourself#vector-maps-simple to generate an obf file, and then imported it into the OsmAnd app.

The resulting map appears with correct colouring of N road shields:
![Screenshot_2022-12-11-20-52-33-65_014aeb6b5e04ee7837dcdaecc5244511](https://user-images.githubusercontent.com/19391546/206929633-15cd47bd-f9f9-45d6-9a6e-4a25f3caf5f5.jpg)
