### PR TITLE
enable known unclassified mtb routes

### DIFF
--- a/obf_creation/rendering_types.xml
+++ b/obf_creation/rendering_types.xml
@@ -2387,6 +2387,7 @@
 		<type tag="mtb:scale" value="4" minzoom="11" additional="true" />
 		<type tag="mtb:scale" value="5" minzoom="11" additional="true" />
 		<type tag="mtb:scale" value="6" minzoom="11" additional="true" />
+		<type tag="mtb:scale" value="?" minzoom="11" additional="true" />
 		<type tag="incline" value="up" minzoom="11" additional="true" />
 		<type tag="incline" value="down" minzoom="11" additional="true" />
 		<entity_convert pattern="tag_transform" from_tag="incline" from_value="-1" to_tag1="incline" to_value1="down" poi="no" routing="no"/>


### PR DESCRIPTION
Like for dirtbikes tagging, enabling the `mtb:scale=?` tag in the OBF process will enable renderers to highlight known MTB routes that haven't yet been classified yet by difficulty level. 

This feature will help MTB mappers prioritize enhancing these known paths and routes, improving the quality of local data for the community.