### PR TITLE
Nautical Render INT-1, P, R, S: Lights, Fog Signals, Radar in nameTag2

### DIFF
--- a/obf_creation/rendering_types.xml
+++ b/obf_creation/rendering_types.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <osmand_types>
-    <!-- Version 1.1, 2021-12-22 adding tags for nautical rendering for seamarks in INT-1 section K Obstructions and J Seabed, Weed, Seagrass -->
+    <!-- Version 1.3, 2023-05-03 adding tags for nautical rendering for seamarks in INT-1 P, R, S sections Lights, Fog Signals, Radar -->
 	
 	<!-- currently name tags are indexed with name and additional in nameTags separated by comma -->
 
@@ -4398,6 +4398,9 @@
 		<type tag="public_transport" value="stop_position" minzoom="15"/>
 	</category>
 
+	<type tag="man_made" value="offshore_platform" minzoom="10" nameTags="seamark:name,name,seamark:light:character,seamark:light:add_sectors,seamark:light:1:add_sector,seamark:light:2:add_sector,seamark:light:3:add_sector,seamark:light:4:add_sector,seamark:light:5:add_sector"/> <!-- nameTags for INT-1 P Section Lights, in front of aeroway=helipad and power=substation for visibility in nautical.render.xml -->
+	<type tag="seamark:type" value="platform" minzoom="10" nameTags="seamark:name,name,seamark:light:character,seamark:light:add_sectors,seamark:light:1:add_sector,seamark:light:2:add_sector,seamark:light:3:add_sector,seamark:light:4:add_sector,seamark:light:5:add_sector"/> <!-- nameTags for INT-1 P Section Lights, in front of aeroway=helipad and power=substation for visibility in nautical.render.xml -->
+
 	<category name="aeroway">
 		 <!-- artificial tags. Used because only (usually) large aerodromes are using these tags and they are nameTags -->
 		<entity_convert pattern="tag_transform" from_tag="iata" if_tag1="aeroway" if_value1="aerodrome" to_tag1="large_aerodrome" to_value1="yes" to_tag2="iata"/>
@@ -4422,7 +4425,7 @@
 		<entity_convert pattern="tag_transform" from_tag="aerodrome" from_value="airfield" to_tag1="aerodrome:type" to_value1="airfield"/>
 		<type tag="aerodrome:type" value="military" minzoom="6" additional="true" />
 		<type tag="aeroway" value="terminal" minzoom="14" order="60"/>
-		<type tag="aeroway" value="helipad" minzoom="10" />
+		<type tag="aeroway" value="helipad" minzoom="10"/>
 		<type tag="aeroway" value="runway" minzoom="11"/>
 		<type tag="aeroway" value="taxiway" minzoom="12" nameTags="ref"/>
 		<type tag="aeroway" value="apron" minzoom="12"/>
@@ -4583,7 +4586,7 @@
 		<type tag="amenity" value="weightbridge" minzoom="15" />
 		<type tag="man_made" value="ventilation_shaft" minzoom="15" />
 		<type tag="man_made" value="pumping_station" minzoom="15" />
-		<type tag="man_made" value="lighthouse" minzoom="15" />
+		<type tag="man_made" value="lighthouse" minzoom="10" nameTags="seamark:name,name,seamark:light:character,seamark:light:add_sectors,seamark:light:1:add_sector,seamark:light:2:add_sector,seamark:light:3:add_sector,seamark:light:4:add_sector,seamark:light:5:add_sector"/> <!-- nameTags for INT-1 P Section Lights -->
 		<type tag="man_made" value="mineshaft" minzoom="15" />
 		<entity_convert pattern="tag_transform" from_tag="man_made" from_value="mine" to_tag1="man_made" to_value1="mineshaft"/>
 		<type tag="man_made" value="adit" minzoom="15" />
@@ -4603,7 +4606,7 @@
 		<entity_convert pattern="tag_transform" from_tag="man_made" from_value="surveillance" if_tag1="healthcare" to_tag1="surveillance" to_value1="yes"/>
 		<type tag="man_made" value="standpipe" minzoom="15" />
 		<type tag="man_made" value="survey_point" minzoom="11" />
-		<type tag="man_made" value="tower" minzoom="10" order="60"/>
+		<type tag="man_made" value="tower" minzoom="10" order="60" nameTags="seamark:name,name,seamark:light:character,seamark:light:add_sectors,seamark:light:1:add_sector,seamark:light:2:add_sector,seamark:light:3:add_sector,seamark:light:4:add_sector,seamark:light:5:add_sector"/> <!-- nameTags for INT-1 P Section Lights -->
 		<type tag="tower:type" value="communication" additional="true" minzoom="10" />
 		<type tag="tower:type" value="lighting" additional="true" minzoom="10" />
 		<type tag="tower:type" value="observation" additional="true" minzoom="10" />
@@ -4616,7 +4619,7 @@
 		<entity_convert pattern="tag_transform" from_tag="historic" from_value="tower" to_tag1="man_made" to_value1="tower" to_tag2="historic" to_value2="yes"/>
 		<type tag="man_made" value="antenna" minzoom="14"/>
 		<entity_convert pattern="tag_transform" from_tag="tower:type" from_value="communication" to_tag1="tower:type" to_value1="communication" to_tag2="man_made" to_value2="tower" poi="no"/>
-		<type tag="man_made" value="mast" minzoom="10"/>
+		<type tag="man_made" value="mast" minzoom="10" nameTags="seamark:name,name,seamark:light:character,seamark:light:add_sectors,seamark:light:1:add_sector,seamark:light:2:add_sector,seamark:light:3:add_sector,seamark:light:4:add_sector,seamark:light:5:add_sector"/> <!-- nameTags for INT-1 P Section Lights -->
 		<entity_convert pattern="tag_transform" from_tag="tower:type" from_value="mast" if_not_tag1="man_made" if_not_value1="mast" to_tag1="man_made" to_value1="mast"/>
 		<type tag="man_made" value="satellite_dish" minzoom="14"/>
 		<type tag="man_made" value="flare" minzoom="13"/>
@@ -6742,7 +6745,8 @@
 		<!-- Here user defined categories could be added -->
 		<!-- <type tag="user_defined" value="wsl" minzoom="10" /> -->
 	</category>
-
+	
+	<!-- Seamarks -->
 	<!-- example of definition openseamaps needs to be enabled later -->
 	<!-- preprocess rules
 		1. seamark:type=VAR -> seamark:VAR=''
@@ -6754,14 +6758,16 @@
 				+ tag seamark:attached=$(seamark:type)
 		3. seamark:*:VAR -> seamark:VAR
 		   Example : seamark:buoy_lateral:category -> seamark:category (additional)
-	 -->	
-	 <!-- TODO define in additional file? -->
+	 -->
+	 
+	<!-- TODO define in additional file? -->
 	<type tag="seamark:category" minzoom="11" additional="true" notosm="true"/>
 	<type tag="seamark:character" minzoom="11" additional="text" notosm="true"/>
+	<type tag="seamark:group" minzoom="11" additional="text" notosm="true"/>																				 
 	<type tag="seamark:colour" minzoom="11" additional="true" notosm="true"/>
 	<type tag="seamark:height" minzoom="11" additional="text" notosm="true"/>
 	<type tag="seamark:clearance_height" minzoom="11" additional="text" notosm="true"/>
-<!--	<type tag="seamark:name" minzoom="11" additional="text"/>-->
+	<!-- <type tag="seamark:name" minzoom="11" additional="text"/> -->
 	<type tag="seamark:period" minzoom="11" additional="true" notosm="true"/>
 	<type tag="seamark:range" minzoom="11" additional="true" notosm="true"/>
 	<type tag="seamark:reference" minzoom="11" additional="text" notosm="true"/>
@@ -6771,6 +6777,51 @@
 	<type tag="seamark:topmark" minzoom="11" additional="true" notosm="true"/>
 	<type tag="seamark:attached" minzoom="11" additional="true" notosm="true"/>
 	<type tag="seamark:surface" minzoom="11" additional="text" notosm="true"/>
+	
+	<!-- INT-1 P, R, S Sections: Lights, Fog Signals, Radar. Composition of lightDetail for nameTag2, finally selected in nautical.render.xml renderingProperty attr="lightDetail" -->
+	<!-- seamark:name and seamark:light tags as nameTag2 (as far as possible today). The OSMAND display was validated at Texel, Den Helder, Helgoland, Elbe and Weser Approaches, Rotterdam, Cherbourg.
+	default: 		name (light:character.group.period[in seconds].fog_signal:category.group.period[in seconds].radar_transponder:category.group) 
+					e.g. T6-VH 1 (Fl.2+1.10)= Buoy T6-VH 1 with light flashes in groups of 2 and 1. This is repeated after 10 seconds.
+					name (light:character.period[in seconds]) or name (light:character.group), with only one number element. 
+	sectors: 		name (sector1start[bearing in degree]-end[bearing in degree]-colour-sector2 ... -sector3 ... -lightcategory)
+	sector1...5:	name (sector1character.group.colour.period[in seconds].start[bearing in degree].end[bearing in degree].category[dircetional,upper,etc.].exhibition[night,fog,etc.].visibilitydistance[in nautical miles])
+	Note1: In the default, a single number remains ambiguous, because the group brackets and the unit cannot be added to the nameTag2, so far. 
+	Note2: The group tag is/cannot? be attributed correctly, e.g. for seamarks cardinal south.
+	More specific formatting, inclusion of colours and combination of text elements in the nameTags in OSMAND will require amendments for parsing of commands from rendering_types.xml and rendering styles (nautical.render.xml) 
+	aiming at OSMAND text display according to IHO Chart INT-1 Section P: Lights and Section R Fog Signals, e.g. https://map.openseamap.org/?zoom=15&lon=4.79&lat=53.00 .
+	An appropriate graphical display of sector lights with coloured circle sections requires further development of code in OSMAND. Feedback welcome: josail @ gmx.de  -->
+	<type tag="seamark:light:add_sectors" minzoom="11" additional="text" notosm="true"/>
+	<type tag="seamark:light:1:add_sector" minzoom="11" additional="text" notosm="true"/>
+	<type tag="seamark:light:2:add_sector" minzoom="11" additional="text" notosm="true"/>
+	<type tag="seamark:light:3:add_sector" minzoom="11" additional="text" notosm="true"/>
+	<type tag="seamark:light:4:add_sector" minzoom="11" additional="text" notosm="true"/>
+	<type tag="seamark:light:5:add_sector" minzoom="11" additional="text" notosm="true"/>
+	<!-- fill missing tags for complete display of seamark:light:character in nautical.render.xml, which depends on existance of seamark:name -->
+	<entity_convert pattern="tag_transform" from_tag="name" if_tag1="seamark:type" if_not_tag2="seamark:name" to_tag1="name" to_tag2="seamark:name"/>
+	<entity_convert pattern="tag_transform" from_tag="seamark:type" if_not_tag1="name" if_not_tag2="seamark:name" to_tag1="seamark:type" to_tag2="seamark:name" to_value2="."/>
+	<entity_convert pattern="tag_transform" from_tag="seamark:light:1:character" to_tag1="seamark:light:character"/>
+	<entity_convert pattern="tag_transform" from_tag="seamark:light:1:group" to_tag1="seamark:light:group"/>
+	<entity_convert pattern="tag_transform" from_tag="seamark:light:1:period" to_tag1="seamark:light:period"/>
+	<!-- <apply_if lightDetail="" (default) nameTag2="seamark:light:character" (incl. light:group, light:period, fog_signal:category, fog_signal:group, fog_signal:period)/>, if-conditions assure nameTag2 display in case only seamark:light:character exists -->
+	<entity_convert pattern="tag_combine" separator="." from_tag="seamark:light:character" if_tag1="seamark:light:group" from_tag1="seamark:light:group" from_tag2="seamark:light:period" from_tag3="seamark:fog_signal:category" from_tag4="seamark:fog_signal:group" from_tag5="seamark:fog_signal:period" from_tag6="seamark:radar_transponder:category" from_tag7="seamark:radar_transponder:group" to_tag1="seamark:light:character"/>
+	<entity_convert pattern="tag_combine" separator="." from_tag="seamark:light:character" if_tag1="seamark:light:period" from_tag1="seamark:light:group" from_tag2="seamark:light:period" from_tag3="seamark:fog_signal:category" from_tag4="seamark:fog_signal:group" from_tag5="seamark:fog_signal:period" from_tag6="seamark:radar_transponder:category" from_tag7="seamark:radar_transponder:group" to_tag1="seamark:light:character"/>
+	<entity_convert pattern="tag_combine" separator="." from_tag="seamark:light:character" if_tag1="seamark:light:range" from_tag1="seamark:light:group" from_tag2="seamark:light:period" from_tag3="seamark:fog_signal:category" from_tag4="seamark:fog_signal:group" from_tag5="seamark:fog_signal:period" from_tag6="seamark:radar_transponder:category" from_tag7="seamark:radar_transponder:group" to_tag1="seamark:light:character"/>
+	<entity_convert pattern="tag_combine" separator="." from_tag="seamark:light:character" if_tag1="seamark:fog_signal:category" from_tag1="seamark:light:group" from_tag2="seamark:light:period" from_tag3="seamark:fog_signal:category" from_tag4="seamark:fog_signal:group" from_tag5="seamark:fog_signal:period" from_tag6="seamark:radar_transponder:category" from_tag7="seamark:radar_transponder:group" to_tag1="seamark:light:character"/>
+	<entity_convert pattern="tag_combine" separator="." from_tag="seamark:light:1:character" if_tag1="seamark:light:1:group" from_tag1="seamark:light:1:group" from_tag2="seamark:light:1:period" from_tag3="seamark:fog_signal:category" from_tag4="seamark:fog_signal:group" from_tag5="seamark:fog_signal:period" from_tag6="seamark:radar_transponder:category" from_tag7="seamark:radar_transponder:group" to_tag1="seamark:light:character"/>
+	<entity_convert pattern="tag_combine" separator="." from_tag="seamark:light:1:character" if_tag1="seamark:light:1:period" from_tag1="seamark:light:1:group" from_tag2="seamark:light:1:period" from_tag3="seamark:fog_signal:category" from_tag4="seamark:fog_signal:group" from_tag5="seamark:fog_signal:period" from_tag6="seamark:radar_transponder:category" from_tag7="seamark:radar_transponder:group" to_tag1="seamark:light:character"/>
+	<entity_convert pattern="tag_combine" separator="." from_tag="seamark:light:1:character" if_tag1="seamark:light:1:range" from_tag1="seamark:light:1:group" from_tag2="seamark:light:1:period" from_tag3="seamark:fog_signal:category" from_tag4="seamark:fog_signal:group" from_tag5="seamark:fog_signal:period" from_tag6="seamark:radar_transponder:category" from_tag7="seamark:radar_transponder:group" to_tag1="seamark:light:character"/>
+	<entity_convert pattern="tag_combine" separator="." from_tag="seamark:light:1:character" if_tag1="seamark:fog_signal:category" from_tag1="seamark:light:1:group" from_tag2="seamark:light:1:period" from_tag3="seamark:fog_signal:category" from_tag4="seamark:fog_signal:group" from_tag5="seamark:fog_signal:period" from_tag6="seamark:radar_transponder:category" from_tag7="seamark:radar_transponder:group" to_tag1="seamark:light:character"/>
+    <entity_convert pattern="tag_combine" separator="." from_tag="seamark:fog_signal:category" if_not_tag1="seamark:light:character" if_not_tag2="seamark:light:1:character" from_tag4="seamark:fog_signal:group" from_tag5="seamark:fog_signal:period" from_tag6="seamark:radar_transponder:category" from_tag7="seamark:radar_transponder:group" to_tag1="seamark:light:character"  additional="text"/>
+	<entity_convert pattern="tag_combine" separator="." from_tag="seamark:radar_transponder:category" if_not_tag1="seamark:light:character" if_not_tag2="seamark:light:1:character" if_not_tag3="seamark:fog_signal"from_tag7="seamark:radar_transponder:group" to_tag1="seamark:light:character" additional="text"/>
+	<!-- <apply_if lightDetail="sectors" nameTag2="seamark:light:add_sectors"/> -->
+	<entity_convert pattern="tag_combine" separator="-" from_tag="seamark:light:1:sector_start"	from_tag1="seamark:light:1:sector_end" from_tag2="seamark:light:1:colour" from_tag3="seamark:light:2:sector_start" from_tag4="seamark:light:2:sector_end" from_tag5="seamark:light:2:colour" from_tag6="seamark:light:3:sector_start" from_tag7="seamark:light:3:sector_end" from_tag8="seamark:light:3:colour" from_tag15="seamark:light:category" 
+					to_tag1="seamark:light:add_sectors"/>	
+	<!-- <apply_if lightDetail="sector1..5" nameTag2="seamark:light:1:add_sector"/> -->
+	<entity_convert pattern="tag_combine" separator="." from_tag="seamark:light:1:character" from_tag2="seamark:light:1:group" from_tag3="seamark:light:1:colour" from_tag4="seamark:light:1:period" from_tag5="seamark:light:1:sector_start" from_tag6="seamark:light:1:sector_end" from_tag7="seamark:light:1:category" from_tag8="seamark:light:1:exhibition" from_tag9="seamark:light:1:range" to_tag1="seamark:light:1:add_sector"/>			
+	<entity_convert pattern="tag_combine" separator="." from_tag="seamark:light:2:character" from_tag2="seamark:light:2:group" from_tag3="seamark:light:2:colour" from_tag4="seamark:light:2:period" from_tag5="seamark:light:2:sector_start" from_tag6="seamark:light:2:sector_end" from_tag7="seamark:light:2:category" from_tag8="seamark:light:2:exhibition" from_tag9="seamark:light:2:range" to_tag1="seamark:light:2:add_sector"/>			
+	<entity_convert pattern="tag_combine" separator="." from_tag="seamark:light:3:character" from_tag2="seamark:light:3:group" from_tag3="seamark:light:3:colour" from_tag4="seamark:light:3:period" from_tag5="seamark:light:3:sector_start" from_tag6="seamark:light:3:sector_end" from_tag7="seamark:light:3:category" from_tag8="seamark:light:3:exhibition" from_tag9="seamark:light:3:range" to_tag1="seamark:light:3:add_sector"/>
+	<entity_convert pattern="tag_combine" separator="." from_tag="seamark:light:4:character" from_tag2="seamark:light:4:group" from_tag3="seamark:light:4:colour" from_tag4="seamark:light:4:period" from_tag5="seamark:light:4:sector_start" from_tag6="seamark:light:4:sector_end" from_tag7="seamark:light:4:category" from_tag8="seamark:light:4:exhibition" from_tag9="seamark:light:4:range" to_tag1="seamark:light:4:add_sector"/>		
+	<entity_convert pattern="tag_combine" separator="." from_tag="seamark:light:5:character" from_tag2="seamark:light:5:group" from_tag3="seamark:light:5:colour" from_tag4="seamark:light:5:period" from_tag5="seamark:light:5:sector_start" from_tag6="seamark:light:5:sector_end" from_tag7="seamark:light:5:category" from_tag8="seamark:light:5:exhibition" from_tag9="seamark:light:5:range" to_tag1="seamark:light:5:add_sector"/>
 
 	<category name="seamarks_map">
 		<type tag="seamark:type" value="anchorage" minzoom="11" nameTags="seamark:name"/>
@@ -6778,17 +6829,18 @@
 		<type tag="seamark:type" value="berth" minzoom="11" nameTags="seamark:name,seamark:berth:information"/>
 		<type tag="seamark:type" value="bridge" minzoom="11" nameTags="seamark:name,seamark:bridge:clearance_height,seamark:bridge:clearance_height_closed,seamark:bridge:clearance_height_open"/>
 		<type tag="seamark:type" value="building" minzoom="15" nameTags="seamark:name"/>
-		<type tag="seamark:type" value="buoy_lateral" minzoom="11" nameTags="seamark:name,seamark:light:character"/>
-		<type tag="seamark:type" value="buoy_cardinal" minzoom="11" nameTags="seamark:name,seamark:light:character"/>
-		<type tag="seamark:type" value="buoy_isolated_danger" minzoom="11" nameTags="seamark:name,seamark:light:character"/>
-		<type tag="seamark:type" value="buoy_safe_water" minzoom="11" nameTags="seamark:name,seamark:light:character"/>
-		<type tag="seamark:type" value="buoy_special_purpose" minzoom="11" nameTags="seamark:name,seamark:light:character"/>
-		<type tag="seamark:type" value="buoy_installation" minzoom="11" nameTags="seamark:name,seamark:light:character"/>
-		<type tag="seamark:type" value="beacon_lateral" minzoom="11" nameTags="seamark:name,seamark:light:character"/>
-		<type tag="seamark:type" value="beacon_cardinal" minzoom="11" nameTags="seamark:name,seamark:light:character"/>
-		<type tag="seamark:type" value="beacon_isolated_danger" minzoom="11" nameTags="seamark:name,seamark:light:character"/>
-		<type tag="seamark:type" value="beacon_safe_water" minzoom="11" nameTags="seamark:name,seamark:light:character"/>
-		<type tag="seamark:type" value="beacon_special_purpose" minzoom="11" nameTags="seamark:name,seamark:light:character"/>
+		<!-- INT-1 P, Q, R, S Sections: Lights, Buoys and Becons, Fog Signals, Radar nameTags -->
+		<type tag="seamark:type" value="buoy_lateral" minzoom="11" nameTags="seamark:name,seamark:light:character,seamark:light:add_sectors,seamark:light:1:add_sector,seamark:light:2:add_sector,seamark:light:3:add_sector,seamark:light:4:add_sector,seamark:light:5:add_sector"/>
+		<type tag="seamark:type" value="buoy_cardinal" minzoom="11" nameTags="seamark:name,seamark:light:character,seamark:light:add_sectors,seamark:light:1:add_sector,seamark:light:2:add_sector,seamark:light:3:add_sector,seamark:light:4:add_sector,seamark:light:5:add_sector"/>
+		<type tag="seamark:type" value="buoy_isolated_danger" minzoom="11" nameTags="seamark:name,seamark:light:character,seamark:light:add_sectors,seamark:light:1:add_sector,seamark:light:2:add_sector,seamark:light:3:add_sector,seamark:light:4:add_sector,seamark:light:5:add_sector"/>
+		<type tag="seamark:type" value="buoy_safe_water" minzoom="11" nameTags="seamark:name,seamark:light:character,seamark:light:add_sectors,seamark:light:1:add_sector,seamark:light:2:add_sector,seamark:light:3:add_sector,seamark:light:4:add_sector,seamark:light:5:add_sector"/>
+		<type tag="seamark:type" value="buoy_special_purpose" minzoom="11" nameTags="seamark:name,seamark:light:character,seamark:light:add_sectors,seamark:light:1:add_sector,seamark:light:2:add_sector,seamark:light:3:add_sector,seamark:light:4:add_sector,seamark:light:5:add_sector"/>
+		<type tag="seamark:type" value="buoy_installation" minzoom="11" nameTags="seamark:name,seamark:light:character,seamark:light:add_sectors,seamark:light:1:add_sector,seamark:light:2:add_sector,seamark:light:3:add_sector,seamark:light:4:add_sector,seamark:light:5:add_sector"/>
+		<type tag="seamark:type" value="beacon_lateral" minzoom="11" nameTags="seamark:name,seamark:light:character,seamark:light:add_sectors,seamark:light:1:add_sector,seamark:light:2:add_sector,seamark:light:3:add_sector,seamark:light:4:add_sector,seamark:light:5:add_sector"/>
+		<type tag="seamark:type" value="beacon_cardinal" minzoom="11" nameTags="seamark:name,seamark:light:character,seamark:light:add_sectors,seamark:light:1:add_sector,seamark:light:2:add_sector,seamark:light:3:add_sector,seamark:light:4:add_sector,seamark:light:5:add_sector"/>
+		<type tag="seamark:type" value="beacon_isolated_danger" minzoom="11" nameTags="seamark:name,seamark:light:character,seamark:light:add_sectors,seamark:light:1:add_sector,seamark:light:2:add_sector,seamark:light:3:add_sector,seamark:light:4:add_sector,seamark:light:5:add_sector"/>
+		<type tag="seamark:type" value="beacon_safe_water" minzoom="11" nameTags="seamark:name,seamark:light:character,seamark:light:add_sectors,seamark:light:1:add_sector,seamark:light:2:add_sector,seamark:light:3:add_sector,seamark:light:4:add_sector,seamark:light:5:add_sector"/>
+		<type tag="seamark:type" value="beacon_special_purpose" minzoom="11" nameTags="seamark:name,seamark:light:character,seamark:light:add_sectors,seamark:light:1:add_sector,seamark:light:2:add_sector,seamark:light:3:add_sector,seamark:light:4:add_sector,seamark:light:5:add_sector"/>
 		<type tag="seamark:type" value="cable_area" minzoom="10" nameTags="seamark:name"/>
 		<type tag="seamark:type" value="cable_overhead" minzoom="12" nameTags="seamark:name,seamark:cable_overhead:vertical_clearance_safe"/>
 		<type tag="seamark:type" value="cable_submarine" minzoom="10" nameTags="seamark:name"/>
@@ -6800,17 +6852,17 @@
 		<type tag="seamark:type" value="gate" minzoom="10" nameTags="seamark:name"/>
 		<type tag="seamark:type" value="fairway" minzoom="10" nameTags="seamark:name"/>
 		<entity_convert pattern="tag_transform" from_tag="waterway" from_value="fairway" to_tag1="seamark:type" to_value1="fairway" routing="no"/>
-		<type tag="seamark:type" value="fog_signal" minzoom="11" nameTags="seamark:name"/>
+		<type tag="seamark:type" value="fog_signal" minzoom="11" nameTags="seamark:name,seamark:light:character"/> <!-- INT-1 R Sections: Fog Signal nameTags integrated in seamark:light:character -->
 		<type tag="seamark:type" value="fishing_facility" minzoom="11" nameTags="seamark:name"/>
 		<type tag="seamark:type" value="fortified_structure" minzoom="11" nameTags="seamark:name"/>
 		<type tag="seamark:type" value="harbour" minzoom="9" nameTags="name,seamark:name"/>
 		<type tag="seamark:type" value="hulk" minzoom="13" nameTags="seamark:name"/>
 		<type tag="seamark:type" value="inshore_traffic_zone" minzoom="10" nameTags="seamark:name"/>
-		<type tag="seamark:type" value="landmark" minzoom="10" nameTags="seamark:name"/>
-		<type tag="seamark:type" value="light_major" minzoom="10" nameTags="seamark:name,seamark:light:character"/>
-		<type tag="seamark:type" value="light_minor" minzoom="11" nameTags="seamark:name,seamark:light:character"/>
-		<type tag="seamark:type" value="light_float" minzoom="11" nameTags="seamark:name,seamark:light:character"/>
-		<type tag="seamark:type" value="light_vessel" minzoom="11" nameTags="seamark:name,seamark:light:character"/>
+		<type tag="seamark:type" value="landmark" minzoom="10" nameTags="seamark:name,name,seamark:light:character,seamark:light:add_sectors,seamark:light:1:add_sector,seamark:light:2:add_sector,seamark:light:3:add_sector,seamark:light:4:add_sector,seamark:light:5:add_sector"/> <!-- INT-1 P Section: Lights, nameTags -->
+		<type tag="seamark:type" value="light_major" minzoom="10" nameTags="seamark:name,name,seamark:light:character,seamark:light:add_sectors,seamark:light:1:add_sector,seamark:light:2:add_sector,seamark:light:3:add_sector,seamark:light:4:add_sector,seamark:light:5:add_sector"/> <!-- INT-1 P Section: Lights, nameTags -->
+		<type tag="seamark:type" value="light_minor" minzoom="11" nameTags="seamark:name,name,seamark:light:character,seamark:light:add_sectors,seamark:light:1:add_sector,seamark:light:2:add_sector,seamark:light:3:add_sector,seamark:light:4:add_sector,seamark:light:5:add_sector"/> <!-- INT-1 P Section: Lights, nameTags -->
+		<type tag="seamark:type" value="light_float" minzoom="11" nameTags="seamark:name,name,seamark:light:character,seamark:light:add_sectors,seamark:light:1:add_sector,seamark:light:2:add_sector,seamark:light:3:add_sector,seamark:light:4:add_sector,seamark:light:5:add_sector"/> <!-- INT-1 P Section: Lights, nameTags -->
+		<type tag="seamark:type" value="light_vessel" minzoom="11" nameTags="seamark:name,name,seamark:light:character,seamark:light:add_sectors,seamark:light:1:add_sector,seamark:light:2:add_sector,seamark:light:3:add_sector,seamark:light:4:add_sector,seamark:light:5:add_sector"/> <!-- INT-1 P Section: Lights, nameTags -->
 		<type tag="seamark:type" value="lock_basin" minzoom="10" nameTags="seamark:name"/>
 		<type tag="seamark:type" value="lock_basin_part" minzoom="10" nameTags="seamark:name"/>
 		<type tag="lock" value="yes" minzoom="11" nameTags="lock_name,lock_ref"/>
@@ -6835,13 +6887,13 @@
 		<type tag="seamark:type" value="pile" minzoom="11" nameTags="seamark:name"/>
 		<type tag="seamark:type" value="pipeline_area" minzoom="11" nameTags="seamark:name"/>
 		<type tag="seamark:type" value="pipeline_submarine" minzoom="11" nameTags="seamark:name"/>
-		<type tag="seamark:type" value="platform" minzoom="11" nameTags="seamark:name"/>
+		<!-- <type tag="seamark:type" value="platform" minzoom="11" nameTags="seamark:name,name,seamark:light:character,seamark:light:add_sectors,seamark:light:1:add_sector,seamark:light:2:add_sector,seamark:light:3:add_sector,seamark:light:4:add_sector,seamark:light:5:add_sector"/> INT-1 P Section: Lights, nameTags, moved before aeroway=helipad and power=substation for visibility in nautical render -->
 		<type tag="seamark:type" value="precautionary_area" minzoom="10" nameTags="seamark:name"/>
 		<type tag="seamark:type" value="production_area" minzoom="10" nameTags="seamark:name"/>
 		<type tag="seamark:type" value="pylon" minzoom="10" nameTags="seamark:name"/>
 		<type tag="seamark:type" value="radar_reflector" minzoom="15" nameTags="seamark:name"/>
 		<type tag="seamark:type" value="radar_station" minzoom="11" nameTags="seamark:name"/>
-		<type tag="seamark:type" value="radar_transponder" minzoom="11" nameTags="seamark:name"/>
+		<type tag="seamark:type" value="radar_transponder" minzoom="11" nameTags="seamark:name,name,seamark:light:character"/> <!-- INT-1 S Section: Radar, nameTags integrated in seamark:light:character -->
 		<type tag="seamark:type" value="radio_station" minzoom="11" nameTags="seamark:name"/>
 		<type tag="seamark:type" value="recommended_track" minzoom="10" nameTags="seamark:name"/>
 		<type tag="seamark:type" value="recommended_traffic_lane" minzoom="10" nameTags="seamark:name"/>
@@ -6916,10 +6968,13 @@
 		<entity_convert pattern="tag_transform" from_tag="seamark:daymark:colour_pattern" to_tag1="seamark:topmark:colour_pattern"/>
 		<type tag="seamark:light_float:colour" minzoom="11" additional="true"/>
 		<type tag="seamark:light_float:colour_pattern" minzoom="11" additional="true"/>
+		
+		<!-- INT-1 P Section: Lights, colours-->
 		<type tag="seamark:light:colour" minzoom="11" additional="true"/>
 		<entity_convert pattern="tag_transform" from_tag="seamark:light:1:colour" to_tag1="seamark:light:colour"/>
 		<type tag="seamark:light:2:colour" minzoom="11" additional="true"/>
 		<type tag="seamark:light:3:colour" minzoom="11" additional="true"/>
+		
 		<type tag="seamark:fog_signal:category" minzoom="11" additional="true"/>
 		<type tag="seamark:platform:category" minzoom="11" additional="true"/>
 		<type tag="seamark:radar_reflector" minzoom="11" additional="true"/>
@@ -7064,7 +7119,7 @@
 		
 		<!-- INT-1 J14, J15 sand_waves, spring -->
 		<type tag="seamark:type" value="sand_waves" minzoom="11" /> 
-		<type tag="seamark:type" value="spring" minzoom="11" /> 
+		<type tag="seamark:type" value="spring" minzoom="11" />
 	</category>
 
 	<category name="seamarks" nameTags="seamark:name,ref" >
@@ -7377,7 +7432,7 @@
 		<routing_type tag="maxheight" mode="amend" base="true" type="length"/>
 		<routing_type tag="maxlength" mode="amend" base="true" type="length"/>
 		<routing_type tag="maxweight" mode="amend" base="true" type="weight"/>
-		<routing_type tag="maxweightrating" mode="amend" base="true" type="weight"/>
+		<routing_type tag="maxweightrating" mode="amend" base="true" type="weight"/>																	  
 		<routing_type tag="maxwidth" mode="amend" base="true" type="length"/>
 		<routing_type tag="maxaxleload" mode="amend" base="true" type="weight"/>
 		<routing_type tag="width" mode="amend" base="true" type="length"/>

--- a/rendering_styles/nautical.render.xml
+++ b/rendering_styles/nautical.render.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<renderingStyle name="nautical" depends="" defaultColor="#fddb8f" version="1.2"> 
-<!-- Version 1.2, 2022-05-30 adding nautical rendering for seamarks in INT-1 section K Obstructions and J Seabed, Weed, Seagrass -->
+<renderingStyle name="nautical" depends="" defaultColor="#fddb8f" version="1.3"> 
+<!-- Version 1.3, 2023-05-03 adding nautical rendering for seamarks in INT-1 P, R, S sections Lights, Fog Signals, Radar -->
 
 <!--	<renderingProperty attr="appMode" name="Rendering mode" description="Map optimization for respective User Profile"
 		type="string" possibleValues="browse map,car,bicycle,pedestrian"/>-->
@@ -10,7 +10,8 @@
 		type="boolean" possibleValues="" category="hide"/>-->
 	<renderingProperty attr="whiteWaterSports" name="Whitewater sports" description="Whitewater sports"
 		type="boolean" possibleValues="" category="routes"/>
-	<renderingProperty attr="seabedDetail" name="Seabed detail" description="Additional text information on seabed surface_qualification, combined surface types, category and taxon of weed or seagrass" category="details" type="string" defaultValue="" defaultValueDescription="simple" possibleValues="category,all,omit" /> <!-- used in INT-1 J Section: Nature of the Seabed -->  
+	<renderingProperty attr="lightDetail" name="Light detail" description="Default: seamark name (light character.group.period), select additional information on sectors 1 to 3 or sector 1,2,3,4,5 light character" category="details" type="string" defaultValue="" defaultValueDescription="simple" possibleValues="sectors,sector1,sector2,sector3,sector4,sector5,small,name_only,omit" /> <!-- used in INT-1 P, R, S Sections: Lights, Fog Signals, Radar -->
+	<renderingProperty attr="seabedDetail" name="Seabed detail" description="Additional text information on seabed surface_qualification, combined surface types, category and taxon of weed or seagrass" category="details" type="string" defaultValue="" defaultValueDescription="simple" possibleValues="category,all,omit" /> <!-- used in INT-1 J Section: Nature of the Seabed -->
 	<renderingProperty attr="currentTrackColor" name="Current GPX color" description="Color of the currently recording track"
 		type="string" possibleValues="red,orange,yellow,lightgreen,green,lightblue,blue,purple,translucent_red,translucent_orange,translucent_yellow,translucent_lightgreen,translucent_green,translucent_lightblue,translucent_blue,translucent_purple" defaultValueDescription="default"/>
 	<renderingProperty attr="currentTrackWidth" name="Current GPX width" description="Width of the currently recording track"
@@ -647,6 +648,7 @@
 			<case tag="seamark:type" value="rock"/>
 			<case tag="seamark:type" value="obstruction" order="4"/>
 			<case tag="seamark" value=""/>
+			<case tag="seamark" value="light"/> <!-- for INT-1 P -->											   
 			<case tag="seamark:type" value="fishing_facility"/>
 			<case tag="seamark:type" value="seabed_area" order="5"/>
 			<case tag="seamark:type" value="weed" order="5"/>
@@ -1393,8 +1395,8 @@
 					<case minzoom="13" tag="landuse" value="quarry"/>
 				</switch>
 				<case minzoom="17" textSize="12" tag="man_made" value="windmill"/>
-				<case minzoom="17" tag="man_made" value="tower"/>
-				<case minzoom="17" tag="man_made" value="mast"/>
+				<!-- <case minzoom="17" tag="man_made" value="tower"/> nameTag applied for seamark in INT-1 P Section Lights -->
+				<!-- <case minzoom="17" tag="man_made" value="mast"/> nameTag applied for seamark in INT-1 P Section Lights -->
 				<case minzoom="17" tag="man_made" value="monitoring_station"/>
 				<case minzoom="16" tag="man_made" value="petroleum_well"/>
 				<case minzoom="18" tag="man_made" value="crane"/>
@@ -1515,24 +1517,37 @@
 
 			<!-- Seamarks -->
 			<switch minzoom="11" textColor="#0400ab" textHaloColor="#5576cbea" textHaloRadius="2">
+				<!-- INT-1 P, R, S Sections: Lights, Fog Signals, Radar. seamark:name and seamark:light tags as nameTag2 (as far as possible today). The OSMAND display was validated at Texel, Den Helder, Helgoland, Elbe and Weser Approaches, Rotterdam, Cherbourg.
+				default: 		name (light:character.group.period[in seconds].fog_signal:category.group.period[in seconds].radar_transponder:category.group) 
+								e.g. T6-VH 1 (Fl.2+1.10)= Buoy T6-VH 1 with light flashes in groups of 2 and 1. This is repeated after 10 seconds.
+								name (light:character.period[in seconds]) or name (light:character.group), with only one number element. 
+								sectors: 		name (sector1start[bearing in degree]-end[bearing in degree]-colour-sector2 ... -sector3 ... -lightcategory)
+				sector1...5:	name (sector1character.group.colour.period[in seconds].start[bearing in degree].end[bearing in degree].category[dircetional,upper].exhibition[night,fog,etc.].visibilitydistance[in nautical miles])
+				Note1: In the default, a single number remains ambiguous, because the group brackets and the unit cannot be added to the nameTag2, so far. 
+				Note2: The group tag is/cannot? be attributed correctly, e.g. for seamarks cardinal south.
+				More specific formatting, inclusion of colours and combination of text elements in the nameTags in OSMAND will require amendments for parsing of commands from rendering_types.xml and rendering styles (nautical.render.xml).
+				aiming at OSMAND text display according to IHO Chart INT-1 Section P: Lights and Section R Fog Signals, e.g. https://map.openseamap.org/?zoom=15&lon=4.79&lat=53.00 .
+				An appropriate graphical display of sector lights with coloured circle sections requires further development of code in OSMAND. Feedback welcome: josail @ gmx.de -->
+				
 				<switch nameTag="seamark:name" nameTag2="seamark:light:character">
+					<!-- empty nameTag="seamark:name" is filled with "." in rendering_types.xml in order to assure nameTag2 display. Check e.g. on buoy cardinal west: https://map.openseamap.org/?zoom=16&lon=8.170&lat=53.780 -->
 					<switch textItalic="true">
-						<case minzoom="15" tag="seamark:type" value="buoy_lateral"/>
-						<case minzoom="15" tag="seamark:type" value="buoy_cardinal"/>
-						<case minzoom="14" tag="seamark:type" value="buoy_isolated_danger"/>
-						<case minzoom="14" tag="seamark:type" value="buoy_safe_water"/>
-						<case minzoom="15" tag="seamark:type" value="buoy_special_purpose"/>
-						<case minzoom="15" tag="seamark:type" value="buoy_installation"/>
+						<case minzoom="14" tag="seamark:type" value="buoy_lateral"/>
+						<case minzoom="14" tag="seamark:type" value="buoy_cardinal"/>
+						<case minzoom="13" tag="seamark:type" value="buoy_isolated_danger"/>
+						<case minzoom="13" tag="seamark:type" value="buoy_safe_water"/>
+						<case minzoom="14" tag="seamark:type" value="buoy_special_purpose"/>
+						<case minzoom="14" tag="seamark:type" value="buoy_installation"/>
 					</switch>
-					<case minzoom="15" tag="seamark:type" value="beacon_lateral"/>
-					<case minzoom="15" tag="seamark:type" value="beacon_cardinal"/>
-					<case minzoom="14" tag="seamark:type" value="beacon_isolated_danger"/>
-					<case minzoom="14" tag="seamark:type" value="beacon_safe_water"/>
-					<case minzoom="15" tag="seamark:type" value="beacon_special_purpose"/>
+					<case minzoom="14" tag="seamark:type" value="beacon_lateral"/>
+					<case minzoom="14" tag="seamark:type" value="beacon_cardinal"/>
+					<case minzoom="13" tag="seamark:type" value="beacon_isolated_danger"/>
+					<case minzoom="13" tag="seamark:type" value="beacon_safe_water"/>
+					<case minzoom="14" tag="seamark:type" value="beacon_special_purpose"/>
 					<case minzoom="17" tag="seamark:type" value="rock"/>
 					<case minzoom="17" tag="seamark:type" value="wreck"/>
-					<case minzoom="15" tag="seamark:type" value="light_float"/>
-					<case minzoom="15" tag="seamark:type" value="light_vessel"/>
+					<case minzoom="14" tag="seamark:type" value="light_float"/>
+					<case minzoom="14" tag="seamark:type" value="light_vessel"/>
 					<case minzoom="17" tag="seamark:type" value="radar_reflector"/>
 					<case minzoom="17" tag="seamark:type" value="waterway_gauge"/>
 					<case minzoom="17" tag="seamark:type" value="notice" nameTag="seamark:notice:information"/>
@@ -1546,14 +1561,78 @@
 						<case minzoom="17" tag="seamark:type" value="gate"/>
 					</switch>
 					<apply textWrapWidth="19"/>
-					<apply_if engine_v1="false" textDy="7"/>
+					<apply_if engine_v1="false" textDy="-10"/> <!-- avoid large distance of nameTags due to light shield -->
+					<apply_if additional="seamark:light:colour" textDy="-16"/> <!-- avoid large distance of nameTags due to light shield -->
+					<!-- INT-1 P Section: Lights, lightDetail nameTag2 composed in rendering_types.xml -->
+					<apply_if lightDetail="sectors" nameTag2="seamark:light:add_sectors"/>
+					<apply_if lightDetail="sector1" nameTag2="seamark:light:1:add_sector"/>
+					<apply_if lightDetail="sector2" nameTag2="seamark:light:2:add_sector"/> 
+					<apply_if lightDetail="sector3" nameTag2="seamark:light:3:add_sector"/>
+					<apply_if lightDetail="sector4" nameTag2="seamark:light:4:add_sector"/> 
+					<apply_if lightDetail="sector5" nameTag2="seamark:light:5:add_sector"/> 
+					<apply_if lightDetail="small" textSize="9" textColor="#bf0400ab"/> <!-- small and translucent dark blue for reduced impact -->
+					<apply_if lightDetail="name_only" nameTag2="$null"/>
+					<apply_if lightDetail="omit" disable="true"/>
 				</switch>
-			
+				
+				<switch> <!-- for big icons -->
+					<switch>
+						<case minzoom="11" tag="seamark:type" value="light_major" nameTag="seamark:name" nameTag2="seamark:light:character" textOrder="60"/>
+						<case minzoom="11" tag="seamark:type" value="light_major" nameTag="name" nameTag2="seamark:light:character" textOrder="60"/>
+						<case minzoom="12" tag="seamark:type" value="light_minor" nameTag2="seamark:light:character" textOrder="65"/>
+						<case minzoom="12" tag="man_made" value="mast" nameTag="seamark:name" nameTag2="seamark:light:character" textOrder="66"/>
+						<case minzoom="12" tag="man_made" value="mast" nameTag="name" nameTag2="seamark:light:character" textOrder="66"/>
+						<case minzoom="12" tag="man_made" value="tower" nameTag="name" nameTag2="seamark:light:character" textOrder="67"/>
+						<case minzoom="12" tag="man_made" value="tower" nameTag="seamark:name" nameTag2="seamark:light:character" textOrder="67"/>
+						<case minzoom="11" tag="seamark:type" value="landmark" nameTag="seamark:name" nameTag2="seamark:light:character" textOrder="68"/>
+						<case minzoom="11" tag="seamark:type" value="landmark" nameTag="name" nameTag2="seamark:light:character" textOrder="68"/>
+						<case minzoom="11" tag="seamark:type" value="platform" nameTag="seamark:name" nameTag2="seamark:light:character" textOrder="69"/>
+						<case minzoom="11" tag="seamark:type" value="platform" nameTag="name" nameTag2="seamark:light:character" textOrder="69"/>
+						<case minzoom="11" tag="man_made" value="offshore_platform"  nameTag="name" nameTag2="seamark:light:character" textOrder="69"/>
+						<case minzoom="11" tag="man_made" value="offshore_platform"  nameTag="seamark:name" nameTag2="seamark:light:character" textOrder="69"/>
+						<case minzoom="11" tag="man_made" value="lighthouse" nameTag="name" nameTag2="seamark:light:character" textOrder="70"/>
+						<case minzoom="11" tag="man_made" value="lighthouse" nameTag="seamark:name" nameTag2="seamark:light:character" textOrder="70"/>
+						<!-- INT-1 P Section: Lights, lightDetail nameTag2 composed in rendering_types.xml -->
+						<apply_if lightDetail="sectors" nameTag2="seamark:light:add_sectors"/>
+						<apply_if lightDetail="sector1" nameTag2="seamark:light:1:add_sector"/>
+						<apply_if lightDetail="sector2" nameTag2="seamark:light:2:add_sector"/>
+						<apply_if lightDetail="sector3" nameTag2="seamark:light:3:add_sector"/>
+						<apply_if lightDetail="sector4" nameTag2="seamark:light:4:add_sector"/>
+						<apply_if lightDetail="sector5" nameTag2="seamark:light:5:add_sector"/>
+						<apply_if lightDetail="small" textSize="9" textColor="#bf0400ab"/> <!-- small and translucent dark blue for reduced visual impact -->
+						<apply_if lightDetail="name_only" nameTag2="$null"/>
+						<apply_if lightDetail="omit" disable="true"/>
+						<apply textDy="-10"/>						
+					</switch>
+					<case minzoom="12" tag="seamark:type" value="fog_signal" textOrder="70"/>
+					<case minzoom="12" tag="seamark:type" value="radar_transponder" textOrder="71"/> <!-- INT-1 S Section Radar, Ramark, Racon -->
+					<case minzoom="12" tag="seamark:type" value="radio_station" textOrder="71"/> 
+					<apply_if lightDetail="" additional="seamark:radio_station:category" value="ais" nameTag2="seamark:radio_station:category"/> <!-- INT-1 S Section Radar, AIS -->
+					<apply_if lightDetail="" additional="seamark:radio_station:category" value="v-ais" nameTag2="seamark:radio_station:category"/> <!-- INT-1 S Section Radar, V-AIS -->
+					<case minzoom="12" tag="seamark:type" value="radar_station" textOrder="71"/>
+					<case minzoom="17" tag="seamark:type" value="signal_station_traffic" nameTag="seamark:name" nameTag2="seamark:signal_station_traffic:category_name" textOrder="71"/>
+					<case minzoom="17" tag="seamark:type" value="signal_station_traffic" nameTag="seamark:signal_station_traffic:category_name" textOrder="71"/>
+					<case minzoom="17" tag="seamark:type" value="signal_station_warning" nameTag="seamark:name" nameTag2="seamark:signal_station_warning:category_name" textOrder="71"/>
+					<case minzoom="17" tag="seamark:type" value="signal_station_warning" nameTag="seamark:signal_station_warning:category_name" textOrder="71"/>
+<!--					<apply_if engine_v1="true" textDy="19"/>-->
+<!--					<apply_if engine_v1="false" textDy="0"/>-->
+					<apply_if legend="true" textDy="-10"/>
+					<apply_if additional="seamark:light:colour" textDy="-28"/> <!-- avoid very large distance of nameTags due to major/minor_light shields -->
+					<apply_if additional="seamark:light:1:colour" textDy="-28"/> <!-- avoid very large distance of nameTags due to major/minor_light shields -->
+					<apply_if minzoom="11" maxzoom="13" tag="seamark:type" value="platform" textDy="-10"/>
+					<apply_if minzoom="11" maxzoom="13" tag="man_made" value="offshore_platform" textDy="-10"/>
+					<apply_if minzoom="11" maxzoom="11" tag="man_made" value="lighthouse" additional="seamark:light:colour" textDy="-14"/>
+					<apply_if minzoom="11" maxzoom="11" tag="man_made" value="lighthouse" additional="seamark:light:1:colour" textDy="-14"/>
+					<apply_if minzoom="11" tag="seamark:type:landmark:category" value="tower" additional="seamark:light:colour" textDy="-14"/>
+					<apply_if minzoom="11" tag="seamark:type:landmark:category" value="tower" additional="seamark:light:1:colour" textDy="-14"/>
+					<apply_if minzoom="11" tag="seamark:type" value="landmark" additional="seamark:light:colour" textDy="-14"/>
+					<apply_if minzoom="11" tag="seamark:type" value="landmark" additional="seamark:light:1:colour" textDy="-14"/>
+				</switch>
+				
 				<!-- INT-1 J Section: Nature of the Seabed -->
 				<!-- INT-1 J1 to J12 Types of Seabed, OsmAnd nautical.render.xml renderingProperty options for seabedDetail nameTag: ""(default)=""= 1st surface type as letters according to INT-1 J1-J13, seabed_letters are generated in obf according to rendering_types.xml, nameTag2: "category"=surface tag in seamark_category, "all"=surface qualification and type included in seabed_surface_all, seagrass and weed in seabed_taxon_all including category, genus and taxon, "omit"=no display -->
 				<!-- Tested 2022-05-30 together with version 1.1 of rendering_types.xml, e.g.  http://osmand.net/go.html?lat=36.65161&lon=25.37019&z=16, feedback welcome: josail @ gmx.de -->
 				<switch minzoom="16" textWrapWidth="20" textOrder="14" textDy="10" textColor="#0400ab" textItalic="true" textHaloColor="$waterwayColor" textHaloRadius="2">
-
 					<!-- seabedDetail="default" or "simple" display with letters only -->
 					<switch seabedDetail="">
 						<case tag="seamark:type" value="seabed_area" nameTag="seabed_surface_1"/>
@@ -1576,38 +1655,16 @@
 						<case tag="seamark:type" value="weed"/>
 						<case tag="seamark:type" value="seagrass"/>
 					</switch>
-			
 					<!-- omit seabedDetail of seamark -->
 					<switch seabedDetail="omit">
 						<case tag="seamark:type" maxzoom="18" value="seabed_area" disable="true"/>
 						<case tag="seamark:type" minzoom="19" value="seabed_area" nameTag="seabed_surface_1"/><!-- in case SeabedDetail="omit" text is omitted, but a simplified seabed letter display at very high zoom level is maintained-->	
 						<case tag="seamark:type" value="weed" disable="true"/>
 						<case tag="seamark:type" value="seagrass" disable="true"/>
-					</switch>
-					
+					</switch>					
 					<apply_if nightMode="true" textColor="#e4d0e3"/>
 				</switch>
 
-				<switch> <!-- for big icons -->
-					<switch>
-						<case minzoom="11" tag="seamark:type" value="light_major" nameTag="name" nameTag2="seamark:light:character" textOrder="60"/>
-						<case minzoom="11" tag="seamark:type" value="light_major" nameTag="seamark:name" nameTag2="seamark:light:character" textOrder="60"/>
-						<case minzoom="13" tag="seamark:type" value="light_minor" textOrder="65"/>
-						<case minzoom="13" tag="man_made" value="lighthouse" textOrder="70"/>
-					</switch>
-					<case minzoom="12" tag="seamark:type" value="fog_signal" textOrder="70"/>
-					<case minzoom="12" tag="seamark:type" value="radar_transponder" textOrder="71"/>
-					<case minzoom="12" tag="seamark:type" value="radio_station" textOrder="71"/>
-					<case minzoom="12" tag="seamark:type" value="radar_station" textOrder="71"/>
-					<case minzoom="17" tag="seamark:type" value="signal_station_traffic" nameTag="seamark:name" nameTag2="seamark:signal_station_traffic:category_name" textOrder="71"/>
-					<case minzoom="17" tag="seamark:type" value="signal_station_traffic" nameTag="seamark:signal_station_traffic:category_name" textOrder="71"/>
-					<case minzoom="17" tag="seamark:type" value="signal_station_warning" nameTag="seamark:name" nameTag2="seamark:signal_station_warning:category_name" textOrder="71"/>
-					<case minzoom="17" tag="seamark:type" value="signal_station_warning" nameTag="seamark:signal_station_warning:category_name" textOrder="71"/>
-					<case minzoom="12" tag="seamark:type" value="platform" textOrder="72" textWrapWidth="25"/>
-<!--					<apply_if engine_v1="true" textDy="19"/>-->
-<!--					<apply_if engine_v1="false" textDy="-10"/>-->
-					<apply_if legend="true" textDy="0"/>
-				</switch>
 				<switch textBold="true">
 					<case minzoom="15" tag="leisure" value="marina" textOrder="6" textHaloColor="#88d4ecff"/>
 					<switch minzoom="10" tag="seamark:type" value="harbour" textOrder="52" textHaloColor="#88d4ecff">
@@ -1622,6 +1679,7 @@
 <!--					<apply_if engine_v1="true" textDy="15"/>-->
 				</switch>
 				<apply>
+					<case lightDetail="small"/> <!-- no change of textSize when already defined before -->
 					<case maxzoom="12" textSize="12"/>
 					<case maxzoom="14" textSize="12"/>
 					<case minzoom="15" textSize="13"/>
@@ -1777,7 +1835,7 @@
 	<!-- Seamarks -->
 		<switch>
 			<switch>
-				<!-- Buoys -->
+				<!-- INT-1 Q Section: Buoys -->
 				<switch iconVisibleSize="9" intersectionSizeFactor="0.6" iconOrder="100" icon_shift_py="-0.8">
 					<case minzoom="12" tag="seamark:type" value="buoy_lateral" icon="seamark_buoy_pillar">
 						<case additional="seamark:buoy_lateral:colour=red" icon="seamark_buoy_red_pillar">
@@ -2024,7 +2082,7 @@
 					</apply>
 				</switch>
 
-				<!-- Beacons -->
+				<!-- INT-1 Q Section: Beacons -->
 				<switch iconVisibleSize="9" intersectionSizeFactor="0.6" iconOrder="100" icon_shift_py="-0.8">
 					<case minzoom="12" tag="seamark:type" value="beacon_lateral" icon="seamark_beacon_pile">
 						<switch>
@@ -2247,7 +2305,7 @@
 					<case additional="seamark:light:2:colour" shield="light_violet_shield"/>
 				</apply>
 			</switch>
-			<case minzoom="12" maxzoom="13" tag="seamark:type" value="platform" icon="seamark_platform_small" iconVisibleSize="14" intersectionSizeFactor="0.9"/>
+			<case minzoom="11" maxzoom="13" tag="seamark:type" value="platform" icon="seamark_platform_small" iconVisibleSize="14" intersectionSizeFactor="0.9"/>
 			<switch>
 				<switch>
 					<case minzoom="9" maxzoom="10" tag="seamark:type" value="light_major" icon="seamark_light_major_small" iconOrder="60"/>
@@ -2311,6 +2369,7 @@
 						<case additional="seamark:topmark:shape=sphere" icon__1="seamark_topmark_vertical_black_sphere_big"/>
 						<case additional="seamark:topmark:shape=x-shape" icon__1="seamark_topmark_vertical_yellow_xshape_big"/>
 					</apply>
+					<!-- INT-1 S Section: Radar, Radio -->
 					<apply_if additional="seamark:radio_station:category" icon_4="seamark_radar_transponder_additional_center_big" iconVisibleSize="20" intersectionSizeFactor="0.6">
 						<switch>
 							<case additional="seamark:radio_station:category=ais"/>
@@ -2342,7 +2401,7 @@
 						<apply_if nightMode="true" icon_4="seamark_radar_transponder_additional_center_big_night"/>
 					</apply_if>
 				</switch>
-				<apply>
+				<apply> <!-- INT-1 P Section: Lights -->
 					<case additional="seamark:light:colour=white" shield="light_white_center_shield"/>
 					<case additional="seamark:light:colour=red" shield="light_red_center_shield"/>
 					<case additional="seamark:light:colour=green" shield="light_green_center_shield"/>

--- a/rendering_styles/nautical.render.xml
+++ b/rendering_styles/nautical.render.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <renderingStyle name="nautical" depends="" defaultColor="#fddb8f" version="1.3"> 
-<!-- Version 1.3, 2023-05-03 adding nautical rendering for seamarks in INT-1 P, R, S sections Lights, Fog Signals, Radar -->
+<!-- Version 1.3, 2023-05-07 adding nautical rendering for seamarks in INT-1 P, R, S sections Lights, Fog Signals, Radar -->
 
 <!--	<renderingProperty attr="appMode" name="Rendering mode" description="Map optimization for respective User Profile"
 		type="string" possibleValues="browse map,car,bicycle,pedestrian"/>-->
@@ -2305,7 +2305,6 @@
 					<case additional="seamark:light:2:colour" shield="light_violet_shield"/>
 				</apply>
 			</switch>
-			<case minzoom="11" maxzoom="13" tag="seamark:type" value="platform" icon="seamark_platform_small" iconVisibleSize="14" intersectionSizeFactor="0.9"/>
 			<switch>
 				<switch>
 					<case minzoom="9" maxzoom="10" tag="seamark:type" value="light_major" icon="seamark_light_major_small" iconOrder="60"/>
@@ -2331,6 +2330,7 @@
 						</apply_if>
 						<apply_if additional="seamark:radar_station:category=coast" icon_5="seamark_radar_station_coast_additional"/>
 					</case>
+					<case minzoom="11" maxzoom="13" tag="seamark:type" value="platform" icon="seamark_platform_small" iconVisibleSize="14" intersectionSizeFactor="0.9"/>
 					<case minzoom="14" tag="seamark:type" value="platform" icon="seamark_platform" iconVisibleSize="20" intersectionSizeFactor="0.7" iconOrder="72">
 						<apply_if additional="seamark:platform:category=production" icon_3="seamark_platform_production_additional"/>
 						<apply_if additional="seamark:platform:category=oil" icon_3="seamark_platform_production_additional"/>


### PR DESCRIPTION
Adding detail to the text display in nautical rendering for seamarks according to **[INT-1 section P](https://wiki.openstreetmap.org/wiki/Seamarks/INT-1_Section_P) on [Lights](https://wiki.openstreetmap.org/wiki/Seamarks/Lights), [R Fog Signals](https://wiki.openstreetmap.org/wiki/Seamarks/INT-1_Section_R) and [S Radar](https://wiki.openstreetmap.org/wiki/Seamarks/INT-1_Section_S)**. This is **addressing part 1 of https://github.com/osmandapp/OsmAnd/issues/16894**, as far as possible today.

Information for the identification of navigational aids from their light character is included in the OpenStreetMap tags for **seamark:light (character, group, period), seamark:fog_signal and seamark:radar_transponder**. These are compiled to the nameTag2 seamark:light:character during the creation of the OBF binary map data. This is implemented as amendment of the rendering_types.xml definitions in the relevant section of seamarks.

OSMAND nautical chart and the nautical.render.xml style is amended accordingly to display the detail on the light characters. 

Display1 - Texel nautical render of light character details in nameTag2 displayed in brackets
![Display1](https://user-images.githubusercontent.com/93162192/236059039-ee539f2e-1626-46f1-84de-d45e1c1256ae.png)

lightDetail=[default]: 
name (light:character.group.period[in seconds].
fog_signal:category.group.period[in seconds].
radar_transponder:category.group) 
e.g. 

_T6-VH 1 (Fl.2+1.10)_ 

denoting buoy T6-VH 1 with light flashes in groups of 2 and 1. This pattern of light flashes is repeated every 10 seconds.
Denotation according to INT-1 standard would more precisely read as in https://map.openseamap.org/?zoom=15&lon=4.79&lat=53.00 integrating the letter "R" for red light colour:

**_T6-VH 1_**
**_Fl(2+1)R.10s_**

The new OSMAND nameTag2 display was thoroughly **validated** at Texel (see example Display 1 above), Den Helder, Helgoland, Elbe and Weser Approaches, Rotterdam and Cherbourg (see examples Displays 2 and 3 below).

Display2 - Cherbourg nautical render with default for lightDetail 
![Display2](https://user-images.githubusercontent.com/93162192/236059083-4b297d2e-0aa3-407f-9f54-0f14f88dfed0.png) 

In the **Detail options** convenient level of lightDetail of the nameTag2 text display can be selected for the OSMAND nautical chart.

These lightDetail options includes access to **text information on multiple light:1, light:2, etc. sections** of one single seamark. 

lightDetail=**sector1...5**:	
name (sector1character.group.colour.period[in seconds].
start[bearing in degree].end[bearing in degree].
category[dircetional,upper].exhibition[night,fog,etc.].
visibilitydistance[in nautical miles])

This is especially relevant for lights shown with different colours or characters in different sectors of the bearing, leading lights and direction lights.

lightDetail=**sectors**: 
name (sector1start[bearing in degree]-end[bearing in degree]-colour-
sector2 ... -sector3 ... -lightcategory)

Note that the information for each light sector (up to 3 are displayed jointly) starts with two numbers indicating clockwise the start and end of the light sector as bearing towards the light position in degrees.

Display3 - Cherbourg nautical render with lightDetail=sectors 
![Display3](https://user-images.githubusercontent.com/93162192/236059092-481e8c10-1d26-4d87-9be1-938b2d82db82.png)

In comparison to the international INT-1 standard for nautical charts and display of light information in the OpenSeaMap, it is obvious, that an additional graphical display of the sectors would allow for much easier interpretation of sector lights, e.g.: 

Display4 - Cherbourg display in OpenSeaMap according to INT-1 standard
![Display4](https://user-images.githubusercontent.com/93162192/236059105-2f7955de-fcac-4700-a5ac-4be8c7c53a16.png)
https://map.openseamap.org/?zoom=14&lon=-1.61625&lat=49.66348

**Additional remarks:**

**Note1:** 
In the default display of the light character, a single number remains ambiguous, because the group brackets and the inclusion of additional letters for the right unit cannot be added to the nameTag2, so far: 
Denotation of a Minor Light in the centre of the harbour of Cherbourg 

(Oc.4)

could be interpreted either as
(light:character.period[in seconds]) i.e. one occulting every 4 seconds or as
(light:character.group), i.e. as a repeated group of 4 occultings
This can be clarified as red light occulting once every 4 seconds by a correct and complete denotation according to INT-1 as

**Oc.R.4s9m7M**

where
9m denotes the light elevation in meters
7M denotes the light range in nautical miles

**Note2:** 
The group tag is/cannot? be attributed correctly, e. g. for seamarks cardinal south, e. g. cardinal south buoy at Helgoland Düne:

_Düne-S (Q+LFl.6.15)_ 

should correctly be displayed according to INT-1 P Section and Q130.3 S as at
https://map.openseamap.org/?zoom=15&lon=7.93186&lat=54.15923:

**_Düne-S_** 
**_Q (6)+LFl.15s_**

**Further work** 
Next steps of develpment of nautical render should aim at OSMAND text display more precisely according to IHO standard of Chart INT-1 Section P Lights, Section R Fog Signals and Section S Radar. Find a pdf version of INT-1 here https://www.nauticalcharts.noaa.gov/publications/docs/us-chart-1/ChartNo1.pdf

**More specific formatting**, inclusion of colours and combination **of text elements** in the nameTags in OSMAND will require amendments for parsing of commands from rendering_types.xml and rendering styles (nautical.render.xml). Especially the 
a. addtion of letters for the units, 
b. brackets around the group numbers, 
c. selected positioning of "." as a separation mark, 
d. bold text for seamark:name of Buoys and Beacons in nameTag and 
e. display of two lines of text from nameTags, i.e. a linefeed between nameTag and nameTag2
can not be implemented correctly today.

The appropriate **graphical display** of sector lights according to INT-1 with **coloured circle sections** requires further development of code in OSMAND. This would address part 2 of https://github.com/osmandapp/OsmAnd/issues/16894.

Feedback welcome: josail (a) gmx.de