### PR TITLE
DRAFT_Overestimated-ETA-for-bunch-of-traffic-light-fix

### DIFF
--- a/routing/routing.xml
+++ b/routing/routing.xml
@@ -1052,7 +1052,7 @@
 			<select value="180" t="barrier" v="toll_booth"/>
 			<select value="25" t="barrier"/>
 			<select value="10" t="traffic_calming"/>
-			<select value="20" t="highway" v="traffic_signals"/>
+			<select value="10" t="highway" v="traffic_signals"/>
 			<select value="1"  t="crossing" v="unmarked"/>
 			<select value="5"  t="crossing" v="uncontrolled"/>
 			<select value="15" t="highway" v="crossing"/>
@@ -1900,7 +1900,7 @@
 			<select value="15" t="highway" v="traffic_signals"/>
 			<select value="10" t="crossing" v="unmarked"/>
 			<select value="5"  t="crossing" v="uncontrolled"/>
-			<select value="15" t="crossing" v="traffic_signals"/>
+			<select value="5" t="crossing" v="traffic_signals"/>
 			<select value="15" t="highway" v="stop"/>
 			<select value="7"  t="highway" v="give_way"/>
 			<select value="200" t="ford"/>
@@ -3270,7 +3270,7 @@
 			<select value="180" t="barrier" v="toll_booth"/>
 			<select value="25" t="barrier"/>
 			<select value="10" t="traffic_calming"/>
-			<select value="20" t="highway" v="traffic_signals"/>
+			<select value="10" t="highway" v="traffic_signals"/>
 			<select value="1"  t="crossing" v="unmarked"/>
 			<select value="5"  t="crossing" v="uncontrolled"/>
 			<select value="15" t="highway" v="crossing"/>


### PR DESCRIPTION
[issue](https://github.com/osmandapp/OsmAnd/issues/25390)
[request](https://github.com/osmandapp/OsmAnd/pull/25764)

reduce x2 traffic light penalty. but I don't think this is a proper way to fix

```
//before
<select value="20" t="highway" v="traffic_signals"/>
<select value="15" t="crossing" v="traffic_signals"/>

//after
<select value="10" t="highway" v="traffic_signals"/>
<select value="5" t="crossing" v="traffic_signals"/>
```

// before - after
<img width="300"  alt="Screenshot 2026-08-28 at 11 55 13" src="https://github.com/user-attachments/assets/bbe1b7c1-7b92-41fa-9b87-d1893d2f48b1" />    <img width="300"  alt="Screenshot 2026-08-28 at 12 53 44" src="https://github.com/user-attachments/assets/a6a535f6-b57a-4835-83b9-e78c20596f68" />
