### PR TITLE
Make forests darker for better readability

### DIFF
--- a/rendering_styles/default.render.xml
+++ b/rendering_styles/default.render.xml
@@ -1408,7 +1408,7 @@
 			<case moreDetailed="true" additional="wood:density=sparse"/>
 			<apply attrColorValue="#91DA80"/>
 		</switch>
-		<case attrColorValue="#87cc70"/>
+		<case attrColorValue="#489d2c"/>
 	</renderingAttribute>
 	<renderingAttribute name="forestColor">
 		<case attrColorValue="$woodColor"/>


### PR DESCRIPTION
Help distinguish between `natural=wood` and `natural=grassland` when hiking and using a phone in broad daylight.
Implements https://github.com/osmandapp/OsmAnd/issues/20054
