### PR TITLE
Provide full name for tts engine

### DIFF
--- a/voice/pl/pl_tts.js
+++ b/voice/pl/pl_tts.js
@@ -112,8 +112,7 @@ function populateDictionary(tts) {
 	
 	// DISTANCE UNIT SUPPORT
 	// Some TTS engines get declinations right if abbreviated distance and time units are used.
-	//dictionary["meters"] = tts ? "metrów" : "meters.ogg";
-	dictionary["meters"] = tts ? "m" : "meters.ogg";
+	dictionary["meters"] = tts ? "metrów" : "meters.ogg";
 	dictionary["around_1_kilometer"] = tts ? "około jeden kilometr" : "around_1_kilometer.ogg";
 	dictionary["around"] = tts ? "około" : "around.ogg";
 	dictionary["kilometers"] = tts ? "kilometrów" : "kilometers.ogg";


### PR DESCRIPTION
I think that the app should provide the complete name for tts engine because I can't really see benefit of not doing it and without it the results sound really strange with e.g. RHVoice.