### PR TITLE
Properly render ways with piste:type=* containing ;-separated values

### DIFF
--- a/obf_creation/rendering_types.xml
+++ b/obf_creation/rendering_types.xml
@@ -2547,9 +2547,18 @@
 		<entity_convert pattern="tag_transform" from_tag="piste:type" from_value="downhill" if_not_tag1="piste:oneway" if_not_tag2="oneway" if_not_value2="no" if_not_tag3="aerialway" to_tag1="piste:type" to_value1="downhill" to_tag2="piste:oneway" to_value2="yes" apply_to="way"/>
 		<type tag="piste:type" value="nordic" minzoom="9" />
 		<type tag="piste:type" value="skitour" minzoom="9" relation="true"/>
+        <type tag="piste_hiking_allowed" additional="true" order="90" notosm="true"/>
 		<entity_convert pattern="tag_transform" from_tag="piste:type" from_value="skitour" if_not_tag1="piste:grooming" to_tag1="piste:type" to_value1="skitour" to_tag2="piste:grooming" to_value2="backcountry"/>
-		<entity_convert pattern="tag_transform" from_tag="piste:type" from_value="nordic;hike" to_tag1="piste:type" to_value1="nordic"/>
-		<entity_convert pattern="tag_transform" from_tag="piste:type" from_value="nordic;hiking" to_tag1="piste:type" to_value1="nordic"/>
+        <entity_convert pattern="tag_transform" from_tag="piste:type" from_value="nordic;hike" to_tag1="piste:type" to_value1="nordic" to_tag2="piste_hiking_allowed" to_value2="yes"/>
+        <entity_convert pattern="tag_transform" from_tag="piste:type" from_value="nordic;hiking" to_tag1="piste:type" to_value1="nordic" to_tag2="piste_hiking_allowed" to_value2="yes"/>
+		<entity_convert pattern="tag_transform" from_tag="piste:type" from_value="nordic;fatbike" to_tag1="piste:type" to_value1="nordic"/>
+		<entity_convert pattern="tag_transform" from_tag="piste:type" from_value="fatbike;nordic" to_tag1="piste:type" to_value1="nordic"/>
+        <entity_convert pattern="tag_transform" from_tag="piste:type" from_value="hike;fatbike;nordic" to_tag1="piste:type" to_value1="nordic" to_tag2="piste_hiking_allowed" to_value2="yes"/>
+        <entity_convert pattern="tag_transform" from_tag="piste:type" from_value="fatbike;nordic;hike" to_tag1="piste:type" to_value1="nordic" to_tag2="piste_hiking_allowed" to_value2="yes"/>
+        <entity_convert pattern="tag_transform" from_tag="piste:type" from_value="nordic;hike;fatbike" to_tag1="piste:type" to_value1="nordic" to_tag2="piste_hiking_allowed" to_value2="yes"/>
+        <entity_convert pattern="tag_transform" from_tag="piste:type" from_value="hike;nordic;fatbike" to_tag1="piste:type" to_value1="nordic" to_tag2="piste_hiking_allowed" to_value2="yes"/>
+        <entity_convert pattern="tag_transform" from_tag="piste:type" from_value="nordic;fatbike;hike" to_tag1="piste:type" to_value1="nordic" to_tag2="piste_hiking_allowed" to_value2="yes"/>
+        <entity_convert pattern="tag_transform" from_tag="piste:type" from_value="fatbike;hike;nordic" to_tag1="piste:type" to_value1="nordic" to_tag2="piste_hiking_allowed" to_value2="yes"/>
 		<entity_convert pattern="tag_transform" from_tag="piste:type" from_value="downhill;hike;nordic" to_tag1="piste:type" to_value1="downhill"/>
 		<entity_convert pattern="tag_transform" from_tag="piste:type" from_value="hike;nordic" to_tag1="piste:type" to_value1="nordic"/>
 		<entity_convert pattern="tag_transform" from_tag="piste:type" from_value="nordic; hike" to_tag1="piste:type" to_value1="nordic"/>
@@ -2563,6 +2572,8 @@
 
 		<type tag="piste:type" value="hike" minzoom="9" />
 		<entity_convert pattern="tag_transform" from_tag="piste:type" from_value="snowshoe" if_not_tag1="piste:grooming" to_tag1="piste:type" to_value1="hike" to_tag2="piste:grooming" to_value2="backcountry"/>
+        <entity_convert pattern="tag_transform" from_tag="piste:type" from_value="fatbike;hike" to_tag1="piste:type" to_value1="hike"/>
+        <entity_convert pattern="tag_transform" from_tag="piste:type" from_value="hike;fatbike" to_tag1="piste:type" to_value1="hike"/>
 		<type tag="piste:type" value="sleigh" minzoom="9"/>
 		<type tag="piste:type" value="sled" minzoom="9" />
 		<entity_convert pattern="tag_transform" from_tag="piste:type" from_value="sled" to_tag1="piste:type" to_value1="sled" to_tag2="piste:oneway" to_value2="yes"/>

--- a/rendering_styles/skimap.render.xml
+++ b/rendering_styles/skimap.render.xml
@@ -1259,6 +1259,13 @@
 					<case additional="piste:difficulty=extreme" color="$pisteDifficultyExtremeColor" color_2="$pisteGroomingExtremeColor" color_3="$pisteGroomingExtremeColor" color__2="$pisteGroomingExtremeColor" color_4="$pisteGroomingExtremeColor"/>
 				</switch>
 			</apply>
+			<apply_if additional="piste_hiking_allowed=yes" color_2="$pisteHikeDefaultColor" cap_2="ROUND">
+				<case maxzoom="12" pathEffect_2="1_11" strokeWidth="1:1" strokeWidth_2="2:2"/>
+				<case maxzoom="13" pathEffect_2="1_12" strokeWidth="1.5:1.5" strokeWidth_2="3:3"/>
+				<case maxzoom="14" pathEffect_2="1_14" strokeWidth="2:2" strokeWidth_2="4:4"/>
+				<case maxzoom="16" pathEffect_2="1_17" strokeWidth="2:2" strokeWidth_2="4:4"/>
+				<case minzoom="17" pathEffect_2="1_20" strokeWidth="3:3" strokeWidth_2="5:5"/>
+			</apply_if>
 		</switch>
 
 		<switch pisteRoutes="true">


### PR DESCRIPTION
For example, [this way](https://www.openstreetmap.org/way/158183374) mapped with the `piste:type=nordic;fatbike` tag was not displayed on the ski map, because the rendering config did not support this set of values. [OpenSnowMap](http://opensnowmap.org), however, displays it correctly, with both ski and fatbike icons.

The support is added here. Such ways are rendered as nordic ski tracks.

Also, if a piste is both `nordic` track and `hike`, we render caps on it like for `hike` pistes (see the screenshot).
<img width="1136" alt="Screenshot 2024-01-05 at 21 00 55" src="https://github.com/osmandapp/OsmAnd-resources/assets/16309982/aa293683-249b-4f45-a364-3b19e810dd99">
