### PR TITLE
ge1-unit-test-fix

### DIFF
--- a/test-resources/search/ge1.json
+++ b/test-resources/search/ge1.json
@@ -16,10 +16,8 @@
     "10 Martin-Luther-Straße Korb",
     "35 Ostheimer Weg Korntal",
     "130/6 Mercedes-Benz Werk 1 (Untertürkheim) Stuttgart",
-    "4 Hofäckerstraße Kernen im Remstal"
-  ],
-  "disabled-phrase-fixme" : [
-	  "6 Dorfstraße Remseck am Neckar"
+    "4 Hofäckerstraße Kernen im Remstal",
+    "6 Dorfstraße Neckarrems"
   ], 
   "results": [
     [
@@ -81,17 +79,10 @@
       "4, Hofackerstraße (Nonnenäcker), Rietenau [[2, HOUSE, 4.800, 21.13 km]]",
       "4, Hofackerstraße, Rutesheim [[2, HOUSE, 4.800, 25.93 km]]"
     ],
-	  [
-      "6, Dorfstraße, Neckarrems [[3, HOUSE, 4.800, 6.87 km]]",
-      "6, Dorfstraße (Hofstett am Steig), Weiler ob Helfenstein [[3, HOUSE, 4.030, 46.12 km]]",
-      "6/1, Dorfstraße (Hofstett am Steig), Weiler ob Helfenstein [[3, HOUSE, 4.030, 46.09 km]]",
-      "6, Untere Dorfstraße (Stetten am kalten Markt), Unterglashütte [[3, HOUSE, 4.030, 79.87 km]]",
-      "6, Dorfstraße (Zell am Harmersbach), Unterentersbach [[3, HOUSE, 4.030, 106.31 km]]",
-      "6, Obere Dorfstraße (Ramsberg am Brombachsee), Pleinfeld [[3, HOUSE, 4.030, 123.86 km]]",
-      "6, Untere Dorfstraße (Ramsberg am Brombachsee), Pleinfeld [[3, HOUSE, 4.030, 124.28 km]]",
-      "6, Dorfstraße (Endingen am Kaiserstuhl), Amoltern [[3, HOUSE, 4.030, 141.74 km]]",
-      "6, Dorfstraße (Breisach am Rhein), Hochstetten [[3, HOUSE, 4.030, 152.62 km]]",
-      "6, Dorfstraße (Am Weißen Stein), Schallbach [[3, HOUSE, 4.030, 178.56 km]]",
-	   ],
+    [
+      "6, Dorfstraße, Neckarrems [[3, HOUSE, 91.817, 6.87 km]]",
+      "Dorfstraße, Neckarrems [[2, STREET, 1.710, 6.87 km]]",
+      "Neckarrems, ge1.obf [[1, CITY, 1.000, 6.88 km]]"
+    ]
   ]
 }


### PR DESCRIPTION
remove 'Remseck' token from query because Dorfstraße is became FrequentlyUsed word and 'Remseck' is missed in OBF