### PR TITLE
Hide place=locality until zoom 16 by default. moreDetailed controls v…

### DIFF
--- a/rendering_styles/default.render.xml
+++ b/rendering_styles/default.render.xml
@@ -2418,7 +2418,6 @@
 		<renderingConstant name="placeIsolatedDwellingMinZoom" value="13"/>
 		<renderingConstant name="placeSuburbMinZoom" value="12"/>
 		<renderingConstant name="placeNeighbourhoodMinZoom" value="13"/>
-
 		<renderingConstant name="placeVillageIconMinZoom" value="11"/>
 		<renderingConstant name="placeVillageIconMaxZoom" value="12"/>
 		<renderingConstant name="placeHamletIconMinZoom" value="11"/>
@@ -2809,7 +2808,7 @@
 						<apply order="-1"/>
 						<apply_if additional="osmand_large_state=true" order="128"/>
 					</case>-->
-					<case tag="place" value=""/>
+					<case tag="place" value="locality" moreDetailed="false" maxzoom="15" order="-1"/>
 					<case tag="public_transport" value="platform">
 						<apply_if additional="disused=yes" order="60"/>
 						<apply_if maxzoom="16" additional="disused=yes" order="-1"/>


### PR DESCRIPTION
…isibility at zooms 13-15. (https://github.com/osmandapp/OsmAnd/issues/22119)