### PR TITLE
Add several recycling waste types

### DIFF
--- a/poi/phrases/en/phrases.xml
+++ b/poi/phrases/en/phrases.xml
@@ -600,6 +600,10 @@
 	<string name="poi_recycling_car_batteries">Car batteries</string>
 	<string name="poi_recycling_cars">Cars</string>
 	<string name="poi_recycling_bicycles">Bicycles</string>
+	<string name="poi_recycling_plastic_bottle_caps">Plastic bottle caps</string>
+	<string name="poi_recycling_aluminium_cans">Aluminium cans</string>
+	<string name="poi_recycling_pet_drink_bottles">PET beverage bottles</string>
+	<string name="poi_recycling_textiles">Textiles</string>
 
 	<string name="poi_landfill">Landfill</string>
 	<string name="poi_landfill_waste_nuclear">Nuclear waste</string>

--- a/poi/phrases/ru/phrases.xml
+++ b/poi/phrases/ru/phrases.xml
@@ -288,6 +288,10 @@
     <string name="poi_recycling_car_batteries">Автомобильные аккумуляторы</string>
     <string name="poi_recycling_cars">Автомобили</string>
     <string name="poi_recycling_bicycles">Велосипеды</string>
+    <string name="poi_recycling_plastic_bottle_caps">Крышки от пластиковых бутылок</string>
+    <string name="poi_recycling_aluminium_cans">Алюминиевые банки</string>
+    <string name="poi_recycling_pet_drink_bottles">PET-бутылки из под напитков</string>
+    <string name="poi_recycling_textiles">Текстиль</string>
     <string name="poi_surveillance">Камера видеонаблюдения</string>
     <string name="poi_construction">Стройка</string>
     <string name="poi_works">Завод</string>

--- a/poi/phrases/uk/phrases.xml
+++ b/poi/phrases/uk/phrases.xml
@@ -319,6 +319,10 @@
     <string name="poi_recycling_computers">Комп’ютери</string>
     <string name="poi_recycling_tyres">Шини</string>
     <string name="poi_recycling_tv_monitor">Телевізори, монітори</string>
+    <string name="poi_recycling_plastic_bottle_caps">Кришки від пластикових пляшок</string>
+    <string name="poi_recycling_aluminium_cans">Алюмінієві банки</string>
+    <string name="poi_recycling_pet_drink_bottles">PET-пляшки від напоїв</string>
+    <string name="poi_recycling_textiles">Текстиль</string>
     <string name="poi_node_networks">Вузли пішохідних/велосипедних маршрутів</string>
     <string name="poi_railway_buffer_stop">Залізничний буфер (тупиковий упор)</string>
     <string name="poi_slipway">Суднопідіймальний елінг</string>

--- a/poi/poi_types.xml
+++ b/poi/poi_types.xml
@@ -4589,6 +4589,10 @@
 					<poi_additional name="recycling_car_batteries" tag="recycling:car_batteries" value="yes"/>
 					<poi_additional name="recycling_cars" tag="recycling:cars" value="yes"/>
 					<poi_additional name="recycling_bicycles" tag="recycling:bicycles" value="yes"/>
+					<poi_additional name="recycling_plastic_bottle_caps" tag="recycling:plastic_bottle_caps" value="yes"/>
+					<poi_additional name="recycling_aluminium_cans" tag="recycling:aluminium_cans" value="yes"/>
+					<poi_additional name="recycling_pet_drink_bottles" tag="recycling:pet_drink_bottles" value="yes"/>
+					<poi_additional name="recycling_textiles" tag="recycling:textiles" value="yes"/>
 				</poi_additional_category>
 			</poi_type>
 			<poi_type name="waste_disposal" tag="amenity" value="waste_disposal" excluded_poi_additional_category="payment_type,fee,internet_access_type,opening_hours"/>


### PR DESCRIPTION
This adds four new types of recycling waste that I see in OSM. They are all present in the table for [`amenity=recycling`][table]. This also adds several translations for the names.

I've verified the changes locally after creating a piece of the map with these recycling POIs.

See also: https://github.com/osmandapp/OsmAnd-iOS/pull/2593.

[table]: https://wiki.openstreetmap.org/wiki/Tag:amenity=recycling#Accepts