### PR TITLE
Enable known unclassified dirt bike routes in OBF process

### DIFF
--- a/obf_creation/rendering_types.xml
+++ b/obf_creation/rendering_types.xml
@@ -2949,6 +2949,7 @@
 		<type tag="dirtbike:scale" value="4" minzoom="12" additional="true"/>
 		<type tag="dirtbike:scale" value="5" minzoom="12" additional="true"/>
 		<type tag="dirtbike:scale" value="6" minzoom="12" additional="true"/>
+		<type tag="dirtbike:scale" value="?" minzoom="12" additional="true"/>
 	</category>
 
 	<category name="horse_scale">


### PR DESCRIPTION
Enabling the `dirtbike:scale=?` tag in the OBF process will enable renderers to highlight known dirtbike routes that haven't yet been classified yet by difficulty level. This feature will help mappers prioritize enhancing these known paths and routes, improving the quality of local data for the community.

As updated in the latest OpenStreetMap wiki (Key:dirtbike:scale):

> Additionally, the dirtbike:scale=[?](https://wiki.openstreetmap.org/w/index.php?title=Tag:dirtbike:scale%3D%3F&action=edit&redlink=1) tag can be applied to routes known to accommodate dirt bikes when the precise difficulty level has not been determined.

Statistics reveal that 1,379 routes have been tagged with `dirtbike:scale=?`:
https://taginfo.openstreetmap.org/tags/dirtbike%3Ascale=%3F#overview