### PR TITLE
add footway=sidewalk as additional tag

### DIFF
--- a/obf_creation/rendering_types.xml
+++ b/obf_creation/rendering_types.xml
@@ -140,6 +140,8 @@
 	<type tag="service" value="driveway" minzoom="13" additional="true"/>
 	<type tag="service" value="parking_aisle" minzoom="13" additional="true"/>
 	<type tag="service" value="alley" minzoom="13" additional="true"/>
+    
+	<type tag="footway" value="sidewalk" minzoom="15" additional="true"/>
 
 	<type tag="osmand_access_main" value="tag" minzoom="15" order="150" notosm="true"/>
 	<type tag="osmand_access" minzoom="15" additional="true" order="150" notosm="true"/>


### PR DESCRIPTION
I hope it is fine to propose this addition this way.

Adding footway=sidewalk to the list of additional tags allows to make the maps in cities more readable while still showing footways e.g. in parks in a lower zoom level.