### PR TITLE
Add workflow to generate OSF files for testing pull requests

### DIFF
--- a/.github/workflows/generate_osf_file.yml
+++ b/.github/workflows/generate_osf_file.yml
@@ -1,0 +1,34 @@
+name: Build OSF file
+on:
+  pull_request:
+    paths: ['rendering_styles/*.render.xml']
+
+jobs:
+  build_osf:
+    name: Build OSF file
+    runs-on: ubuntu-latest
+    steps:
+      - name: Prepare repo
+        uses: actions/checkout@v4
+        with:
+            sparse-checkout: 'rendering_styles'
+            # This should be enough to figure out which rendering files changed in the PR without fetching the full history
+            fetch-depth: 2
+
+      - name: Install system packages
+        run: |
+          sudo apt-get update
+          sudo apt-get -y install jq moreutils
+
+      - name: Build OSF file
+        # Generate a list of modified files (excluding d[eleted] files), and generate an osf containing only those files
+        # Since the default checkout is a merge-PR-into-base commit, the ^1 commit is the base commit (which we have available with fetch-depth: 2).
+        # See https://github.com/actions/checkout/issues/520#issuecomment-1167205721
+        run: |
+          git diff --name-only --diff-filter=d HEAD^1 HEAD | grep '.xml$' | xargs -d'\n' ./rendering_styles/build_osf.sh output.osf
+
+      - name: Upload built artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: Rendering styles (OSF file)
+          path: output.osf

--- a/.github/workflows/link-artifacts-in-pr.yml
+++ b/.github/workflows/link-artifacts-in-pr.yml
@@ -1,0 +1,40 @@
+# This adds a comment to a PR with a link to any build artifacts. This is done in a separate workflow so it can also run with write permissions on a PR from
+# a third-party repository. The PR-triggered workflow itself is limited in permissions, e.g.
+# https://docs.github.com/en/actions/how-tos/security-for-github-actions/security-guides/use-github_token-in-workflows#modifying-the-permissions-for-the-github_token
+# says:
+#
+# > You can use the permissions key to add and remove read permissions for forked repositories, but typically you can't grant write access. The exception to
+# > this behavior is where an admin user has selected the Send write tokens to workflows from pull requests option in the GitHub Actions settings.
+#
+# However, *this* followup workflow runs from the default branch (so any changes to this workflow in the PR are not reflected, the definintion from the main
+# default is always used), so it can run with full permissions (without having to grant full write permissions to all PR submitters).
+#
+# Note that originally, this was also a separate workflow because the URL for uploaded artifacts was only available after a workflow completed, but with
+# actions/upload-artifact@v4 the url is available right away, so this is no longer a reason for using a separate workflow.
+name: Linking to artifacts in PR
+on:
+  workflow_run:
+    workflows: ["Build OSF file"]
+    types: [completed]
+
+jobs:
+  artifacts-url-comments:
+    name: Add artifact links to PRs
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      # This uses a third-party action that handles figuring out the
+      # pull request to comment on (which is no longer easily available
+      # in a followup workflow) and formatting the comment.
+      - name: Add artifact links to PR and issues
+        uses: tonyhallett/artifacts-url-comments@v1.1.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          prefix: "Automatically generated build artifacts for commit ${{ github.event.workflow_run.head_sha }} (note: these links will expire after some time):\n"
+          format: " - {name}: [:arrow_double_down: Download]({url})"
+          # This adds a hline to terminate the artifact list, just
+          # newlines should work, but it seems they are eaten
+          # somewhere...
+          suffix: "---\n\nTo test this PR, download the OSF file and open it with Osmand\n"

--- a/rendering_styles/build_osf.sh
+++ b/rendering_styles/build_osf.sh
@@ -1,0 +1,33 @@
+#!/bin/sh -e
+
+OUTPUT_FILE="RenderingStyles.osf"
+ITEMS_DIR=$(mktemp -d)
+ITEMS_FILE="${ITEMS_DIR}/items.json"
+
+if [ "$0" = "-h" -o "$0" = "--help" ]; then
+    echo "usage: $0 [OUTPUT.osf [INPUT.xml...]]"
+fi
+
+cleanup() {
+    rm -rf "${ITEMS_DIR}"
+}
+trap cleanup EXIT
+
+if [ "$#" -gt 0 ]; then
+    OUTPUT_FILE="$1"
+    shift
+fi
+
+# Allow specifying xml files to include on the commandline, but default to all if none are specified
+if [ "$#" -eq 0 ]; then
+    set -- "$(dirname "$0")"/*.render.xml
+fi
+
+jq --null-input '{} | .version = 1 | .items = []' > "${ITEMS_FILE}"
+for file in "$@"; do
+    jq --arg file "${file}" '.items += [{type: "FILE", subtype: "rendering_style", file: $file}]' "${ITEMS_FILE}" | sponge "${ITEMS_FILE}"
+done
+
+rm -f "$OUTPUT_FILE"
+zip --junk-paths "$OUTPUT_FILE" "$@" "$ITEMS_FILE"
+echo "Created ${OUTPUT_FILE}"

--- a/rendering_styles/readme.md
+++ b/rendering_styles/readme.md
@@ -1,5 +1,8 @@
 Rendering styles
 ================
+This directory contains rendering style files, which dictate how the map should be rendered.
+See [the OsmAnd documentation](https://osmand.net/docs/technical/osmand-file-formats/osmand-rendering-style/) for details on the format of these files.
+
 **Default (general purposes):**
 * **default.render.xml :** <br>General purpose style. Simplified rendering to have cleaner maps in the populated cities. Key features: contour lines, routes, surface quality, access restrictions, road shields, paths rendering according to SAC scale, whitewater sports features.
 * **Touring-view_(more-contrast-and-details).render.xml :** <br>General purpose style: High-detail, high-contrast map for travelers and professional drivers. Provides at any given map zoom the maximum amount of travel details available, in particular depicts all roads, tracks, paths, and unambiguously distinguishes their types. Also features outdoor touring options like the original SAC Alpine hiking trail coding. (Depends on default.)
@@ -17,3 +20,36 @@ Rendering styles
 * **regions.render.xml**
 * **Topo-map-assimilation.render.xml**
 * **UniRS.render.xml**
+
+Installing modified rendering styles
+------------------------------------
+To test changes to these rendering styles, you can make changes and then copy the modified files into the `Android/data/net.osmand/files/rendering`
+directory (or `net.osmand.plus` for OsmAnd plus and `net.osmand.dev` for OsmAnd nightly/beta) on the Android device (these files should be visible through any
+file manager, or when browsing files via USB). There might already be files with the same name in that directory - OsmAnd copies the default builtin styles into
+that directory whenever you first use them or whenever OsmAnd is updated (so any changes you make will last until the next update).
+
+Alternatively, to simplify this install process, you can generate an .osf file using the `build_osf.sh` script, and then open that with OsmAnd to import these
+files into the right place automatically (this might ask to overwrite files for
+styles that you have used before, which is ok). You can run the script without
+arguments to generate an osf file with *all* rendering styles:
+
+    $ ./build_osf.sh
+      adding: LightRS.render.xml (deflated 87%)
+      adding: Topo-map-assimilation.render.xml (deflated 87%)
+      [ ... snip more files ...]
+      adding: weather.addon.render.xml (deflated 77%)
+      adding: items.json (deflated 89%)
+    Created RenderingStyles.osf
+
+Alternatively, pass an output filename an optionally also xml filenames to include only those files:
+
+
+    $ ./build_osf.sh output.osf routes.addon.render.xml default.render.xml
+      adding: routes.addon.render.xml (deflated 89%)
+      adding: default.render.xml (deflated 87%)
+      adding: items.json (deflated 53%)
+    Created output.osf
+
+In both cases, such changes last until the next update of OsmAnd, then they are overwritten with the default version again.
+
+This script uses POSIX sh, the `jq`, `zip` and `sponge` commands, so it should run on Linux (On Debian: `apt install zip jq moreutils`) and probably MacOS.


### PR DESCRIPTION
This PR contains a workflow that generates an OSF file containing the changes for pull requests made to this repository, and then adds a comment linking to the generated OSF file. This makes it easier to test the changes in a PR by simply opening the generated OSF in OsmAnd.

The OSF-file generation might work right away on this PR already, but adding comments only works once this PR is merged into master (since it uses a followup workflow to get the needed write permissions, see comments in `/link-artifacts-in-pr.yml` for details).

For an example of how the result looks, see https://github.com/matthijskooijman/OsmAnd-resources/pull/4