### PR TITLE
Show cycle routes also at zoom 11/12

### DIFF
--- a/rendering_styles/routes.addon.render.xml
+++ b/rendering_styles/routes.addon.render.xml
@@ -785,7 +785,7 @@
 				<case showCycleRoutes="true" tag="route_bicycle" value=""/>
 				<case showCycleNodeNetworkRoutes="true" tag="route_bicycle" value=""/>
 				<apply>
-					<case maxzoom="11" strokeWidth="1:1"/>
+					<case maxzoom="11" strokeWidth="2:2"/>
 					<case maxzoom="12" strokeWidth="2:2"/>
 					<case maxzoom="13" strokeWidth="3:3"/>
 					<case maxzoom="14" strokeWidth="4:4"/>
@@ -885,7 +885,7 @@
 					<case additional="node_network=ncn" color="$cycleRoutencnColor"/>
 					<case additional="node_network=icn" color="$cycleRouteicnColor"/>
 					<apply>
-						<case maxzoom="11" strokeWidth="1:1" pathEffect="8_1"/>
+						<case maxzoom="11" strokeWidth="2:2" pathEffect="8_1"/>
 						<case maxzoom="12" strokeWidth="2:2" pathEffect="11_1"/>
 						<case maxzoom="13" strokeWidth="3:3" pathEffect="15_2"/>
 						<case maxzoom="14" strokeWidth="4:4" pathEffect="20_2"/>
@@ -903,7 +903,7 @@
 					<case additional="network=ncn" color="$cycleRoutencnColor"/>
 					<case additional="network=icn" color="$cycleRouteicnColor"/>
 					<apply pathEffect="">
-						<case maxzoom="11" strokeWidth="1:1"/>
+						<case maxzoom="11" strokeWidth="2:2"/>
 						<case maxzoom="12" strokeWidth="2:2"/>
 						<case maxzoom="13" strokeWidth="3:3"/>
 						<case maxzoom="14" strokeWidth="4:4"/>

--- a/rendering_styles/routes.addon.render.xml
+++ b/rendering_styles/routes.addon.render.xml
@@ -794,7 +794,7 @@
 					<case maxzoom="17" strokeWidth="6:6"/>
 					<case minzoom="18" strokeWidth="7:7"/>
 				</apply>
-				<apply_if minzoom="13" color="$cycleRouteColor" cap="BUTT"/>
+				<apply_if minzoom="11" color="$cycleRouteColor" cap="BUTT"/>
 			</switch>
 			<case showMtbRoutes="true" tag="route_mtb" value="" cap="ROUND">
 				<case maxzoom="11" strokeWidth="1:1" strokeWidth_2="1:1" strokeWidth__2="2:2"/>


### PR DESCRIPTION
(I was going to submit a feature request for this, but then figured I could try figuring out the needed changes first, which worked, so now I have a PR. Let me know if you prefer to also have an accompanying feature request issue)

While planning my bicycle trips, I use osmand with (node network) routes extensively. However, cycle routes are displayed at zoom 13 and closer only, which is quite too close to plan a route from one town to the other:

<img width="400" src="https://github.com/user-attachments/assets/ff1bc6e2-2924-47a4-bd3e-1725bb24104f"/>

Zooming out, routes disappear, even though the network node shields stay visible until zoom 11:

<img width="400" src="https://github.com/user-attachments/assets/042c4a28-d65f-426c-b8d6-6ff254ed5e17"/>

Zoom 11 is also a good zoom level to do rough planning of a trip, except that the routes are hidden.

This PR contains two commits. The first enables rendering of routes at zoom 11+ (from 13+), which results in:

<img width="400" src="https://github.com/user-attachments/assets/3806fb61-7ed0-40e2-b7e2-9217c4f7cefd" />

To my taste, the route lines are a bit too narrow to be useful at this zoom level (they are ok at 12), so I added a second commit that widens the route lines, resulting in this:

<img width="400" src="https://github.com/user-attachments/assets/371ed53a-9e62-4436-9678-64747c38577a"/>


I've tested this on osmand nightly 4.9.0#2904 and seems to work fine.

I am still a bit unsure about the rendering code for these routes, though. In particular, there are three sections that seem really similar and at first glance redundant, but also seem to handle different cases (`route_bicycle=*`, `node_network=*` and `network=*` it seems?). I'm talking about [here](https://github.com/osmandapp/OsmAnd-resources/blob/988d4af49900ed83f689c00aa6eafa6eea9574f4/rendering_styles/routes.addon.render.xml#L787-L796), [here](https://github.com/osmandapp/OsmAnd-resources/blob/988d4af49900ed83f689c00aa6eafa6eea9574f4/rendering_styles/routes.addon.render.xml#L887-L896) and [here](https://github.com/osmandapp/OsmAnd-resources/blob/988d4af49900ed83f689c00aa6eafa6eea9574f4/rendering_styles/routes.addon.render.xml#L905-L914). I've now just modified all three places, but I have not thoroughly tested all three.