### PR TITLE
Use foot style for shared foot/bicycle paths in pedestrian mode

### DIFF
--- a/rendering_styles/default.render.xml
+++ b/rendering_styles/default.render.xml
@@ -10728,7 +10728,9 @@
 								<apply_if showSurfaceGrade="true" strokeWidth_5="$trackWithSurfaceStrokeWidth"/>
 								<apply_if showSurfaces="true" strokeWidth_5="$trackWithSurfaceStrokeWidth"/>
 							</case>
-							<apply minzoom="14" additional="bicycle=designated" color_5="$cyclewayColor" pathEffect_5="4_2" strokeWidth_5="1:1"/>
+							<apply minzoom="14" additional="bicycle=designated" color_5="$cyclewayColor" pathEffect_5="4_2" strokeWidth_5="1:1">
+								<apply_if baseAppMode="pedestrian" additional="foot=designated" color_5="$pathColor" pathEffect_5="$pathPathEffect" strokeWidth_5="$pathStrokeWidth"/>
+							</apply>
 							<apply_if additional="winter_road=yes" minzoom="11" strokeWidth_4="2:2"/>
 							<apply_if additional="ice_road=yes" minzoom="11" strokeWidth_4="2:2"/>
 							<apply_if nightMode="true">
@@ -10803,7 +10805,9 @@
 							<apply minzoom="14" strokeWidth_4="1.4:1.4" strokeWidth_5="1:1" pathEffect_5="$cyclewayPathEffect"/>
 						</case>
 						<case minzoom="14" strokeWidth_4="1.3:1.3" strokeWidth_5="$cyclewayStrokeWidth" pathEffect_5="$cyclewayPathEffect"/>
-						<apply color_5="$cyclewayColor"/>
+						<apply color_5="$cyclewayColor">
+							<apply_if baseAppMode="pedestrian" additional="foot=designated" color_5="$footwayColor" pathEffect_5="4_2" strokeWidth_5="$footwayStrokeWidth"/>
+						</apply>
 						<apply_if nightMode="true" color="#77002a2a">
 							<apply_if minzoom="13" maxzoom="13" strokeWidth_4="0.6"/>
 							<apply_if minzoom="14" maxzoom="14" strokeWidth_4="1:1"/>


### PR DESCRIPTION
## Summary
- Fixes https://github.com/osmandapp/OsmAnd/issues/25690: combined foot/bicycle paths (`highway=path`/`highway=cycleway` + `bicycle=designated` + `foot=designated`) were always drawn with the cycleway (blue) color, even in pedestrian profile, making them indistinguishable from bicycle-only paths.
- `highway=path` + `bicycle=designated`: keep the existing blue cycleway color in all other profiles, but fall back to the regular path color/effect/width when `baseAppMode="pedestrian"` and `foot=designated` is also present.
- `highway=cycleway`: same idea, falling back to footway styling in pedestrian mode when `foot=designated` is present.
- `highway=footway` was already correctly restricting its cycleway-color override to `baseAppMode="bicycle"` — left unchanged, used as the reference pattern for this fix.

## Test plan
- [x] `default.render.xml` validated as well-formed XML.
- [ ] Manually render a way tagged `highway=path` + `bicycle=designated` + `foot=designated` in pedestrian vs. bicycle profile in OsmAnd/JOSM and confirm it now shows the path color in pedestrian mode and the cycleway color in bicycle mode.
- [ ] Same check for `highway=cycleway` + `foot=designated`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)