### PR TITLE
[5.1] Improve pedestrian routing (service=alley, etc)

### DIFF
--- a/routing/routing.xml
+++ b/routing/routing.xml
@@ -2254,10 +2254,12 @@
 			<select value="0" t="sidewalk" v="both"/>
 			<select value="0" t="foot" v="yes"/>
 			<select value="0" t="foot" v="designated"/>
-			<select value="0" t="highway" v="residential"/>
 			<select value="0" t="public_transport" v="platform"/>
 			<select value="0"  t="railway" v="platform"/>
+			<select value="0" t="service" v="alley"/>
 			<!-- give highway penalty to use mostly footways if available-->
+			<select value="10" t="highway" v="residential"/>
+			<select value="20" t="highway" v="service"/>
 			<select value="90"/>
 			
 		</way>


### PR DESCRIPTION
https://wiki.openstreetmap.org/wiki/Tag:service%3Dalley

In some regions, chiefly in Europe, narrow streets in historic cities that provide access to the main entrances of buildings may also be mapped as alleys, distinguishing them from wider modern streets mapped, for example, as [highway](https://wiki.openstreetmap.org/wiki/Key:highway)=[residential](https://wiki.openstreetmap.org/wiki/Tag:highway%3Dresidential).

To Do

- [x] merge into master