### PR TITLE
Add coupure and height restrictor to rounting.xml

### DIFF
--- a/routing/routing.xml
+++ b/routing/routing.xml
@@ -1142,7 +1142,9 @@
 			<select value="1"   t="barrier" v="entrance"/>
 			<select value="100" t="barrier" v="sally_port"/>
 			<select value="1"   t="barrier" v="toll_booth"/>
-			<!-- These 2 shouldn't be allowed per the wiki (access=no is assumed) but people often do not add the proper access tags. -->
+			<select value="1"   t="barrier" v="height_restrictor"/>
+			<select value="1"   t="barrier" v="coupure"/>
+            <!-- These 2 shouldn't be allowed per the wiki (access=no is assumed) but people often do not add the proper access tags. -->
 			<select value="300" t="barrier" v="lift_gate"/>
 			<select value="300" t="barrier" v="swing_gate"/>
 			<!-- Without explicit access marking, barriers other than the listed values above are impassable to a car. -->
@@ -1791,10 +1793,10 @@
 
 		<point attribute="obstacle_time">
 			<select value="10" t="barrier" v="cycle_barrier"/>
-			<select value="15"  t="barrier" v="gate"/>
-			<select value="20"  t="barrier" v="lift_gate"/>
-			<select value="20"  t="barrier" v="swing_gate"/>
-			<select value="15"  t="barrier" v="log"/>
+			<select value="15" t="barrier" v="gate"/>
+			<select value="20" t="barrier" v="lift_gate"/>
+			<select value="20" t="barrier" v="swing_gate"/>
+			<select value="15" t="barrier" v="log"/>
 			<select value="5"  t="barrier"/>
 			<select value="15" t="highway" v="traffic_signals"/>
 			<select value="10" t="crossing" v="unmarked"/>
@@ -1805,7 +1807,7 @@
 			<select value="200" t="ford"/>
 			<select value="25" t="railway" v="crossing"/>
 			<select value="25" t="railway" v="level_crossing"/>
-			<select value="5" t="railway" v="tram_level_crossing"/>
+			<select value="5"  t="railway" v="tram_level_crossing"/>
 		</point>
 
 		<point attribute="obstacle">
@@ -1869,6 +1871,9 @@
 				<select value="180"  t="access" v="private"/>
 			</if>
 
+            <select value="1"   t="barrier" v="height_restrictor"/>
+			<select value="1"   t="barrier" v="coupure"/>
+            
 			<!--<select value="-1" t="crossing" v="no"/>-->
 
 		</point>
@@ -2493,6 +2498,8 @@
 			<select value="-1"  t="barrier" v="turnstile"/>
 			<select value="15"  t="barrier" v="wicket_gate"/>
 			<select value="15"  t="barrier" v="log"/>
+			<select value="1"   t="barrier" v="height_restrictor"/>
+			<select value="1"   t="barrier" v="coupure"/>
 			
 			<select value="15" t="barrier" v="bump_gate"/>
 			<select value="5"  t="barrier"/>


### PR DESCRIPTION
Add coupure and height restrictor barriers to rounting.xml to explicitly mark them as passable.