### PR TITLE
Add stand up paddling activity to activities.json

### DIFF
--- a/poi/activities.json
+++ b/poi/activities.json
@@ -488,6 +488,11 @@
                     ]
                 },
                 {
+                    "label": "Stand up paddling",
+                    "id": "sup",
+                    "icon_name": "ic_sample"
+                },
+                {
                     "label": "Surfing",
                     "id": "surfing",
                     "icon_name": "activities_surfing"


### PR DESCRIPTION
Adds Stand up paddling (SUP) as a water sports activity. I don't have a nice icon, so I just used "ic_sample" as used already for other activities.