### PR TITLE
make nightMode roadRoadColor slightly darker

### DIFF
--- a/rendering_styles/default.render.xml
+++ b/rendering_styles/default.render.xml
@@ -1062,7 +1062,7 @@
 	<!-- NOTE: A `Road` represents a way of unknown classification and could be anything—from a motorway to a private driveway or even a public footpath. Ways tagged as `Road` need to be (re)surveyed. Additional tags should not affect rendering until the way is reclassified into a more specific category. -->
 	<renderingAttribute name="roadRoadColor">
 		<case attrColorValue="#cdcdcd">
-			<apply_if nightMode="true" attrColorValue="#2e2e2e"/>
+			<apply_if nightMode="true" attrColorValue="#3a3a3a"/>
 		</case>
 	</renderingAttribute>
 


### PR DESCRIPTION
I used `#3a3a3a`, but if you need something brighter, you can try `#404040` or `#4a4a4a`.

It's important that these roads don't draw too much visual attention. Unlike otherroads, they require careful consideration due to the potential for erroneous data.