### PR TITLE
Render path=climbing_access under Climbing routes option

### DIFF
--- a/obf_creation/rendering_types.xml
+++ b/obf_creation/rendering_types.xml
@@ -3088,6 +3088,10 @@
 		<type tag="sac_scale" value="difficult_alpine_hiking" minzoom="12" additional="true"/>
 	</category>
 
+	<category name="climbing">
+		<type tag="path" value="climbing_access" minzoom="12" additional="true"/>
+	</category>
+
 	<category name="cai_scale">
 		<type tag="cai_scale" value="t" minzoom="12" additional="true" relation="true"/>
 		<type tag="cai_scale" value="e" minzoom="12" additional="true" relation="true"/>

--- a/rendering_styles/default.render.xml
+++ b/rendering_styles/default.render.xml
@@ -1329,6 +1329,7 @@
 		<renderingConstant name="sacScaleColorT4" value="#6000ff"/>
 		<renderingConstant name="sacScaleColorT5" value="#6000ff"/>
 		<renderingConstant name="sacScaleColorT6" value="#6000ff"/>
+		<renderingConstant name="climbingAccessColor" value="#FF8C00"/>
 
 		<renderingAttribute name="caiScaleColor">
 			<case attrColorValue="#e23cad"/>
@@ -10795,6 +10796,7 @@
 								</switch>
 							</case>
     						</apply_if>
+						<apply_if showClimbingRoutes="true" additional="path=climbing_access" color_5="$climbingAccessColor" pathEffect_5="6_3"/>
 					</switch>
 
 					<case minzoom="$cyclewayMinZoom" tag="highway" value="cycleway">


### PR DESCRIPTION

<img width="2056" height="1064" alt="before_after_side_by_side" src="https://github.com/user-attachments/assets/8a161673-a9f5-4a25-9923-e6c6d328e20b" />

## Summary
- Registers `path=climbing_access` (~2000 uses in OSM, documented tag for "paths dedicated to access climbing crags") as an additional type in `rendering_types.xml`, so it's no longer dropped during OBF map generation.
- Renders it as a distinct orange dashed line in `default.render.xml` when the existing **Climbing routes** map style option is enabled, complementing the climbing crag/route rendering added in #21248.

Previously such approach paths were only visible through the generic sac_scale hiking-difficulty coloring (thin grey dotted line), indistinguishable from any other graded hiking trail.

Closes https://github.com/osmandapp/OsmAnd/issues/25827

## Before / after
Rendered locally with the legacy native renderer against a small OBF built from a live Overpass extract around 50.887594,14.255976 (Saxon Switzerland climbing area), way ids 130333838 / 130333839 / 130333840.

Before: approach path blends in as a generic sac_scale-graded trail.
After: approach path is a distinct orange dashed line when Climbing routes is enabled.

(screenshots attached separately)

## Test plan
- [ ] Built a test OBF from an Overpass extract containing `path=climbing_access` ways and confirmed the tag now round-trips through map generation
- [ ] Rendered before/after tiles with the legacy native renderer (`libosmand.dylib`) confirming the new orange dashed line appears only with **Climbing routes** enabled
- [ ] Visual check that regular `highway=path`/sac_scale styling is unaffected when `path=climbing_access` is absent

🤖 Generated with [Claude Code](https://claude.com/claude-code)