### PR TITLE
Soften height_obstacles to fix issue and speed up routing (Issue #18290)

### DIFF
--- a/routing/routing.xml
+++ b/routing/routing.xml
@@ -1433,24 +1433,24 @@
 					<select value="-1" t="highway" v="track"/>
 				</gt>
 				<gt value1="-25" value2=":incline">
-					<select value="180" t="osmand_highway_integrity_brouting_low" v="yes"/>
-					<select value="180" t="highway" v="path"/>
-					<select value="170" t="highway" v="track"/>
-				</gt>
-				<gt value1="-17" value2=":incline">
-					<select value="150" t="osmand_highway_integrity_brouting_low" v="yes"/>
-					<select value="150" t="highway" v="path"/>
-					<select value="140" t="highway" v="track"/>
-				</gt>
-				<gt value1="-9" value2=":incline">
 					<select value="30" t="osmand_highway_integrity_brouting_low" v="yes"/>
 					<select value="30" t="highway" v="path"/>
 					<select value="25" t="highway" v="track"/>
 				</gt>
+				<gt value1="-17" value2=":incline">
+					<select value="7.7" t="osmand_highway_integrity_brouting_low" v="yes"/>
+					<select value="7.7" t="highway" v="path"/>
+					<select value="6.4" t="highway" v="track"/>
+				</gt>
+				<gt value1="-9" value2=":incline">
+					<select value="3.0" t="osmand_highway_integrity_brouting_low" v="yes"/>
+					<select value="3.0" t="highway" v="path"/>
+					<select value="2.5" t="highway" v="track"/>
+				</gt>
 				<gt value1="-3" value2=":incline">
-					<select value="2" t="osmand_highway_integrity_brouting_low" v="yes"/>
-					<select value="2" t="highway" v="path"/>
-					<select value="2" t="highway" v="track"/>
+					<select value="1.8" t="osmand_highway_integrity_brouting_low" v="yes"/>
+					<select value="1.8" t="highway" v="path"/>
+					<select value="1.5" t="highway" v="track"/>
 				</gt>
 				<if param="relief_smoothness_factor_more_plains">
 					<gt value1="3" value2=":incline">


### PR DESCRIPTION
Formula proposed:

**percent (incline factor) * difficulty (factor) = xml_penalty_value**

1.03 * **1.5** = 1.5
1.09 * **2.5** = 2.5
1.17 * **5.5** = 6.4
1.25 * **20** = 25.0

highway=**path** gains penalty by 1.2 (**+20%**)

Actual final penalty formula is: diff (segment difference in meters) * xml_penalty_value (_formula kept as is_)

Tested (and fixed) on issue #18290

Tested on familiar terrain of Carpatian mountains (bicycle).

The issue: https://github.com/osmandapp/OsmAnd/issues/18290

Results:

base routing_cost=6800 (w/o height_obstacles)

Before proposed formula: routing_cost=115000 (16x), native lib hangs with timeout

**After proposed formula: routing_cost=22626 (3x), native lib seems OK**
