### PR TITLE
Treat dog_toilet like dog_park

### DIFF
--- a/obf_creation/rendering_types.xml
+++ b/obf_creation/rendering_types.xml
@@ -4616,6 +4616,7 @@
 
 	<category name="leisure">
 		<type tag="leisure" value="dog_park" minzoom="15" />
+        <entity_convert pattern="tag_transform" from_tag="amenity" from_value="dog_toilet" to_tag1="leisure" to_value1="dog_park"/>
 		<entity_convert pattern="tag_transform" from_tag="sport" from_value="stadium" to_tag1="leisure"/>
 		<type tag="leisure" value="horse_riding" minzoom="12" />
 		<type tag="leisure" value="water_park" minzoom="13" order="71" />


### PR DESCRIPTION
Currently dog_toilet is not rendered. Since it's a relatively rare key, I guess it makes sense to treat it as dog_park, even though there are actually subtle differences

https://wiki.openstreetmap.org/wiki/Tag:amenity%3Ddog_toilet