### PR TITLE
Add amenity=luggage_locker and list bakery under sustenance

### DIFF
--- a/poi/poi_types.xml
+++ b/poi/poi_types.xml
@@ -4520,6 +4520,7 @@
 				</poi_type>
 				<poi_type name="food_court" tag="amenity" value="food_court"/>
 			</poi_filter>
+			<poi_reference name="bakery"/>
 			<poi_type name="fast_food" tag="amenity" value="fast_food" poi_additional_category="delivery,outdoor_seating,drive_in,smoking,diet,dish,cuisine,organic,drinking_water_refill,changing_table_filter,self_checkout,cafe_filter">
 				<poi_additional_category name="drive_through">
 					<poi_additional name="drive_through_yes" tag="drive_through" value="yes"/>
@@ -4642,6 +4643,7 @@
 				<poi_additional name="post_flats" tag="post:flats" type="text"/>
 			</poi_type>
 			<poi_type name="parcel_locker" tag="amenity" value="parcel_locker" excluded_poi_additional_category="drive_through,internet_access_type"/>
+			<poi_type name="luggage_locker" tag="amenity" value="luggage_locker" excluded_poi_additional_category="drive_through,internet_access_type"/>
 			<poi_type name="beauty" tag="shop" value="beauty" excluded_poi_additional_category="payment_type,fee">
 				<poi_additional_category name="beauty_salon_service" icon="beauty_salon_nails">
 					<poi_additional name="beauty_salon_nails" tag="beauty" value="nails" top="true"/>


### PR DESCRIPTION
Two small additions to `poi_types.xml`:

1. **`amenity=luggage_locker`** — fixes https://github.com/osmandapp/OsmAnd/issues/22680: the tag (1,600+ uses worldwide, documented as *in use*) was not searchable in OsmAnd at all. Placed in the *service* category next to `parcel_locker` with the same excluded additional categories. The English phrase is added in the companion PR https://github.com/osmandapp/OsmAnd/pull/25370.
2. **`<poi_reference name="bakery"/>` in the *sustenance* category** — bakeries are food shops, so they should also be findable when browsing the Sustenance/Gastronomy category, analogous to how *emergency* references `clinic`/`hospital`. The type itself stays in the shop category, so nothing changes for existing filters.

Validated: XML parses, `luggage_locker` is unique, the reference target exists.

Background: this follows the gap analysis of officially documented Map Features vs. `poi_types.xml` posted in https://github.com/osmandapp/OsmAnd/issues/18654#issuecomment-4883184126 — these are the first, user-reported items from that list.

🤖 Generated with [Claude Code](https://claude.com/claude-code) — model: Claude Fable 5, reasoning effort: xhigh