### PR TITLE
Make unknown barriers not passable to cars when navigating

### DIFF
--- a/routing/routing.xml
+++ b/routing/routing.xml
@@ -1127,17 +1127,9 @@
 				<select value="0" t="motorcycle" v="customers"/>
 				<select value="0" t="motorcycle" v="official"/>
 			</if>
-			<select value="-1" t="barrier" v="bollard"/>
-			<select value="-1" t="barrier" v="chain"/>
-			<select value="-1" t="barrier" v="debris"/>
-			<select value="-1" t="barrier" v="jersey_barrier"/>
-			<select value="-1" t="barrier" v="block"/>
-			<select value="-1" t="barrier" v="turnstile"/>
-			<select value="-1" t="barrier" v="bus_trap"/>
-			<select value="-1" t="barrier" v="cycle_barrier"/>
-			<select value="-1" t="barrier" v="sump_buster"/>
 
-			<if param="short_way">
+            <!-- These barriers are implicitly passable with a car. -->
+            <if param="short_way">
 				<select value="0" t="barrier" v="cattle_grid"/>
 				<select value="0" t="barrier" v="border_control"/>
 				<select value="0" t="barrier" v="bump_gate"/>
@@ -1149,20 +1141,26 @@
 				<select value="5" t="highway" v="traffic_signals"/>
 				<select value="0" t="highway" v="give_way"/>
 			</if>
-			<select value="5"   t="barrier" v="cattle_grid"/>
 			<select value="298" t="barrier" v="border_control"/>
 			<select value="300" t="barrier" v="bump_gate"/>
-			<select value="300" t="barrier" v="gate" /> <!-- could be on many ferries (make accessible) -->
-			<select value="1"   t="barrier" v="entrance"/>
-			<select value="100" t="barrier" v="sally_port"/>
-			<select value="1"   t="barrier" v="toll_booth"/>
-			<select value="1"   t="barrier" v="height_restrictor"/>
+			<select value="5"   t="barrier" v="cattle_grid"/>
 			<select value="1"   t="barrier" v="coupure"/>
-			<!-- These 2 shouldn't be allowed per the wiki (access=no is assumed) but people often do not add the proper access tags. -->
+			<select value="1"   t="barrier" v="entrance"/>
+            <select value="300" t="barrier" v="gate" /> <!-- could be on many ferries (make accessible) -->
+			<select value="300" t="barrier" v="hampshire_gate"/>
+			<select value="1"   t="barrier" v="height_restrictor"/>
+            <select value="100" t="barrier" v="sally_port"/>
+			<select value="1"   t="barrier" v="toll_booth"/>
+
+			<!-- These shouldn't be allowed per the wiki (access=no is assumed) but people often do not add the proper access tags. -->
 			<select value="300" t="barrier" v="lift_gate"/>
-			<select value="300" t="barrier" v="swing_gate"/>
-			<!-- Without explicit access marking, barriers other than the listed values above are impassable to a car. -->
-			<select value="10" t="traffic_calming"/>
+			<select value="300" t="barrier" v="sliding_beam"/>
+            <select value="300" t="barrier" v="sliding_gate"/>
+            <select value="300" t="barrier" v="swing_gate"/>
+            <!-- Without explicit access marking, barriers other than the listed values above are impassable to a car. -->
+            <select value="-1" t="barrier"/>
+
+            <select value="10" t="traffic_calming"/>
 			<select value="5"  t="highway" v="give_way"/>
 			<select value="15"  t="highway" v="stop"/>
 			<!-- introduction to not drive through city -->


### PR DESCRIPTION
Except a short list of passable barriers (by SOME modes of transport), the wiki suggests other barriers assume access=no (https://wiki.openstreetmap.org/wiki/Barriers#Routing) . People very often do not tag any access tags onto barriers, as they are there to block access and as that is assumed to be the default...

This patch fixes #6753, #5170, #6530 in the proper way of disallowing all unknown barriers in CAR navigation except some whitelisted barriers. Other transport modes have their own lists.