### PR TITLE
Support waterway=access_point as canoe put in / take out

### DIFF
--- a/obf_creation/rendering_types.xml
+++ b/obf_creation/rendering_types.xml
@@ -6328,6 +6328,24 @@
 	<entity_convert pattern="tag_transform" from_tag="whitewater" from_value="put_in;egress" to_tag1="canoe" to_value1="put_in;egress"/>
 	<entity_convert pattern="tag_transform" from_tag="whitewater" from_value="portage_way" to_tag1="canoe" to_value1="portage"/>
 
+	<!-- waterway=access_point is the modern (and now most common) tagging for a paddlecraft put in / take out point:
+	     https://wiki.openstreetmap.org/wiki/Tag:waterway%3Daccess_point
+	     canoe=put_in / egress / put_in;egress refine it and are handled by the types above, canoe=no means "not for paddlecraft".
+	     Everything else (no canoe=* at all, canoe=yes/designated/permissive/...) is a generic access point usable both ways. -->
+	<entity_convert pattern="tag_transform" poi="no" from_tag="waterway" from_value="access_point"
+			if_not_tag1="canoe" if_not_value1="no"
+			if_not_tag2="canoe" if_not_value2="put_in"
+			if_not_tag3="canoe" if_not_value3="egress"
+			if_not_tag4="canoe" if_not_value4="put_in;egress"
+			to_tag1="canoe" to_value1="put_in;egress"/>
+	<!-- canoe=put_in;egress has no poi_type (";" combination is not allowed there), so index such points as canoe=put_in for POI search -->
+	<entity_convert pattern="tag_transform" map="no" routing="no" from_tag="waterway" from_value="access_point"
+			if_not_tag1="canoe" if_not_value1="no"
+			if_not_tag2="canoe" if_not_value2="put_in"
+			if_not_tag3="canoe" if_not_value3="egress"
+			if_not_tag4="canoe" if_not_value4="put_in;egress"
+			to_tag1="canoe" to_value1="put_in"/>
+
 	<type tag="portage" value="yes" minzoom="14"/>
 	<type tag="portage" value="designated" minzoom="14"/>
 	<type tag="portage" value="permissive" minzoom="14"/>

--- a/test-resources/synthetic_test_rendering.osm
+++ b/test-resources/synthetic_test_rendering.osm
@@ -1419,6 +1419,25 @@
     <tag k="canoe" v="put_in;egress"/>
     <tag k="name" v="Put in; Egress"/>
   </node>
+  <node id="16642" version="1" lat="45.6858339" lon="36.5002781">
+    <tag k="name" v="Access point"/>
+    <tag k="waterway" v="access_point"/>
+  </node>
+  <node id="16643" version="1" lat="45.6856079" lon="36.5002781">
+    <tag k="canoe" v="put_in"/>
+    <tag k="name" v="Access point put in"/>
+    <tag k="waterway" v="access_point"/>
+  </node>
+  <node id="16644" version="1" lat="45.6858307" lon="36.5021445">
+    <tag k="canoe" v="yes"/>
+    <tag k="name" v="Access point canoe yes"/>
+    <tag k="waterway" v="access_point"/>
+  </node>
+  <node id="16645" version="1" lat="45.6856047" lon="36.5021445">
+    <tag k="canoe" v="no"/>
+    <tag k="name" v="Access point canoe no (not rendered)"/>
+    <tag k="waterway" v="access_point"/>
+  </node>
   <node id="906" version="1" lat="45.68772" lon="36.5021453"/>
   <node id="907" version="1" lat="45.6876189" lon="36.5021452">
     <tag k="name" v="Rapid grade 0"/>


### PR DESCRIPTION
Fixes osmandapp/OsmAnd#25512

### Problem

[`waterway=access_point`](https://wiki.openstreetmap.org/wiki/Tag:waterway%3Daccess_point) is by now the most common way to tag a paddlecraft put in / take out, but OsmAnd only knows `canoe=*` and the older `whitewater=*` tags. Access points tagged the modern way are missing from the **Whitewater sports** overlay and from POI search.

Note on the QA repro in the issue: node [6238842200](https://www.openstreetmap.org/node/6238842200) also carries `canoe=put_in` and is already handled — but `waterway=access_point` was only added there on 2026-05-09 (v2 replaced `leisure=slipway`), so that screenshot was most likely taken on an older map. The real gap is a bare `waterway=access_point`.

### Change

`obf_creation/rendering_types.xml` — two `entity_convert` rules next to the existing `whitewater=*` → `canoe=*` ones:

* map: `waterway=access_point` → `canoe=put_in;egress` (an access point works both ways, so the `put_in_egress` icon)
* POI: → `canoe=put_in`, because `canoe=put_in;egress` has no `poi_type` ("Broken combination is not allowed"), and without this the point would not be searchable

Both rules are skipped when the node already carries `canoe=put_in`, `canoe=egress`, `canoe=put_in;egress` (existing handling applies) or `canoe=no` (stays invisible, as requested in the issue).

No rendering style change is needed — `routes.addon.render.xml` already draws `canoe=put_in;egress` under `whiteWaterSports="true"`.

`test-resources/synthetic_test_rendering.osm` — 4 nodes added to the whitewater cluster: bare access point, with `canoe=put_in`, with `canoe=yes`, with `canoe=no`.

### Verification

`MapRenderingTypesEncoder.transformTags()` output before/after the conversion:

| input | MAP | POI |
| --- | --- | --- |
| `waterway=access_point` | `canoe=put_in;egress` | `canoe=put_in` |
| `waterway=access_point` + `canoe=put_in` | unchanged | unchanged |
| `waterway=access_point` + `canoe=egress` | unchanged | unchanged |
| `waterway=access_point` + `canoe=put_in;egress` | unchanged | unchanged |
| `waterway=access_point` + `canoe=yes` | `canoe=put_in;egress` | `canoe=put_in` |
| `waterway=access_point` + `canoe=no` | unchanged (not rendered) | unchanged |
| `whitewater=put_in` | `canoe=put_in` | `canoe=put_in` | 

The last row confirms the existing `whitewater=*` conversions are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)