### PR TITLE
Add surface=laterite and stop converting surface=clay to dirt

### DIFF
--- a/obf_creation/rendering_types.xml
+++ b/obf_creation/rendering_types.xml
@@ -2753,7 +2753,8 @@
 		<entity_convert pattern="tag_transform" from_tag="surface" from_value="soil" to_tag1="surface" to_value1="ground"/>
 		<type tag="surface" value="dirt" minzoom="14" additional="true"/>
 		<entity_convert pattern="tag_transform" from_tag="surface" from_value="dirt/sand" to_tag1="surface" to_value1="dirt"/>
-		<entity_convert pattern="tag_transform" from_tag="surface" from_value="clay" to_tag1="surface" to_value1="dirt" poi="false"/>
+		<type tag="surface" value="clay" minzoom="14" additional="true"/>
+		<type tag="surface" value="laterite" minzoom="14" additional="true"/>
 		<type tag="surface" value="mud" minzoom="14" additional="true"/>
 		<type tag="surface" value="ice" minzoom="14" additional="true"/>
 		<type tag="surface" value="salt" minzoom="14" additional="true"/>

--- a/routing/routing.xml
+++ b/routing/routing.xml
@@ -1845,6 +1845,8 @@
 			<select value="0.65" t="surface" v="grass"/>
 			<select value="0.75" t="surface" v="ground"/>
 			<select value="0.5" t="surface" v="mud"/>
+			<select value="0.55" t="surface" v="laterite"/>
+			<select value="0.60" t="surface" v="clay"/>
 			<select value="0.5" t="smoothness" v="very_bad"/>
 			<select value="1.2" t="route_bicycle"/> 
 			<!-- If a part of a bicycle route has a surface tag, it will have


### PR DESCRIPTION
`surface=laterite` was approved via OSM's proposal process ([Proposal:Surface=laterite](https://wiki.openstreetmap.org/wiki/Proposal:Surface%3Dlaterite), 29-0-0) and is documented at [Tag:surface=laterite](https://wiki.openstreetmap.org/wiki/Tag:surface%3Dlaterite).

**Two separate bugs, one fix:**

1. `obf_creation/rendering_types.xml` had no `<type>` registration for `laterite` at all, so it wasn't being retained as a distinct surface value in the compiled map data.
2. The same file silently rewrites `surface=clay` to `surface=dirt` on import (`entity_convert ... from_value="clay" to_value1="dirt"`), so `clay` never survives to reach a routing profile as `clay` in the first place, any speed factor keyed on `clay` would be dead code.

This PR registers both as retained values, then gives them their own speed factors in the bicycle profile's `multiply_factor` table in `routing/routing.xml`: `clay=0.60`, `laterite=0.55`, placed between the existing `dirt`/`mud` (0.50) and `ground`/`earth` (0.75) entries.

**Reasoning for the values:** `mud` has no dry season, so it keeps the harshest existing factor. `clay` and `laterite` are both seasonal, dry and passable for roughly half the year, so both sit above `mud`. `laterite` sits below `clay` because of an added risk `clay` doesn't have: a near-frictionless "black ice" phase right as it turns wet, distinct from clay's more gradual sticky/plastic transition. After sustained rain and traffic churn, laterite converges to the same sticky, plastic state as wet clay, so this is about capturing that earlier transition window, not describing a permanently worse material. These are a starting position based on that reasoning, not measured data, open to a different split if there's a preferred methodology.

**Photos**, for context:

<img src="https://commons.wikimedia.org/wiki/Special:FilePath/Dry_laterite_road_with_blocky_desiccation_cracking_between_wheel_tracks.jpg" alt="Dry laterite road with blocky desiccation cracking between wheel tracks" width="480">

*Dry: desiccation cracks into large, blocky plates, distinct from clay's smaller, curved cracking pattern.* [Source](https://commons.wikimedia.org/wiki/File:Dry_laterite_road_with_blocky_desiccation_cracking_between_wheel_tracks.jpg)

<img src="https://commons.wikimedia.org/wiki/Special:FilePath/Wet_laterite_road_surface_during_rainfall,_appearing_firm.jpg" alt="Wet laterite road surface during rainfall, appearing firm" width="480">

*Wet, phase 1 (near-frictionless): surface still looks firm, but this is the near-frictionless "black ice" phase specific to laterite, distinct from wet clay's visibly sticky, plastic transition.* [Source](https://commons.wikimedia.org/wiki/File:Wet_laterite_road_surface_during_rainfall,_appearing_firm.jpg)

<img src="https://commons.wikimedia.org/wiki/Special:FilePath/Red-clay-sticky-plastic-when-wet.jpg" alt="Red clay sticky and plastic when wet" width="480">

*Wet, phase 2 (after sustained rain and traffic): confirmed laterite despite the filename (mislabeled before `surface=laterite` existed as a distinct tag), showing the later sticky, plastic, heavily rutted state that laterite converges to, the same state wet clay reaches.* [Source](https://commons.wikimedia.org/wiki/File:Red-clay-sticky-plastic-when-wet.jpg)