### PR TITLE
fix moped:backward=designated on cycleway

### DIFF
--- a/routing/routing.xml
+++ b/routing/routing.xml
@@ -3094,6 +3094,8 @@
 			<select value="1" t="moped" v="destination"/>
 			<select value="1" t="moped" v="dismount"/>
 			<select value="-1" t="moped" v="no"/>
+			<select value="1" t="moped:forward" v="designated"/>
+			<select value="1" t="moped:backward" v="designated"/>
 			<!-- <select value="-1" t="moped" v="use_sidepath"/> Already done by an entity_convert when creating the map files -->
 
 			<!-- Don't allow mopeds on steps or elevators, unless excplicly tagged and caught by rules above -->
@@ -3240,9 +3242,10 @@
 			<select value="1" t="oneway:bicycle" v="yes"/>
 			<select value="-1" t="oneway:bicycle" v="-1"/>
 
+            <select value="1" t="moped:forward" v="designated"/>
 			<select value="-1" t="moped:forward" v="no"/>
 			<select value="-1" t="moped:forward" v="use_sidepath"/>
-
+			
 			<select value="1" t="oneway:vehicle" v="yes"/>
 			<select value="0" t="oneway:vehicle" v="no"/>
 			<select value="-1" t="oneway:vehicle" v="-1"/>
@@ -3250,8 +3253,8 @@
 			<select value="-1" t="motor_vehicle:forward" v="no"/>
 			<select value="1" t="vehicle:backward" v="no"/>
 			<select value="-1" t="vehicle:forward" v="no"/>
+			<select value="-1" t="moped:backward" v="designated"/>
 			<select value="1" t="moped:backward" v="no"/>
-			<select value="-1" t="moped:forward" v="no"/>
 
 			<select value="1" t="oneway" v="yes"/>
 			<select value="1" t="oneway" v="1"/>

--- a/routing/routing.xml
+++ b/routing/routing.xml
@@ -3242,10 +3242,9 @@
 			<select value="1" t="oneway:bicycle" v="yes"/>
 			<select value="-1" t="oneway:bicycle" v="-1"/>
 
-            <select value="1" t="moped:forward" v="designated"/>
 			<select value="-1" t="moped:forward" v="no"/>
 			<select value="-1" t="moped:forward" v="use_sidepath"/>
-			
+
 			<select value="1" t="oneway:vehicle" v="yes"/>
 			<select value="0" t="oneway:vehicle" v="no"/>
 			<select value="-1" t="oneway:vehicle" v="-1"/>
@@ -3253,8 +3252,8 @@
 			<select value="-1" t="motor_vehicle:forward" v="no"/>
 			<select value="1" t="vehicle:backward" v="no"/>
 			<select value="-1" t="vehicle:forward" v="no"/>
-			<select value="-1" t="moped:backward" v="designated"/>
 			<select value="1" t="moped:backward" v="no"/>
+			<select value="-1" t="moped:forward" v="no"/>
 
 			<select value="1" t="oneway" v="yes"/>
 			<select value="1" t="oneway" v="1"/>


### PR DESCRIPTION
[issue](https://github.com/osmandapp/OsmAnd/issues/25093)

---

### Example from issue - with full tags

https://www.openstreetmap.org/way/436695603
52.28089 6.77860
52.28112, 6.77845

```
moped:backward  = designated 
moped:forward = no     //existed
```


before: 

<img width="200"  alt="Screenshot 2026-09-03 at 21 52 03" src="https://github.com/user-attachments/assets/0bead1cd-43a9-4f04-ac61-9c1769419630" />        <img width="200"  alt="Screenshot 2026-09-03 at 21 52 10" src="https://github.com/user-attachments/assets/4dc5a1ed-1451-4d08-9d31-096ddf2ac20e" />

after:

<img width="200" alt="Screenshot 2026-09-03 at 21 53 30" src="https://github.com/user-attachments/assets/398bd0ac-d3b4-4a63-9791-9c1bf30e2eb2" />
<img width="200" alt="Screenshot 2026-09-03 at 21 53 39" src="https://github.com/user-attachments/assets/6073b0e8-d4b3-475a-a1bd-e3ac45c6aa36" />

---

### Example with partial tags

https://www.openstreetmap.org/way/790181672
51.36465 6.13448
51.36448 6.13443

```
moped:backward  = designated 
moped:forward = no    // not existed
```

before: 

<img width="200"  src="https://github.com/user-attachments/assets/ff55a2a6-98e1-46d4-a42c-f39361b7088e" />   <img width="200" src="https://github.com/user-attachments/assets/7ab84332-d85c-42a8-aa39-025ac698d3cb" />

after:

<img width="200"  alt="Screenshot 2026-09-03 at 22 16 15" src="https://github.com/user-attachments/assets/938a276b-d019-49f1-87cb-821bcd015265" />           <img width="200"  alt="Screenshot 2026-09-03 at 22 15 58" src="https://github.com/user-attachments/assets/e355e826-02f6-4b23-8e2d-1603d3443335" />

---

