### PR TITLE
Style: draw routes sharing a path as parallel lanes

### DIFF
--- a/obf_creation/rendering_types.xml
+++ b/obf_creation/rendering_types.xml
@@ -1203,6 +1203,10 @@
 
 		<type tag="width" additional="true" minzoom="3"/>
 		<type tag="track_color" additional="true" minzoom="3" notosm="true"/>
+		<type tag="route_lane" additional="true" minzoom="3" notosm="true"/>
+		<type tag="route_lane_end" additional="true" minzoom="3" notosm="true"/>
+		<type tag="route_lane_side" additional="true" minzoom="3" notosm="true"/>
+		<type tag="route_shared_lane" additional="true" minzoom="3" notosm="true"/>
 		<type tag="translucent_line_colors" additional="true" minzoom="3" notosm="true"/>
 
 		<type tag="icon" additional="true" minzoom="3" notosm="true"/>

--- a/rendering_styles/routes.addon.render.xml
+++ b/rendering_styles/routes.addon.render.xml
@@ -4,6 +4,9 @@
 		type="string" possibleValues="browse map,car,bicycle,pedestrian"/>
 	<renderingProperty attr="baseAppMode" name="Default Rendering mode" description="Map optimization for respective User Profile based on base (parent) profile"
 		type="string" possibleValues="default,car,bicycle,pedestrian,public_transport,boat,ski"/>
+	<renderingProperty attr="routeLaneMode" name="Parallel route lanes"
+		description="How routes sharing a path are separated"
+		type="string" possibleValues="side,braid" defaultValueDescription="off" category="routes"/>
 	<renderingProperty attr="showCycleRoutes" name="Cycle routes" description="Show long distance cycle routes"
 		type="boolean" possibleValues="" category="routes"/>
 	<renderingProperty attr="showCycleNodeNetworkRoutes" name="Node network cycle routes" description="Show node network cycle routes"
@@ -1110,6 +1113,177 @@
 							<case additional="track_color=purple" color="$osmcPurpleColor" rClass=".route.bicycle.color.route_marker"/>
 							<case additional="track_color=pink" color="$osmcPinkColor" rClass=".route.bicycle.color.route_marker"/>
 							<case additional="track_color=teal" color="$osmcTealColor" rClass=".route.bicycle.color.route_marker"/>
+							<apply_if routeLaneMode="braid" additional="route_lane=0" maxzoom="13" hmargin="0"/>
+							<apply_if routeLaneMode="braid" additional="route_lane=0" minzoom="14" maxzoom="15" hmargin="0"/>
+							<apply_if routeLaneMode="braid" additional="route_lane=0" minzoom="16" maxzoom="17" hmargin="0"/>
+							<apply_if routeLaneMode="braid" additional="route_lane=0" minzoom="18" hmargin="0"/>
+							<apply_if routeLaneMode="braid" additional="route_lane=-8" maxzoom="13" hmargin="-10"/>
+							<apply_if routeLaneMode="braid" additional="route_lane_end=-8" maxzoom="13" hmargin_end="-10"/>
+							<apply_if routeLaneMode="braid" additional="route_lane=-8" minzoom="14" maxzoom="15" hmargin="-16"/>
+							<apply_if routeLaneMode="braid" additional="route_lane_end=-8" minzoom="14" maxzoom="15" hmargin_end="-16"/>
+							<apply_if routeLaneMode="braid" additional="route_lane=-8" minzoom="16" maxzoom="17" hmargin="-28"/>
+							<apply_if routeLaneMode="braid" additional="route_lane_end=-8" minzoom="16" maxzoom="17" hmargin_end="-28"/>
+							<apply_if routeLaneMode="braid" additional="route_lane=-8" minzoom="18" hmargin="-40"/>
+							<apply_if routeLaneMode="braid" additional="route_lane_end=-8" minzoom="18" hmargin_end="-40"/>
+							<apply_if routeLaneMode="braid" additional="route_lane=-7" maxzoom="13" hmargin="-8.75"/>
+							<apply_if routeLaneMode="braid" additional="route_lane_end=-7" maxzoom="13" hmargin_end="-8.75"/>
+							<apply_if routeLaneMode="braid" additional="route_lane=-7" minzoom="14" maxzoom="15" hmargin="-14"/>
+							<apply_if routeLaneMode="braid" additional="route_lane_end=-7" minzoom="14" maxzoom="15" hmargin_end="-14"/>
+							<apply_if routeLaneMode="braid" additional="route_lane=-7" minzoom="16" maxzoom="17" hmargin="-24.5"/>
+							<apply_if routeLaneMode="braid" additional="route_lane_end=-7" minzoom="16" maxzoom="17" hmargin_end="-24.5"/>
+							<apply_if routeLaneMode="braid" additional="route_lane=-7" minzoom="18" hmargin="-35"/>
+							<apply_if routeLaneMode="braid" additional="route_lane_end=-7" minzoom="18" hmargin_end="-35"/>
+							<apply_if routeLaneMode="braid" additional="route_lane=-6" maxzoom="13" hmargin="-7.5"/>
+							<apply_if routeLaneMode="braid" additional="route_lane_end=-6" maxzoom="13" hmargin_end="-7.5"/>
+							<apply_if routeLaneMode="braid" additional="route_lane=-6" minzoom="14" maxzoom="15" hmargin="-12"/>
+							<apply_if routeLaneMode="braid" additional="route_lane_end=-6" minzoom="14" maxzoom="15" hmargin_end="-12"/>
+							<apply_if routeLaneMode="braid" additional="route_lane=-6" minzoom="16" maxzoom="17" hmargin="-21"/>
+							<apply_if routeLaneMode="braid" additional="route_lane_end=-6" minzoom="16" maxzoom="17" hmargin_end="-21"/>
+							<apply_if routeLaneMode="braid" additional="route_lane=-6" minzoom="18" hmargin="-30"/>
+							<apply_if routeLaneMode="braid" additional="route_lane_end=-6" minzoom="18" hmargin_end="-30"/>
+							<apply_if routeLaneMode="braid" additional="route_lane=-5" maxzoom="13" hmargin="-6.25"/>
+							<apply_if routeLaneMode="braid" additional="route_lane_end=-5" maxzoom="13" hmargin_end="-6.25"/>
+							<apply_if routeLaneMode="braid" additional="route_lane=-5" minzoom="14" maxzoom="15" hmargin="-10"/>
+							<apply_if routeLaneMode="braid" additional="route_lane_end=-5" minzoom="14" maxzoom="15" hmargin_end="-10"/>
+							<apply_if routeLaneMode="braid" additional="route_lane=-5" minzoom="16" maxzoom="17" hmargin="-17.5"/>
+							<apply_if routeLaneMode="braid" additional="route_lane_end=-5" minzoom="16" maxzoom="17" hmargin_end="-17.5"/>
+							<apply_if routeLaneMode="braid" additional="route_lane=-5" minzoom="18" hmargin="-25"/>
+							<apply_if routeLaneMode="braid" additional="route_lane_end=-5" minzoom="18" hmargin_end="-25"/>
+							<apply_if routeLaneMode="braid" additional="route_lane=-4" maxzoom="13" hmargin="-5"/>
+							<apply_if routeLaneMode="braid" additional="route_lane_end=-4" maxzoom="13" hmargin_end="-5"/>
+							<apply_if routeLaneMode="braid" additional="route_lane=-4" minzoom="14" maxzoom="15" hmargin="-8"/>
+							<apply_if routeLaneMode="braid" additional="route_lane_end=-4" minzoom="14" maxzoom="15" hmargin_end="-8"/>
+							<apply_if routeLaneMode="braid" additional="route_lane=-4" minzoom="16" maxzoom="17" hmargin="-14"/>
+							<apply_if routeLaneMode="braid" additional="route_lane_end=-4" minzoom="16" maxzoom="17" hmargin_end="-14"/>
+							<apply_if routeLaneMode="braid" additional="route_lane=-4" minzoom="18" hmargin="-20"/>
+							<apply_if routeLaneMode="braid" additional="route_lane_end=-4" minzoom="18" hmargin_end="-20"/>
+							<apply_if routeLaneMode="braid" additional="route_lane=-3" maxzoom="13" hmargin="-3.75"/>
+							<apply_if routeLaneMode="braid" additional="route_lane_end=-3" maxzoom="13" hmargin_end="-3.75"/>
+							<apply_if routeLaneMode="braid" additional="route_lane=-3" minzoom="14" maxzoom="15" hmargin="-6"/>
+							<apply_if routeLaneMode="braid" additional="route_lane_end=-3" minzoom="14" maxzoom="15" hmargin_end="-6"/>
+							<apply_if routeLaneMode="braid" additional="route_lane=-3" minzoom="16" maxzoom="17" hmargin="-10.5"/>
+							<apply_if routeLaneMode="braid" additional="route_lane_end=-3" minzoom="16" maxzoom="17" hmargin_end="-10.5"/>
+							<apply_if routeLaneMode="braid" additional="route_lane=-3" minzoom="18" hmargin="-15"/>
+							<apply_if routeLaneMode="braid" additional="route_lane_end=-3" minzoom="18" hmargin_end="-15"/>
+							<apply_if routeLaneMode="braid" additional="route_lane=-2" maxzoom="13" hmargin="-2.5"/>
+							<apply_if routeLaneMode="braid" additional="route_lane_end=-2" maxzoom="13" hmargin_end="-2.5"/>
+							<apply_if routeLaneMode="braid" additional="route_lane=-2" minzoom="14" maxzoom="15" hmargin="-4"/>
+							<apply_if routeLaneMode="braid" additional="route_lane_end=-2" minzoom="14" maxzoom="15" hmargin_end="-4"/>
+							<apply_if routeLaneMode="braid" additional="route_lane=-2" minzoom="16" maxzoom="17" hmargin="-7"/>
+							<apply_if routeLaneMode="braid" additional="route_lane_end=-2" minzoom="16" maxzoom="17" hmargin_end="-7"/>
+							<apply_if routeLaneMode="braid" additional="route_lane=-2" minzoom="18" hmargin="-10"/>
+							<apply_if routeLaneMode="braid" additional="route_lane_end=-2" minzoom="18" hmargin_end="-10"/>
+							<apply_if routeLaneMode="braid" additional="route_lane=-1" maxzoom="13" hmargin="-1.25"/>
+							<apply_if routeLaneMode="braid" additional="route_lane_end=-1" maxzoom="13" hmargin_end="-1.25"/>
+							<apply_if routeLaneMode="braid" additional="route_lane=-1" minzoom="14" maxzoom="15" hmargin="-2"/>
+							<apply_if routeLaneMode="braid" additional="route_lane_end=-1" minzoom="14" maxzoom="15" hmargin_end="-2"/>
+							<apply_if routeLaneMode="braid" additional="route_lane=-1" minzoom="16" maxzoom="17" hmargin="-3.5"/>
+							<apply_if routeLaneMode="braid" additional="route_lane_end=-1" minzoom="16" maxzoom="17" hmargin_end="-3.5"/>
+							<apply_if routeLaneMode="braid" additional="route_lane=-1" minzoom="18" hmargin="-5"/>
+							<apply_if routeLaneMode="braid" additional="route_lane_end=-1" minzoom="18" hmargin_end="-5"/>
+							<apply_if routeLaneMode="braid" additional="route_lane=1" maxzoom="13" hmargin="1.25"/>
+							<apply_if routeLaneMode="braid" additional="route_lane_end=1" maxzoom="13" hmargin_end="1.25"/>
+							<apply_if routeLaneMode="braid" additional="route_lane=1" minzoom="14" maxzoom="15" hmargin="2"/>
+							<apply_if routeLaneMode="braid" additional="route_lane_end=1" minzoom="14" maxzoom="15" hmargin_end="2"/>
+							<apply_if routeLaneMode="braid" additional="route_lane=1" minzoom="16" maxzoom="17" hmargin="3.5"/>
+							<apply_if routeLaneMode="braid" additional="route_lane_end=1" minzoom="16" maxzoom="17" hmargin_end="3.5"/>
+							<apply_if routeLaneMode="braid" additional="route_lane=1" minzoom="18" hmargin="5"/>
+							<apply_if routeLaneMode="braid" additional="route_lane_end=1" minzoom="18" hmargin_end="5"/>
+							<apply_if routeLaneMode="braid" additional="route_lane=2" maxzoom="13" hmargin="2.5"/>
+							<apply_if routeLaneMode="braid" additional="route_lane_end=2" maxzoom="13" hmargin_end="2.5"/>
+							<apply_if routeLaneMode="braid" additional="route_lane=2" minzoom="14" maxzoom="15" hmargin="4"/>
+							<apply_if routeLaneMode="braid" additional="route_lane_end=2" minzoom="14" maxzoom="15" hmargin_end="4"/>
+							<apply_if routeLaneMode="braid" additional="route_lane=2" minzoom="16" maxzoom="17" hmargin="7"/>
+							<apply_if routeLaneMode="braid" additional="route_lane_end=2" minzoom="16" maxzoom="17" hmargin_end="7"/>
+							<apply_if routeLaneMode="braid" additional="route_lane=2" minzoom="18" hmargin="10"/>
+							<apply_if routeLaneMode="braid" additional="route_lane_end=2" minzoom="18" hmargin_end="10"/>
+							<apply_if routeLaneMode="braid" additional="route_lane=3" maxzoom="13" hmargin="3.75"/>
+							<apply_if routeLaneMode="braid" additional="route_lane_end=3" maxzoom="13" hmargin_end="3.75"/>
+							<apply_if routeLaneMode="braid" additional="route_lane=3" minzoom="14" maxzoom="15" hmargin="6"/>
+							<apply_if routeLaneMode="braid" additional="route_lane_end=3" minzoom="14" maxzoom="15" hmargin_end="6"/>
+							<apply_if routeLaneMode="braid" additional="route_lane=3" minzoom="16" maxzoom="17" hmargin="10.5"/>
+							<apply_if routeLaneMode="braid" additional="route_lane_end=3" minzoom="16" maxzoom="17" hmargin_end="10.5"/>
+							<apply_if routeLaneMode="braid" additional="route_lane=3" minzoom="18" hmargin="15"/>
+							<apply_if routeLaneMode="braid" additional="route_lane_end=3" minzoom="18" hmargin_end="15"/>
+							<apply_if routeLaneMode="braid" additional="route_lane=4" maxzoom="13" hmargin="5"/>
+							<apply_if routeLaneMode="braid" additional="route_lane_end=4" maxzoom="13" hmargin_end="5"/>
+							<apply_if routeLaneMode="braid" additional="route_lane=4" minzoom="14" maxzoom="15" hmargin="8"/>
+							<apply_if routeLaneMode="braid" additional="route_lane_end=4" minzoom="14" maxzoom="15" hmargin_end="8"/>
+							<apply_if routeLaneMode="braid" additional="route_lane=4" minzoom="16" maxzoom="17" hmargin="14"/>
+							<apply_if routeLaneMode="braid" additional="route_lane_end=4" minzoom="16" maxzoom="17" hmargin_end="14"/>
+							<apply_if routeLaneMode="braid" additional="route_lane=4" minzoom="18" hmargin="20"/>
+							<apply_if routeLaneMode="braid" additional="route_lane_end=4" minzoom="18" hmargin_end="20"/>
+							<apply_if routeLaneMode="braid" additional="route_lane=5" maxzoom="13" hmargin="6.25"/>
+							<apply_if routeLaneMode="braid" additional="route_lane_end=5" maxzoom="13" hmargin_end="6.25"/>
+							<apply_if routeLaneMode="braid" additional="route_lane=5" minzoom="14" maxzoom="15" hmargin="10"/>
+							<apply_if routeLaneMode="braid" additional="route_lane_end=5" minzoom="14" maxzoom="15" hmargin_end="10"/>
+							<apply_if routeLaneMode="braid" additional="route_lane=5" minzoom="16" maxzoom="17" hmargin="17.5"/>
+							<apply_if routeLaneMode="braid" additional="route_lane_end=5" minzoom="16" maxzoom="17" hmargin_end="17.5"/>
+							<apply_if routeLaneMode="braid" additional="route_lane=5" minzoom="18" hmargin="25"/>
+							<apply_if routeLaneMode="braid" additional="route_lane_end=5" minzoom="18" hmargin_end="25"/>
+							<apply_if routeLaneMode="braid" additional="route_lane=6" maxzoom="13" hmargin="7.5"/>
+							<apply_if routeLaneMode="braid" additional="route_lane_end=6" maxzoom="13" hmargin_end="7.5"/>
+							<apply_if routeLaneMode="braid" additional="route_lane=6" minzoom="14" maxzoom="15" hmargin="12"/>
+							<apply_if routeLaneMode="braid" additional="route_lane_end=6" minzoom="14" maxzoom="15" hmargin_end="12"/>
+							<apply_if routeLaneMode="braid" additional="route_lane=6" minzoom="16" maxzoom="17" hmargin="21"/>
+							<apply_if routeLaneMode="braid" additional="route_lane_end=6" minzoom="16" maxzoom="17" hmargin_end="21"/>
+							<apply_if routeLaneMode="braid" additional="route_lane=6" minzoom="18" hmargin="30"/>
+							<apply_if routeLaneMode="braid" additional="route_lane_end=6" minzoom="18" hmargin_end="30"/>
+							<apply_if routeLaneMode="braid" additional="route_lane=7" maxzoom="13" hmargin="8.75"/>
+							<apply_if routeLaneMode="braid" additional="route_lane_end=7" maxzoom="13" hmargin_end="8.75"/>
+							<apply_if routeLaneMode="braid" additional="route_lane=7" minzoom="14" maxzoom="15" hmargin="14"/>
+							<apply_if routeLaneMode="braid" additional="route_lane_end=7" minzoom="14" maxzoom="15" hmargin_end="14"/>
+							<apply_if routeLaneMode="braid" additional="route_lane=7" minzoom="16" maxzoom="17" hmargin="24.5"/>
+							<apply_if routeLaneMode="braid" additional="route_lane_end=7" minzoom="16" maxzoom="17" hmargin_end="24.5"/>
+							<apply_if routeLaneMode="braid" additional="route_lane=7" minzoom="18" hmargin="35"/>
+							<apply_if routeLaneMode="braid" additional="route_lane_end=7" minzoom="18" hmargin_end="35"/>
+							<apply_if routeLaneMode="braid" additional="route_lane=8" maxzoom="13" hmargin="10"/>
+							<apply_if routeLaneMode="braid" additional="route_lane_end=8" maxzoom="13" hmargin_end="10"/>
+							<apply_if routeLaneMode="braid" additional="route_lane=8" minzoom="14" maxzoom="15" hmargin="16"/>
+							<apply_if routeLaneMode="braid" additional="route_lane_end=8" minzoom="14" maxzoom="15" hmargin_end="16"/>
+							<apply_if routeLaneMode="braid" additional="route_lane=8" minzoom="16" maxzoom="17" hmargin="28"/>
+							<apply_if routeLaneMode="braid" additional="route_lane_end=8" minzoom="16" maxzoom="17" hmargin_end="28"/>
+							<apply_if routeLaneMode="braid" additional="route_lane=8" minzoom="18" hmargin="40"/>
+							<apply_if routeLaneMode="braid" additional="route_lane_end=8" minzoom="18" hmargin_end="40"/>
+							<apply_if routeLaneMode="side" additional="route_lane_side=0" maxzoom="13" hmargin="1.5"/>
+							<apply_if routeLaneMode="side" additional="route_lane_side=0" minzoom="14" maxzoom="15" hmargin="2.5"/>
+							<apply_if routeLaneMode="side" additional="route_lane_side=0" minzoom="16" maxzoom="17" hmargin="4"/>
+							<apply_if routeLaneMode="side" additional="route_lane_side=0" minzoom="18" hmargin="6"/>
+							<apply_if routeLaneMode="side" additional="route_lane_side=1" maxzoom="13" hmargin="3"/>
+							<apply_if routeLaneMode="side" additional="route_lane_side=1" minzoom="14" maxzoom="15" hmargin="5"/>
+							<apply_if routeLaneMode="side" additional="route_lane_side=1" minzoom="16" maxzoom="17" hmargin="8"/>
+							<apply_if routeLaneMode="side" additional="route_lane_side=1" minzoom="18" hmargin="12"/>
+							<apply_if routeLaneMode="side" additional="route_lane_side=2" maxzoom="13" hmargin="4.5"/>
+							<apply_if routeLaneMode="side" additional="route_lane_side=2" minzoom="14" maxzoom="15" hmargin="7.5"/>
+							<apply_if routeLaneMode="side" additional="route_lane_side=2" minzoom="16" maxzoom="17" hmargin="12"/>
+							<apply_if routeLaneMode="side" additional="route_lane_side=2" minzoom="18" hmargin="18"/>
+							<apply_if routeLaneMode="side" additional="route_lane_side=3" maxzoom="13" hmargin="6"/>
+							<apply_if routeLaneMode="side" additional="route_lane_side=3" minzoom="14" maxzoom="15" hmargin="10"/>
+							<apply_if routeLaneMode="side" additional="route_lane_side=3" minzoom="16" maxzoom="17" hmargin="16"/>
+							<apply_if routeLaneMode="side" additional="route_lane_side=3" minzoom="18" hmargin="24"/>
+							<apply_if routeLaneMode="side" additional="route_lane_side=4" maxzoom="13" hmargin="7.5"/>
+							<apply_if routeLaneMode="side" additional="route_lane_side=4" minzoom="14" maxzoom="15" hmargin="12.5"/>
+							<apply_if routeLaneMode="side" additional="route_lane_side=4" minzoom="16" maxzoom="17" hmargin="20"/>
+							<apply_if routeLaneMode="side" additional="route_lane_side=4" minzoom="18" hmargin="30"/>
+							<apply_if routeLaneMode="side" additional="route_lane_side=5" maxzoom="13" hmargin="9"/>
+							<apply_if routeLaneMode="side" additional="route_lane_side=5" minzoom="14" maxzoom="15" hmargin="15"/>
+							<apply_if routeLaneMode="side" additional="route_lane_side=5" minzoom="16" maxzoom="17" hmargin="24"/>
+							<apply_if routeLaneMode="side" additional="route_lane_side=5" minzoom="18" hmargin="36"/>
+							<apply_if routeLaneMode="side" additional="route_lane_side=6" maxzoom="13" hmargin="10.5"/>
+							<apply_if routeLaneMode="side" additional="route_lane_side=6" minzoom="14" maxzoom="15" hmargin="17.5"/>
+							<apply_if routeLaneMode="side" additional="route_lane_side=6" minzoom="16" maxzoom="17" hmargin="28"/>
+							<apply_if routeLaneMode="side" additional="route_lane_side=6" minzoom="18" hmargin="42"/>
+							<apply_if routeLaneMode="side" additional="route_lane_side=7" maxzoom="13" hmargin="12"/>
+							<apply_if routeLaneMode="side" additional="route_lane_side=7" minzoom="14" maxzoom="15" hmargin="20"/>
+							<apply_if routeLaneMode="side" additional="route_lane_side=7" minzoom="16" maxzoom="17" hmargin="32"/>
+							<apply_if routeLaneMode="side" additional="route_lane_side=7" minzoom="18" hmargin="48"/>
+							<apply_if routeLaneMode="side" additional="route_lane_side=8" maxzoom="13" hmargin="13.5"/>
+							<apply_if routeLaneMode="side" additional="route_lane_side=8" minzoom="14" maxzoom="15" hmargin="22.5"/>
+							<apply_if routeLaneMode="side" additional="route_lane_side=8" minzoom="16" maxzoom="17" hmargin="36"/>
+							<apply_if routeLaneMode="side" additional="route_lane_side=8" minzoom="18" hmargin="54"/>
+							<apply_if additional="route_shared_lane=yes" maxzoom="15" pathEffect="5_4"/>
+							<apply_if additional="route_shared_lane=yes" minzoom="16" maxzoom="17" pathEffect="7_5"/>
+							<apply_if additional="route_shared_lane=yes" minzoom="18" pathEffect="10_7"/>
 						</case>
 						<case showCycleNodeNetworkRoutes="true" rClass=".route.bicycle.node_network_segments" cap="BUTT">
 							<case additional="node_network=icn" color="$cycleRouteicnColor" rClass=".route.bicycle.color.classification"/>
@@ -1321,6 +1495,177 @@
 							<apply_if additional="track_color=purple" color="$osmcPurpleColor" rClass=".route.hiking.color.route_marker"/>
 							<apply_if additional="track_color=pink" color="$osmcPinkColor" rClass=".route.hiking.color.route_marker"/>
 							<apply_if additional="track_color=teal" color="$osmcTealColor" rClass=".route.hiking.color.route_marker"/>
+							<apply_if routeLaneMode="braid" additional="route_lane=0" maxzoom="13" hmargin="0"/>
+							<apply_if routeLaneMode="braid" additional="route_lane=0" minzoom="14" maxzoom="15" hmargin="0"/>
+							<apply_if routeLaneMode="braid" additional="route_lane=0" minzoom="16" maxzoom="17" hmargin="0"/>
+							<apply_if routeLaneMode="braid" additional="route_lane=0" minzoom="18" hmargin="0"/>
+							<apply_if routeLaneMode="braid" additional="route_lane=-8" maxzoom="13" hmargin="-10"/>
+							<apply_if routeLaneMode="braid" additional="route_lane_end=-8" maxzoom="13" hmargin_end="-10"/>
+							<apply_if routeLaneMode="braid" additional="route_lane=-8" minzoom="14" maxzoom="15" hmargin="-16"/>
+							<apply_if routeLaneMode="braid" additional="route_lane_end=-8" minzoom="14" maxzoom="15" hmargin_end="-16"/>
+							<apply_if routeLaneMode="braid" additional="route_lane=-8" minzoom="16" maxzoom="17" hmargin="-28"/>
+							<apply_if routeLaneMode="braid" additional="route_lane_end=-8" minzoom="16" maxzoom="17" hmargin_end="-28"/>
+							<apply_if routeLaneMode="braid" additional="route_lane=-8" minzoom="18" hmargin="-40"/>
+							<apply_if routeLaneMode="braid" additional="route_lane_end=-8" minzoom="18" hmargin_end="-40"/>
+							<apply_if routeLaneMode="braid" additional="route_lane=-7" maxzoom="13" hmargin="-8.75"/>
+							<apply_if routeLaneMode="braid" additional="route_lane_end=-7" maxzoom="13" hmargin_end="-8.75"/>
+							<apply_if routeLaneMode="braid" additional="route_lane=-7" minzoom="14" maxzoom="15" hmargin="-14"/>
+							<apply_if routeLaneMode="braid" additional="route_lane_end=-7" minzoom="14" maxzoom="15" hmargin_end="-14"/>
+							<apply_if routeLaneMode="braid" additional="route_lane=-7" minzoom="16" maxzoom="17" hmargin="-24.5"/>
+							<apply_if routeLaneMode="braid" additional="route_lane_end=-7" minzoom="16" maxzoom="17" hmargin_end="-24.5"/>
+							<apply_if routeLaneMode="braid" additional="route_lane=-7" minzoom="18" hmargin="-35"/>
+							<apply_if routeLaneMode="braid" additional="route_lane_end=-7" minzoom="18" hmargin_end="-35"/>
+							<apply_if routeLaneMode="braid" additional="route_lane=-6" maxzoom="13" hmargin="-7.5"/>
+							<apply_if routeLaneMode="braid" additional="route_lane_end=-6" maxzoom="13" hmargin_end="-7.5"/>
+							<apply_if routeLaneMode="braid" additional="route_lane=-6" minzoom="14" maxzoom="15" hmargin="-12"/>
+							<apply_if routeLaneMode="braid" additional="route_lane_end=-6" minzoom="14" maxzoom="15" hmargin_end="-12"/>
+							<apply_if routeLaneMode="braid" additional="route_lane=-6" minzoom="16" maxzoom="17" hmargin="-21"/>
+							<apply_if routeLaneMode="braid" additional="route_lane_end=-6" minzoom="16" maxzoom="17" hmargin_end="-21"/>
+							<apply_if routeLaneMode="braid" additional="route_lane=-6" minzoom="18" hmargin="-30"/>
+							<apply_if routeLaneMode="braid" additional="route_lane_end=-6" minzoom="18" hmargin_end="-30"/>
+							<apply_if routeLaneMode="braid" additional="route_lane=-5" maxzoom="13" hmargin="-6.25"/>
+							<apply_if routeLaneMode="braid" additional="route_lane_end=-5" maxzoom="13" hmargin_end="-6.25"/>
+							<apply_if routeLaneMode="braid" additional="route_lane=-5" minzoom="14" maxzoom="15" hmargin="-10"/>
+							<apply_if routeLaneMode="braid" additional="route_lane_end=-5" minzoom="14" maxzoom="15" hmargin_end="-10"/>
+							<apply_if routeLaneMode="braid" additional="route_lane=-5" minzoom="16" maxzoom="17" hmargin="-17.5"/>
+							<apply_if routeLaneMode="braid" additional="route_lane_end=-5" minzoom="16" maxzoom="17" hmargin_end="-17.5"/>
+							<apply_if routeLaneMode="braid" additional="route_lane=-5" minzoom="18" hmargin="-25"/>
+							<apply_if routeLaneMode="braid" additional="route_lane_end=-5" minzoom="18" hmargin_end="-25"/>
+							<apply_if routeLaneMode="braid" additional="route_lane=-4" maxzoom="13" hmargin="-5"/>
+							<apply_if routeLaneMode="braid" additional="route_lane_end=-4" maxzoom="13" hmargin_end="-5"/>
+							<apply_if routeLaneMode="braid" additional="route_lane=-4" minzoom="14" maxzoom="15" hmargin="-8"/>
+							<apply_if routeLaneMode="braid" additional="route_lane_end=-4" minzoom="14" maxzoom="15" hmargin_end="-8"/>
+							<apply_if routeLaneMode="braid" additional="route_lane=-4" minzoom="16" maxzoom="17" hmargin="-14"/>
+							<apply_if routeLaneMode="braid" additional="route_lane_end=-4" minzoom="16" maxzoom="17" hmargin_end="-14"/>
+							<apply_if routeLaneMode="braid" additional="route_lane=-4" minzoom="18" hmargin="-20"/>
+							<apply_if routeLaneMode="braid" additional="route_lane_end=-4" minzoom="18" hmargin_end="-20"/>
+							<apply_if routeLaneMode="braid" additional="route_lane=-3" maxzoom="13" hmargin="-3.75"/>
+							<apply_if routeLaneMode="braid" additional="route_lane_end=-3" maxzoom="13" hmargin_end="-3.75"/>
+							<apply_if routeLaneMode="braid" additional="route_lane=-3" minzoom="14" maxzoom="15" hmargin="-6"/>
+							<apply_if routeLaneMode="braid" additional="route_lane_end=-3" minzoom="14" maxzoom="15" hmargin_end="-6"/>
+							<apply_if routeLaneMode="braid" additional="route_lane=-3" minzoom="16" maxzoom="17" hmargin="-10.5"/>
+							<apply_if routeLaneMode="braid" additional="route_lane_end=-3" minzoom="16" maxzoom="17" hmargin_end="-10.5"/>
+							<apply_if routeLaneMode="braid" additional="route_lane=-3" minzoom="18" hmargin="-15"/>
+							<apply_if routeLaneMode="braid" additional="route_lane_end=-3" minzoom="18" hmargin_end="-15"/>
+							<apply_if routeLaneMode="braid" additional="route_lane=-2" maxzoom="13" hmargin="-2.5"/>
+							<apply_if routeLaneMode="braid" additional="route_lane_end=-2" maxzoom="13" hmargin_end="-2.5"/>
+							<apply_if routeLaneMode="braid" additional="route_lane=-2" minzoom="14" maxzoom="15" hmargin="-4"/>
+							<apply_if routeLaneMode="braid" additional="route_lane_end=-2" minzoom="14" maxzoom="15" hmargin_end="-4"/>
+							<apply_if routeLaneMode="braid" additional="route_lane=-2" minzoom="16" maxzoom="17" hmargin="-7"/>
+							<apply_if routeLaneMode="braid" additional="route_lane_end=-2" minzoom="16" maxzoom="17" hmargin_end="-7"/>
+							<apply_if routeLaneMode="braid" additional="route_lane=-2" minzoom="18" hmargin="-10"/>
+							<apply_if routeLaneMode="braid" additional="route_lane_end=-2" minzoom="18" hmargin_end="-10"/>
+							<apply_if routeLaneMode="braid" additional="route_lane=-1" maxzoom="13" hmargin="-1.25"/>
+							<apply_if routeLaneMode="braid" additional="route_lane_end=-1" maxzoom="13" hmargin_end="-1.25"/>
+							<apply_if routeLaneMode="braid" additional="route_lane=-1" minzoom="14" maxzoom="15" hmargin="-2"/>
+							<apply_if routeLaneMode="braid" additional="route_lane_end=-1" minzoom="14" maxzoom="15" hmargin_end="-2"/>
+							<apply_if routeLaneMode="braid" additional="route_lane=-1" minzoom="16" maxzoom="17" hmargin="-3.5"/>
+							<apply_if routeLaneMode="braid" additional="route_lane_end=-1" minzoom="16" maxzoom="17" hmargin_end="-3.5"/>
+							<apply_if routeLaneMode="braid" additional="route_lane=-1" minzoom="18" hmargin="-5"/>
+							<apply_if routeLaneMode="braid" additional="route_lane_end=-1" minzoom="18" hmargin_end="-5"/>
+							<apply_if routeLaneMode="braid" additional="route_lane=1" maxzoom="13" hmargin="1.25"/>
+							<apply_if routeLaneMode="braid" additional="route_lane_end=1" maxzoom="13" hmargin_end="1.25"/>
+							<apply_if routeLaneMode="braid" additional="route_lane=1" minzoom="14" maxzoom="15" hmargin="2"/>
+							<apply_if routeLaneMode="braid" additional="route_lane_end=1" minzoom="14" maxzoom="15" hmargin_end="2"/>
+							<apply_if routeLaneMode="braid" additional="route_lane=1" minzoom="16" maxzoom="17" hmargin="3.5"/>
+							<apply_if routeLaneMode="braid" additional="route_lane_end=1" minzoom="16" maxzoom="17" hmargin_end="3.5"/>
+							<apply_if routeLaneMode="braid" additional="route_lane=1" minzoom="18" hmargin="5"/>
+							<apply_if routeLaneMode="braid" additional="route_lane_end=1" minzoom="18" hmargin_end="5"/>
+							<apply_if routeLaneMode="braid" additional="route_lane=2" maxzoom="13" hmargin="2.5"/>
+							<apply_if routeLaneMode="braid" additional="route_lane_end=2" maxzoom="13" hmargin_end="2.5"/>
+							<apply_if routeLaneMode="braid" additional="route_lane=2" minzoom="14" maxzoom="15" hmargin="4"/>
+							<apply_if routeLaneMode="braid" additional="route_lane_end=2" minzoom="14" maxzoom="15" hmargin_end="4"/>
+							<apply_if routeLaneMode="braid" additional="route_lane=2" minzoom="16" maxzoom="17" hmargin="7"/>
+							<apply_if routeLaneMode="braid" additional="route_lane_end=2" minzoom="16" maxzoom="17" hmargin_end="7"/>
+							<apply_if routeLaneMode="braid" additional="route_lane=2" minzoom="18" hmargin="10"/>
+							<apply_if routeLaneMode="braid" additional="route_lane_end=2" minzoom="18" hmargin_end="10"/>
+							<apply_if routeLaneMode="braid" additional="route_lane=3" maxzoom="13" hmargin="3.75"/>
+							<apply_if routeLaneMode="braid" additional="route_lane_end=3" maxzoom="13" hmargin_end="3.75"/>
+							<apply_if routeLaneMode="braid" additional="route_lane=3" minzoom="14" maxzoom="15" hmargin="6"/>
+							<apply_if routeLaneMode="braid" additional="route_lane_end=3" minzoom="14" maxzoom="15" hmargin_end="6"/>
+							<apply_if routeLaneMode="braid" additional="route_lane=3" minzoom="16" maxzoom="17" hmargin="10.5"/>
+							<apply_if routeLaneMode="braid" additional="route_lane_end=3" minzoom="16" maxzoom="17" hmargin_end="10.5"/>
+							<apply_if routeLaneMode="braid" additional="route_lane=3" minzoom="18" hmargin="15"/>
+							<apply_if routeLaneMode="braid" additional="route_lane_end=3" minzoom="18" hmargin_end="15"/>
+							<apply_if routeLaneMode="braid" additional="route_lane=4" maxzoom="13" hmargin="5"/>
+							<apply_if routeLaneMode="braid" additional="route_lane_end=4" maxzoom="13" hmargin_end="5"/>
+							<apply_if routeLaneMode="braid" additional="route_lane=4" minzoom="14" maxzoom="15" hmargin="8"/>
+							<apply_if routeLaneMode="braid" additional="route_lane_end=4" minzoom="14" maxzoom="15" hmargin_end="8"/>
+							<apply_if routeLaneMode="braid" additional="route_lane=4" minzoom="16" maxzoom="17" hmargin="14"/>
+							<apply_if routeLaneMode="braid" additional="route_lane_end=4" minzoom="16" maxzoom="17" hmargin_end="14"/>
+							<apply_if routeLaneMode="braid" additional="route_lane=4" minzoom="18" hmargin="20"/>
+							<apply_if routeLaneMode="braid" additional="route_lane_end=4" minzoom="18" hmargin_end="20"/>
+							<apply_if routeLaneMode="braid" additional="route_lane=5" maxzoom="13" hmargin="6.25"/>
+							<apply_if routeLaneMode="braid" additional="route_lane_end=5" maxzoom="13" hmargin_end="6.25"/>
+							<apply_if routeLaneMode="braid" additional="route_lane=5" minzoom="14" maxzoom="15" hmargin="10"/>
+							<apply_if routeLaneMode="braid" additional="route_lane_end=5" minzoom="14" maxzoom="15" hmargin_end="10"/>
+							<apply_if routeLaneMode="braid" additional="route_lane=5" minzoom="16" maxzoom="17" hmargin="17.5"/>
+							<apply_if routeLaneMode="braid" additional="route_lane_end=5" minzoom="16" maxzoom="17" hmargin_end="17.5"/>
+							<apply_if routeLaneMode="braid" additional="route_lane=5" minzoom="18" hmargin="25"/>
+							<apply_if routeLaneMode="braid" additional="route_lane_end=5" minzoom="18" hmargin_end="25"/>
+							<apply_if routeLaneMode="braid" additional="route_lane=6" maxzoom="13" hmargin="7.5"/>
+							<apply_if routeLaneMode="braid" additional="route_lane_end=6" maxzoom="13" hmargin_end="7.5"/>
+							<apply_if routeLaneMode="braid" additional="route_lane=6" minzoom="14" maxzoom="15" hmargin="12"/>
+							<apply_if routeLaneMode="braid" additional="route_lane_end=6" minzoom="14" maxzoom="15" hmargin_end="12"/>
+							<apply_if routeLaneMode="braid" additional="route_lane=6" minzoom="16" maxzoom="17" hmargin="21"/>
+							<apply_if routeLaneMode="braid" additional="route_lane_end=6" minzoom="16" maxzoom="17" hmargin_end="21"/>
+							<apply_if routeLaneMode="braid" additional="route_lane=6" minzoom="18" hmargin="30"/>
+							<apply_if routeLaneMode="braid" additional="route_lane_end=6" minzoom="18" hmargin_end="30"/>
+							<apply_if routeLaneMode="braid" additional="route_lane=7" maxzoom="13" hmargin="8.75"/>
+							<apply_if routeLaneMode="braid" additional="route_lane_end=7" maxzoom="13" hmargin_end="8.75"/>
+							<apply_if routeLaneMode="braid" additional="route_lane=7" minzoom="14" maxzoom="15" hmargin="14"/>
+							<apply_if routeLaneMode="braid" additional="route_lane_end=7" minzoom="14" maxzoom="15" hmargin_end="14"/>
+							<apply_if routeLaneMode="braid" additional="route_lane=7" minzoom="16" maxzoom="17" hmargin="24.5"/>
+							<apply_if routeLaneMode="braid" additional="route_lane_end=7" minzoom="16" maxzoom="17" hmargin_end="24.5"/>
+							<apply_if routeLaneMode="braid" additional="route_lane=7" minzoom="18" hmargin="35"/>
+							<apply_if routeLaneMode="braid" additional="route_lane_end=7" minzoom="18" hmargin_end="35"/>
+							<apply_if routeLaneMode="braid" additional="route_lane=8" maxzoom="13" hmargin="10"/>
+							<apply_if routeLaneMode="braid" additional="route_lane_end=8" maxzoom="13" hmargin_end="10"/>
+							<apply_if routeLaneMode="braid" additional="route_lane=8" minzoom="14" maxzoom="15" hmargin="16"/>
+							<apply_if routeLaneMode="braid" additional="route_lane_end=8" minzoom="14" maxzoom="15" hmargin_end="16"/>
+							<apply_if routeLaneMode="braid" additional="route_lane=8" minzoom="16" maxzoom="17" hmargin="28"/>
+							<apply_if routeLaneMode="braid" additional="route_lane_end=8" minzoom="16" maxzoom="17" hmargin_end="28"/>
+							<apply_if routeLaneMode="braid" additional="route_lane=8" minzoom="18" hmargin="40"/>
+							<apply_if routeLaneMode="braid" additional="route_lane_end=8" minzoom="18" hmargin_end="40"/>
+							<apply_if routeLaneMode="side" additional="route_lane_side=0" maxzoom="13" hmargin="1.5"/>
+							<apply_if routeLaneMode="side" additional="route_lane_side=0" minzoom="14" maxzoom="15" hmargin="2.5"/>
+							<apply_if routeLaneMode="side" additional="route_lane_side=0" minzoom="16" maxzoom="17" hmargin="4"/>
+							<apply_if routeLaneMode="side" additional="route_lane_side=0" minzoom="18" hmargin="6"/>
+							<apply_if routeLaneMode="side" additional="route_lane_side=1" maxzoom="13" hmargin="3"/>
+							<apply_if routeLaneMode="side" additional="route_lane_side=1" minzoom="14" maxzoom="15" hmargin="5"/>
+							<apply_if routeLaneMode="side" additional="route_lane_side=1" minzoom="16" maxzoom="17" hmargin="8"/>
+							<apply_if routeLaneMode="side" additional="route_lane_side=1" minzoom="18" hmargin="12"/>
+							<apply_if routeLaneMode="side" additional="route_lane_side=2" maxzoom="13" hmargin="4.5"/>
+							<apply_if routeLaneMode="side" additional="route_lane_side=2" minzoom="14" maxzoom="15" hmargin="7.5"/>
+							<apply_if routeLaneMode="side" additional="route_lane_side=2" minzoom="16" maxzoom="17" hmargin="12"/>
+							<apply_if routeLaneMode="side" additional="route_lane_side=2" minzoom="18" hmargin="18"/>
+							<apply_if routeLaneMode="side" additional="route_lane_side=3" maxzoom="13" hmargin="6"/>
+							<apply_if routeLaneMode="side" additional="route_lane_side=3" minzoom="14" maxzoom="15" hmargin="10"/>
+							<apply_if routeLaneMode="side" additional="route_lane_side=3" minzoom="16" maxzoom="17" hmargin="16"/>
+							<apply_if routeLaneMode="side" additional="route_lane_side=3" minzoom="18" hmargin="24"/>
+							<apply_if routeLaneMode="side" additional="route_lane_side=4" maxzoom="13" hmargin="7.5"/>
+							<apply_if routeLaneMode="side" additional="route_lane_side=4" minzoom="14" maxzoom="15" hmargin="12.5"/>
+							<apply_if routeLaneMode="side" additional="route_lane_side=4" minzoom="16" maxzoom="17" hmargin="20"/>
+							<apply_if routeLaneMode="side" additional="route_lane_side=4" minzoom="18" hmargin="30"/>
+							<apply_if routeLaneMode="side" additional="route_lane_side=5" maxzoom="13" hmargin="9"/>
+							<apply_if routeLaneMode="side" additional="route_lane_side=5" minzoom="14" maxzoom="15" hmargin="15"/>
+							<apply_if routeLaneMode="side" additional="route_lane_side=5" minzoom="16" maxzoom="17" hmargin="24"/>
+							<apply_if routeLaneMode="side" additional="route_lane_side=5" minzoom="18" hmargin="36"/>
+							<apply_if routeLaneMode="side" additional="route_lane_side=6" maxzoom="13" hmargin="10.5"/>
+							<apply_if routeLaneMode="side" additional="route_lane_side=6" minzoom="14" maxzoom="15" hmargin="17.5"/>
+							<apply_if routeLaneMode="side" additional="route_lane_side=6" minzoom="16" maxzoom="17" hmargin="28"/>
+							<apply_if routeLaneMode="side" additional="route_lane_side=6" minzoom="18" hmargin="42"/>
+							<apply_if routeLaneMode="side" additional="route_lane_side=7" maxzoom="13" hmargin="12"/>
+							<apply_if routeLaneMode="side" additional="route_lane_side=7" minzoom="14" maxzoom="15" hmargin="20"/>
+							<apply_if routeLaneMode="side" additional="route_lane_side=7" minzoom="16" maxzoom="17" hmargin="32"/>
+							<apply_if routeLaneMode="side" additional="route_lane_side=7" minzoom="18" hmargin="48"/>
+							<apply_if routeLaneMode="side" additional="route_lane_side=8" maxzoom="13" hmargin="13.5"/>
+							<apply_if routeLaneMode="side" additional="route_lane_side=8" minzoom="14" maxzoom="15" hmargin="22.5"/>
+							<apply_if routeLaneMode="side" additional="route_lane_side=8" minzoom="16" maxzoom="17" hmargin="36"/>
+							<apply_if routeLaneMode="side" additional="route_lane_side=8" minzoom="18" hmargin="54"/>
+							<apply_if additional="route_shared_lane=yes" maxzoom="15" pathEffect="5_4"/>
+							<apply_if additional="route_shared_lane=yes" minzoom="16" maxzoom="17" pathEffect="7_5"/>
+							<apply_if additional="route_shared_lane=yes" minzoom="18" pathEffect="10_7"/>
 						</switch>
 						<switch hikingRoutesOSMC="walkingRoutesOSMCNodes" cap="BUTT" rClass=".route.hiking.node_network_segments">
 							<case additional="node_network=iwn" color="$iwnNodeNetworkColor" rClass=".route.hiking.color.classification"/>


### PR DESCRIPTION
Draft — the style half of parallel route lanes (OsmAnd-Issues#3110). Needs
osmandapp/OsmAnd-tools#1677 to produce the tags and osmandapp/OsmAnd-core#1101 for the smooth
transitions. Not for merge on its own.

## What

Declares the four map-section tags the generator writes for routes that share a path
(`route_lane`, `route_lane_end`, `route_lane_side`, `route_shared_lane`) and turns them into pixel
offsets.

New rendering property `routeLaneMode`:

| value | look |
|---|---|
| unset | unchanged — routes drawn on top of each other, as today |
| `side` | every route of a bundle beside the path, stacked, like a printed trail map |
| `braid` | the bundle centred on the path; where a route joins or leaves it slides between lanes instead of jumping |

A lane shared by several look-alike routes is drawn dashed, so it reads as "more than one route
here" rather than as one line quietly hiding the others.

`hmargin` and `hmargin_end` are independent attributes, which is why this is one table per lane value
rather than one per pair — 336 rules instead of several thousand.

## Offsets

Per zoom band, in pixels. `side` measures from the path outwards starting at one step, so nothing sits
on the road; `braid` is symmetric, so a route running alone stays exactly on its path.

| zoom | side step | braid half-step |
|---|---|---|
| ≤13 | 1.5 | 1.25 |
| 14–15 | 2.5 | 2 |
| 16–17 | 4 | 3.5 |
| 18+ | 6 | 5 |

These came from looking at renders at z16–z18 against a photographed park map; they are a starting
point, not a considered design decision.

## Not addressed

Stock route lines are wide and translucent (`osmc*Color` alpha `0x44` in the v2 branch, `strokeWidth`
up to 13 px). Offsets of a few pixels are invisible underneath them, so this only reads well with
thinner, more opaque route lines. That restyle is not part of this change — it affects how routes
look everywhere, not just where they overlap, and deserves its own decision.

## AI disclaimer

Produced with Claude Code (Opus 5).

Prompts used (summarised):
1. How can overlapping hiking and cycling route lines be drawn side by side like metro lines?
2. Build test maps and render them locally; iterate on how it looks, including against a photographed paper map of Ojcowski Park Narodowy.
3. Provide two modes — a plain one-sided shift and the braided one — and a key in the viewer to switch between them.
4. Open this as a draft pull request and attach it to the tracker task.

Decided by the agent, not requested explicitly:
- The rendering property name and its three states, including leaving the default unchanged.
- The pixel steps per zoom band.
- Drawing a shared lane dashed.
- Generating the rules mechanically rather than hand-writing them.
