### PR TITLE
enable additional="true" for ford=yes so that ford highways can be rendered differently

### DIFF
--- a/obf_creation/rendering_types.xml
+++ b/obf_creation/rendering_types.xml
@@ -2078,7 +2078,7 @@
 		<type tag="area:highway" value="cycleway" minzoom="16" order="10"/>
 		<type tag="area:highway" value="track" minzoom="16" order="10"/>
 
-		<type tag="ford" value="yes" minzoom="14"/>
+		<type tag="ford" value="yes" minzoom="14" additional="true"/>
 		<type tag="osmand_ford_stub" value="." minzoom="14" additional="text"/>
 		<type tag="ford" value="stepping_stones" minzoom="14"/>
 		<entity_convert pattern="tag_transform" from_tag="ford" if_not_tag1="ford" if_not_value1="no" to_tag1="ford" to_tag2="osmand_ford_stub" to_value2="." poi="no" apply_to="way"/>


### PR DESCRIPTION
According to the OpenStreetMap wiki (https://wiki.openstreetmap.org/wiki/Key:ford#On_a_way), the tag `ford=yes` can be applied to highways that cross long riverbeds, which are commonly found worldwide.

At present, only nodes tagged with `ford=yes` are rendered with a specific icon. Applying `ford=yes` to a highway tag doesn't change its appearance.

To enhance rendering support for `highway=* + ford=yes`, I propose to enable `additional="true"` on the related rule.