### PR TITLE
Add avoid_unknown_access car routing parameter for access=unknown

### DIFF
--- a/routing/routing.xml
+++ b/routing/routing.xml
@@ -423,6 +423,7 @@
 		<parameter id="avoid_borders" name="Avoid border crossing" description="Avoid crossing a border into another country" type="boolean"/>
 		<parameter id="avoid_ice_roads_fords" name="Avoid ice roads, fords" description="Avoid ice roads and fords" type="boolean"/>
 		<parameter id="avoid_4wd_only" name="Avoid 4WD roads" description="Avoid roads only suitable for 4WD only vehicles" type="boolean"/>
+		<parameter id="avoid_unknown_access" name="Avoid unverified access" description="Avoid roads with unverified legal access (access=unknown)" type="boolean"/>
 		<parameter id="allow_private" name="Allow private access" description="Allow access to private areas for cars" type="boolean" profiles="default,motorcycle"/>
 		<parameter id="allow_private_for_truck" name="Allow private access (truck)" description="Allow access to private areas for trucks" type="boolean" profiles="truck"/>
 		<parameter id="goods_restrictions" name="Goods vehicles restrictions" description="Consider access permissions for light goods vehicles (goods)" type="boolean" profiles="default"/>
@@ -470,6 +471,9 @@
 			<if param="avoid_4wd_only">
 				<select value="-1" t="4wd_only" v="yes"/>
 				<select value="-1" t="4wd_only" v="recommended"/>
+			</if>
+			<if param="avoid_unknown_access">
+				<select value="-1" t="access" v="unknown"/>
 			</if>
 			<if param="avoid_unpaved">
 				<select value="-1" t="highway" v="track"/>


### PR DESCRIPTION
`access=unknown` is a de facto OSM tag (https://wiki.openstreetmap.org/wiki/Tag:access%3Dunknown) meaning access conditions were considered and found genuinely unverified, distinct from a way with no access tag at all. It's already acted on elsewhere in the OSM ecosystem, for example StreetComplete's parking-access quest treats it as a deliberate "needs survey" signal rather than silence.

Right now the car profile's access `<select>` block in `routing/routing.xml` (around line 448) doesn't reference `access=unknown` at all, so it falls through to the same default-allowed handling as an untagged way. This PR adds a new opt-in `avoid_unknown_access` parameter, mirroring the existing `avoid_unpaved`/`avoid_4wd_only` pattern: off by default, no behavior change for existing users, and when enabled it deprioritizes/excludes ways tagged `access=unknown`.

A few notes since this is my first change here:
- Scoped to the car profile only, matching where `avoid_4wd_only` lives (bicycle/pedestrian/moped only have `avoid_unpaved`, not a 4wd-style flag, so I followed that precedent rather than adding it everywhere).
- I didn't add a `Routing_test_NN` fixture, since generating the `.obf` test data appears to require the separate OsmAndMapCreator tooling. Happy to add one if pointed to the right process, or if there's a lighter-weight way to test a routing.xml-only change.
- Open to a different parameter name, or folding this into an existing flag, if that fits the project's conventions better.