### PR TITLE
Fix SpatialSearchCombinationsTest[translation] after disc_golf_course POI type

### DIFF
--- a/test-resources/spatial_search/translation.json
+++ b/test-resources/spatial_search/translation.json
@@ -18,8 +18,8 @@
   ],
   "results": [
     [
-      "hotel [[1, POI_TYPE, t1+0-w1-oth-631-tp-2, 0.00 km, ['hotel' [POI_TYPE] 'hotel' id=748, obj=-631 ]]]",
-			"love_hotel [[1, POI_TYPE, t1+0-w1-oth-1-tp-2, 0.00 km, ['hotel' [POI_TYPE] 'love_hotel' id=995, obj=-1 ]]]",
+      "hotel [[1, POI_TYPE, t1+0-w1-oth-631-tp-2, 0.00 km, ['hotel' [POI_TYPE] 'hotel' id=749, obj=-631 ]]]",
+			"love_hotel [[1, POI_TYPE, t1+0-w1-oth-1-tp-2, 0.00 km, ['hotel' [POI_TYPE] 'love_hotel' id=996, obj=-1 ]]]",
 			"Hotel Sacher [[1, POI hotel, t1+0-w1-oth0-32elo-tp0, 0.00 km, Q279260 ['hotel' [POI отель 3504] 'Hotel Sacher' 628990501 56963 (48.2040 16.3701)]]]",
 			"Imperial [[1, POI hotel, t1+0-w1-oth0-28elo-tp0, 0.40 km, Q1630919 ['hotel' [POI отель 3253] 'Imperial' 151292 30696 (48.2011 16.3733)]]]",
 			"Hilton Budapest [[1, POI hotel, t1+0-w1-oth0-28elo-tp0, 213.55 km, Q2673309 ['hotel' [POI отель 3231] 'Hilton Budapest' 5647453 23487 (47.5026 19.0337)]]]",
@@ -31,7 +31,7 @@
 			"Lillafüred Palotaszálló [[1, POI hotel, t1+0-w1-oth0-17elo-tp0, 315.73 km, Q14701669 ['hotel' [POI отель 2506] 'Lillafüred Palotaszálló' 156790161 55383 (48.1047 20.6230)]]]",
 			"Anantara New York Palace Budapest [[1, POI hotel, t1+0-w1-oth0-13elo-tp0, 216.29 km, Q717739 ['hotel' [POI отель 2293] 'Anantara New York Palace Budapest' 1267688599 40938 (47.4987 19.0707)]]]"
     ],[
-      "hotel [[1, POI_TYPE, t1+0-w1-oth-1262-tp-2, 0.00 km, ['готель' [POI_TYPE] 'hotel' id=748, obj=-1,262 ]]]",
+      "hotel [[1, POI_TYPE, t1+0-w1-oth-1262-tp-2, 0.00 km, ['готель' [POI_TYPE] 'hotel' id=749, obj=-1,262 ]]]",
 			"Hotel Sacher [[1, POI hotel, t1+0-w1-oth0-32elo-tp0, 0.00 km, Q279260 ['готель' [POI отель 3504] 'Hotel Sacher' 628990501 56963 (48.2040 16.3701)]]]",
 			"Imperial [[1, POI hotel, t1+0-w1-oth0-28elo-tp0, 0.40 km, Q1630919 ['готель' [POI отель 3253] 'Imperial' 151292 30696 (48.2011 16.3733)]]]",
 			"Hilton Budapest [[1, POI hotel, t1+0-w1-oth0-28elo-tp0, 213.55 km, Q2673309 ['готель' [POI отель 3231] 'Hilton Budapest' 5647453 23487 (47.5026 19.0337)]]]",
@@ -42,7 +42,7 @@
 			"Lillafüred Palotaszálló [[1, POI hotel, t1+0-w1-oth0-17elo-tp0, 315.73 km, Q14701669 ['готель' [POI отель 2506] 'Lillafüred Palotaszálló' 156790161 55383 (48.1047 20.6230)]]]",
 			"Anantara New York Palace Budapest [[1, POI hotel, t1+0-w1-oth0-13elo-tp0, 216.29 km, Q717739 ['готель' [POI отель 2293] 'Anantara New York Palace Budapest' 1267688599 40938 (47.4987 19.0707)]]]"
     ],[
-      "hotel [[1, POI_TYPE, t1+0-w1-oth-1893-tp-2, 0.00 km, ['гатэль' [POI_TYPE] 'hotel' id=748, obj=-1,893 ]]]",
+      "hotel [[1, POI_TYPE, t1+0-w1-oth-1893-tp-2, 0.00 km, ['гатэль' [POI_TYPE] 'hotel' id=749, obj=-1,893 ]]]",
 			"Hotel Sacher [[1, POI hotel, t1+0-w1-oth0-32elo-tp0, 0.00 km, Q279260 ['гатэль' [POI отель 3504] 'Hotel Sacher' 628990501 56963 (48.2040 16.3701)]]]",
 			"Imperial [[1, POI hotel, t1+0-w1-oth0-28elo-tp0, 0.40 km, Q1630919 ['гатэль' [POI отель 3253] 'Imperial' 151292 30696 (48.2011 16.3733)]]]",
 			"Hilton Budapest [[1, POI hotel, t1+0-w1-oth0-28elo-tp0, 213.55 km, Q2673309 ['гатэль' [POI отель 3231] 'Hilton Budapest' 5647453 23487 (47.5026 19.0337)]]]",


### PR DESCRIPTION
## Problem

`net.osmand.search.SpatialSearchCombinationsTest.testSearch[26: translation]` has been failing since build #13263:

```
org.junit.ComparisonFailure: expected:<..._TYPE] 'hotel' id=74[8], obj=-631 ]]]>
                              but was:<..._TYPE] 'hotel' id=74[9], obj=-631 ]]]>
```

https://builder.osmand.net:8080/job/OsmAndMapCreator/lastCompletedBuild/testReport/net.osmand.search/SpatialSearchCombinationsTest/

## Cause

The `id=` printed for `POI_TYPE` results (`SpatialSearchResult.java:438`, `atom.id`) is the ordinal of the POI type in `poi/poi_types.xml`. Commit dbce3a596 ("Add disc_golf_course") inserted `<poi_type name="disc_golf_course" tag="leisure" .../>` at line 3392, which is *before* the `tourism` section, so every ordinal after it shifted by +1:

- `hotel`: 748 → 749
- `love_hotel`: 995 → 996

Only `translation.json` is affected: for non-translation tests the expected/actual strings are truncated at `first '[' + 4` chars, so the id is never compared. Of the three tests with `"translation": true` (`translation.json`, `ukraine_school.json`, `world.json`), only this one contains the shifted types.

## Fix

Updated the four expected strings in `test-resources/spatial_search/translation.json`.

Verified locally:

```
./gradlew :OsmAndMapCreatorUtilities:cleanTest :OsmAndMapCreatorUtilities:test \
    --tests net.osmand.search.SpatialSearchCombinationsTest
```

74 tests, 0 failures (the same run reproduced the failure before the change).

## Note

This test will break again on every POI type added above `tourism` in `poi_types.xml`. Dropping `id=%d` from the `POI_TYPE` format in `SpatialSearchResult.java` would make it robust — happy to do that in a follow-up if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0148FLBxww2xzGdDw9eTvXsP