### PR TITLE
enable `obstacle=vegetation/fallen_tree` on OBF process for further rendering/routing support

### DIFF
--- a/obf_creation/rendering_types.xml
+++ b/obf_creation/rendering_types.xml
@@ -3649,6 +3649,11 @@
 
 	</category>
 
+	<category name="obstacle">
+		<type tag="obstacle" value="vegetation" minzoom="13" additional="true"/>
+		<type tag="obstacle" value="fallen_tree" minzoom="13" additional="true"/>
+	</category>
+
 	<category name="waterway">
 		<entity_convert pattern="tag_transform" from_tag="waterway" from_value="artificial" to_tag1="waterway" to_value1="drain"/>
 		<type tag="waterway" value="boatyard" minzoom="15" />
@@ -7285,6 +7290,7 @@
 		<routing_type tag="sac_scale" mode="amend"/>
 		<routing_type tag="mtb:scale" mode="amend"/>
 		<routing_type tag="dirtbike:scale" mode="amend"/>
+		<routing_type tag="obstacle" mode="amend"/>
 		<routing_type tag="class:bicycle" mode="amend"/>
 		<routing_type tag="class:bicycle:mtb" mode="amend"/>
 		<routing_type tag="footway" mode="amend"/>


### PR DESCRIPTION
`obstacle=*` is a valuable tag that identifies ways that are challenging to navigate due to environmental obstacles.

https://wiki.openstreetmap.org/wiki/Key:obstacle

_Note that individual obstacle nodes should be typically tagged as `barrier=*`, while longer obstructed sections can be marked on ways using `obstacle:*`._

Once enabled in the OBF creation process, renderers can highlight these obstructions, similar to disused or abandoned highways, providing users with warnings. Additionally, routing systems will be able to avoid these obstructed paths.

Some of the most common obstacles covered by this PR include:
<img width="1072" alt="Screen Shot 2567-05-09 at 15 14 02" src="https://github.com/osmandapp/OsmAnd-resources/assets/2485196/3fd0ab3b-e33d-43d9-a927-e2ebc58a99df">
