### PR TITLE
Level up cities for all words equals

### DIFF
--- a/test-resources/search/rossio.json
+++ b/test-resources/search/rossio.json
@@ -14,6 +14,9 @@
         "rossio "
     ],
     "results": [
+		"Rossio, rossio.obf [[1, CITY, 120.000, 92.60 km]]",
+		"Rossio, rossio.obf [[1, CITY, 120.000, 251.42 km]]",
+		"Rossio, rossio.obf [[1, CITY, 120.000, 277.71 km]]",
 		"Praça Dom Pedro IV (Santa Justa), Santa Maria Maior [[1, STREET, 81.000, 0.13 km]]",
 		"Rossio, Barreiro [[1, STREET, 81.000, 8.34 km]]",
 		"Rossio (Montemor-o-Novo), Silveiras [[1, STREET, 80.000, 81.02 km]]",
@@ -23,9 +26,6 @@
 		"Rossio, Aldeia dos Fernandes [[1, STREET, 80.000, 152.88 km]]",
 		"Rossio, São Lourenço [[1, STREET, 80.000, 161.31 km]]",
 		"Rossio, Moura [[1, STREET, 80.000, 161.44 km]]",
-		"Rossio, rossio.obf [[1, CITY, 70.000, 92.60 km]]",
-		"Rossio, rossio.obf [[1, CITY, 70.000, 251.42 km]]",
-		"Rossio, rossio.obf [[1, CITY, 70.000, 277.71 km]]",
 		"Rossio [[1, POI, 61.000, 0.18 km]]",
 		"Rossio [[1, POI, 61.000, 0.20 km]]",
 		"Rossio [[1, POI, 61.000, 0.25 km]]",

--- a/test-resources/search/w_farm_williams.json
+++ b/test-resources/search/w_farm_williams.json
@@ -105,8 +105,8 @@
       "Low Farm Drive, Carlton Colville [[1, STREET, 1.000, 216.72 km]] [w_farm_far_england.obf]"
     ],
     [
+      "Norwich, W farm far [[1, CITY, 120.000, 245.42 km]] [w_farm_far_england.obf]",
       "Norwich, Chedgrave [[1, STREET, 80.000, 232.63 km]] [w_norwich_england.obf]",
-      "Norwich, W farm far [[1, CITY, 70.000, 245.42 km]] [w_farm_far_england.obf]",
       "Norwich Cathedral [[1, POI, 41.573, 244.86 km]] [w_norwich_england.obf]",
       "Norwich Castle Museum [[1, POI, 26.107, 245.14 km]] [w_norwich_england.obf]",
       "City of Norwich Aviation Museum [[1, POI, 11.253, 247.30 km]] [w_norwich_england.obf]",


### PR DESCRIPTION
To issues:
[City of f Münster, Germany not found](https://github.com/osmandapp/OsmAnd/issues/24955)
[Impossible to find exact match from partial matches](https://github.com/osmandapp/OsmAnd/issues/25021)