### PR TITLE
OSM carto style: admin borders & parking spaces

### DIFF
--- a/rendering_styles/osm-carto.render.xml
+++ b/rendering_styles/osm-carto.render.xml
@@ -1203,6 +1203,11 @@
 			<apply_if noPolygons="true" shader="" color_0="$null" color="$null" />
 		</switch>
 		<switch noPolygons="false">
+			<switch moreDetailed="true">
+				<case minzoom="19" tag="amenity" value="parking_space" color="$null" color_2="#DED4D4" strokeWidth_2="0.75">
+					<apply_if nightMode="true" color_2="#33999999"/>
+				</case>
+			</switch>
 			<case minzoom="16" tag="barrier" value="hedge" color="#ADD19E" color_2="#ADD19E" strokeWidth_2="1">
 				<apply_if nightMode="true" color_2="#285926" />
 			</case>
@@ -1249,5 +1254,46 @@
 				<apply_if minzoom="17" additional="oneway=-1" pathIcon="oneway_reverse_black_semitransparent_big" pathIconStep="70"/>
 			</apply_if>
 		</case>
+		
+		<!-- Admin levels (boundaries) -->
+		<switch minzoom="2">
+			<!-- does admin_level=0 exist?? -->
+			<case tag="admin_level" value="0"/>
+			<case tag="admin_level" value="1"/>
+			<case tag="admin_level" value="2"/>
+			<apply color="$boundaryColorOuter" color_0="$boundaryColorInner">
+				<case maxzoom="2" strokeWidth="0.7"/>
+				<case maxzoom="3" strokeWidth="0.9" strokeWidth_0="0.8" pathEffect_0="24_3_6_3"/>
+				<case maxzoom="4" strokeWidth="1:1" strokeWidth_0="0.8" pathEffect_0="24_3_6_3"/>
+				<case maxzoom="5" strokeWidth="2:2" strokeWidth_0="1" pathEffect_0="24_3_6_3"/>
+				<case maxzoom="6" strokeWidth="3:3" strokeWidth_0="1" pathEffect_0="24_3_6_3"/>
+				<case maxzoom="8" strokeWidth="4:4" strokeWidth_0="1:1" pathEffect_0="24_3_6_3"/>
+				<case minzoom="9" strokeWidth="6:6" strokeWidth_0="1:1" pathEffect_0="24_3_6_3"/>
+			</apply>
+		</switch>
+
+		<switch minzoom="4">
+			<case tag="admin_level" value="3" pathEffect_0="16_4_2_4_2_4"/>
+			<case noAdminboundaries="false" tag="admin_level" value="4" pathEffect_0="16_4_2_4_2_4"/>
+			<apply color="$boundaryColorOuter" color_0="$boundaryColorInner">
+				<case engine_v1="true" maxzoom="5" strokeWidth="1" strokeWidth_0="0.4"/>
+				<case engine_v1="false" maxzoom="5" strokeWidth="0.7" strokeWidth_0="0.3"/>
+				<case maxzoom="6" strokeWidth="1:1" strokeWidth_0="0.5"/>
+				<case maxzoom="8" strokeWidth="1.3:1.3" strokeWidth_0="1"/>
+				<case minzoom="9" strokeWidth="2.5:2.5" strokeWidth_0="1"/>
+			</apply>
+		</switch>
+
+		<switch noAdminboundaries="false">
+			<switch>
+				<case tag="admin_level" value="5" minzoom="10" pathEffect_0="16_2_4_2" strokeWidth_0="2"/>
+				<case tag="admin_level" value="6" minzoom="10" pathEffect_0="16_2_4_2" strokeWidth_0="2"/>
+				<case tag="admin_level" value="7" minzoom="11" pathEffect_0="10_2_2_2_2_2_2_2" strokeWidth_0="1.8"/>
+				<case tag="admin_level" value="8" minzoom="12" pathEffect_0="10_2_2_2_2_2_2_2" strokeWidth_0="1.8"/>
+				<case tag="admin_level" value="9" minzoom="13" pathEffect_0="2_2_2_2_2_4" strokeWidth_0="1.4"/>
+				<case tag="admin_level" value="10" minzoom="13" pathEffect_0="2_2_2_4" strokeWidth_0="1.4"/>
+				<apply color="$null" color_0="$boundaryColorInner" strokeWidth="3:3"/>
+			</switch>
+		</switch>
 	</line>
 </renderingStyle>

--- a/rendering_styles/osm-carto.render.xml
+++ b/rendering_styles/osm-carto.render.xml
@@ -73,6 +73,15 @@
 	<renderingConstant name="wetlandMinZoom" value="10"/>
 
 	<renderingConstant name="null" value="#00000000" />
+    <!-- admin -->
+    <renderingAttribute name="boundaryColorInner">
+		<case nightMode="true" attrColorValue="#44b27db3"/>
+		<case attrColorValue="#50800080"/>
+	</renderingAttribute>
+	<renderingAttribute name="boundaryColorOuter">
+		<case nightMode="true" attrColorValue="#55803b80"/>
+		<case attrColorValue="#30800080"/>
+	</renderingAttribute>
 	<!-- Residential landuse-->
 	<renderingAttribute name="landuseResidentialColor">
 		<case nightMode="true" attrColorValue="#3b3b3b" />


### PR DESCRIPTION
Changed admin boundaries and parking space rendering to match OSM carto.

Boundaries:

<img alt="Screenshot_2024-07-05-15-52-29-805_net osmand plus-edit" src="https://github.com/osmandapp/OsmAnd-resources/assets/42336759/2342641b-bbd5-4eaa-bd31-7b8001592b09" width="300"/>
<img alt="Screenshot_2024-07-05-15-51-32-184_net osmand plus-edit" src="https://github.com/osmandapp/OsmAnd-resources/assets/42336759/031438fc-eed4-4365-93c9-945668190ffc" width="300"/>

Parking spaces:

<img alt="Screenshot_2024-07-05-15-51-12-316_net osmand plus-edit" src="https://github.com/osmandapp/OsmAnd-resources/assets/42336759/345f7e50-99c5-488f-8219-cba09c194510" width="400"/>
