### PR TITLE
Turn lanes tests: restore the remaining real-world locations

### DIFF
--- a/test-resources/test_turn_lanes.json
+++ b/test-resources/test_turn_lanes.json
@@ -1,6 +1,7 @@
 [
   {
     "testName": "1.Preston road TR Lorimar drive",
+    "url": "https://test.osmand.net/map/navigate/?start=33.0494369,-96.7942131&end=33.0498939,-96.7928715&profile=car#18/33.04967/-96.79354",
     "startPoint": {
       "latitude": 45.695213,
       "longitude": 35.438503
@@ -15,6 +16,7 @@
   },
   {
     "testName": "1.2.Preston road TL Lorimar drive",
+    "url": "https://test.osmand.net/map/navigate/?start=33.051401,-96.7944678&end=33.0502657,-96.7923758&profile=car#18/33.05083/-96.79342",
     "startPoint": {
       "latitude": 45.69716379996895,
       "longitude": 35.43819894718172
@@ -31,6 +33,7 @@
   },
   {
     "testName": "1.3.Baywater drive TR Preston road",
+    "url": "https://test.osmand.net/map/navigate/?start=33.0502801,-96.795165&end=33.049853,-96.7944631&profile=car#18/33.05007/-96.79481",
     "startPoint": {
       "latitude": 45.6960514631203,
       "longitude": 35.43735606299879
@@ -45,6 +48,7 @@
   },
   {
     "testName": "2. Valley View Lane TU Highway 161 Service Road",
+    "url": "https://test.osmand.net/map/navigate/?start=32.9092666,-96.9519142&end=32.9085396,-96.9513608&profile=car#18/32.90890/-96.95164",
     "startPoint": {
       "latitude": 45.694859388262195,
       "longitude": 35.467755138874054
@@ -59,6 +63,7 @@
   },
   {
     "testName": "2.1 Valley View Lane C Highway 161 Service Road",
+    "url": "https://test.osmand.net/map/navigate/?start=32.9093355,-96.9517536&end=32.9066865,-96.955915&profile=car#18/32.90801/-96.95383",
     "startPoint": {
       "latitude": 45.694859388262195,
       "longitude": 35.467755138874054
@@ -75,6 +80,7 @@
   },
   {
     "testName": "2.2 Valley View Lane TL Highway 161 Service Road",
+    "url": "https://test.osmand.net/map/navigate/?start=32.9093316,-96.9517843&end=32.9076022,-96.9522295&profile=car#18/32.90847/-96.95201",
     "startPoint": {
       "latitude": 45.694859388262195,
       "longitude": 35.467755138874054
@@ -91,6 +97,7 @@
   },
   {
     "testName": "2.3. Highway 161 Service Road to Lyndon B Johnson Freeway (I 635) link",
+    "url": "https://test.osmand.net/map/navigate/?start=32.9085329,-96.9490584&end=32.9070041,-96.9259927&profile=car#18/32.90777/-96.93753",
     "startPoint": {
       "latitude": 45.69384114913531,
       "longitude": 35.46754793822765
@@ -107,6 +114,7 @@
   },
   {
     "testName": "3. Motorway link from Ringweg Zuid TL Amstelveenseweg",
+    "url": "https://test.osmand.net/map/navigate/?start=52.337267,4.8610795&end=52.335431,4.857345&profile=car#18/52.33635/4.85921",
     "startPoint": {
       "latitude": 45.6971206184178,
       "longitude": 35.51630312204361
@@ -121,6 +129,7 @@
   },
   {
     "testName": "3.2 Motorway link from Ringweg Zuid TL Amstelveenseweg",
+    "url": "https://test.osmand.net/map/navigate/?start=52.3372248,4.8611021&end=52.3367236,4.8564099&profile=car#18/52.33697/4.85876",
     "startPoint": {
       "latitude": 45.6971206184178,
       "longitude": 35.51630312204361
@@ -135,6 +144,7 @@
   },
   {
     "testName": "4.Tiefer TL Wilhelm-Kaisen-Brücke",
+    "url": "https://test.osmand.net/map/navigate/?start=53.0733554,8.8069602&end=53.0728922,8.8047487&profile=car#18/53.07312/8.80585",
     "startPoint": {
       "latitude": 45.69999011335712,
       "longitude": 35.53932720422745
@@ -149,6 +159,7 @@
   },
   {
     "testName": "5.1.Fritz-Foerster-Platz (S 172) TR Bergstraße (B 170)",
+    "url": "https://test.osmand.net/map/navigate/?start=51.0305131,13.729892&end=51.0294603,13.7307915&profile=car#18/51.02999/13.73034",
     "startPoint": {
       "latitude": 45.69942484339974,
       "longitude": 35.552937403321266
@@ -163,6 +174,7 @@
   },
   {
     "testName": "5.2.Zellescher Weg (S 172) TL Bergstraße (B 170)",
+    "url": "https://test.osmand.net/map/navigate/?start=51.029967,13.7314275&end=51.0297797,13.7307215&profile=car#18/51.02987/13.73107",
     "startPoint": {
       "latitude": 45.69887876939763,
       "longitude": 35.55432008206844
@@ -179,6 +191,7 @@
   },
   {
     "testName": "6.Platz der Vereinten Nationen TR Platz der Vereinten Nationen",
+    "url": "https://test.osmand.net/map/navigate/?start=52.5223597,13.4298192&end=52.5231408,13.4310631&profile=car#18/52.52275/13.43044",
     "startPoint": {
       "latitude": 45.69942016011204,
       "longitude": 35.568235382437706
@@ -193,6 +206,7 @@
   },
   {
     "testName": "7.1.Spindlersfelder Straße TR Oberspreestraße",
+    "url": "https://test.osmand.net/map/navigate/?start=52.4484886,13.5587579&end=52.4466078,13.5554938&profile=car#18/52.44755/13.55713",
     "startPoint": {
       "latitude": 45.699817301524455,
       "longitude": 35.58391557633877
@@ -207,6 +221,7 @@
   },
   {
     "testName": "7.2.Spindlersfelder Straße TL Oberspreestraße",
+    "url": "https://test.osmand.net/map/navigate/?start=52.44931,13.5586823&end=52.4460691,13.5615837&profile=car#18/52.44769/13.56013",
     "startPoint": {
       "latitude": 45.699817301524455,
       "longitude": 35.58391557633877
@@ -222,6 +237,7 @@
   },
   {
     "testName": "8.Luisenstraße TL Invalidenstraße (L 1008)",
+    "url": "https://test.osmand.net/map/navigate/?start=52.5285998,13.3785941&end=52.5288546,13.3769252&profile=car#18/52.52873/13.37776",
     "startPoint": {
       "latitude": 45.698618375457045,
       "longitude": 35.59940265119076
@@ -237,6 +253,7 @@
   },
   {
     "testName": "9.Torstraße C",
+    "url": "https://test.osmand.net/map/navigate/?start=52.5299151,13.4034704&end=52.5295048,13.3989591&profile=car#18/52.52971/13.40121",
     "startPoint": {
       "latitude": 45.69951195248144,
       "longitude": 35.61424867808819
@@ -251,6 +268,7 @@
   },
   {
     "testName": "10.Ringweg Oost u-turn",
+    "url": "https://test.osmand.net/map/navigate/?start=52.364976,4.9723865&end=52.3656879,4.9694411&profile=car#18/52.36533/4.97091",
     "startPoint": {
       "latitude": 45.69722318654911,
       "longitude": 35.62708438868003
@@ -316,6 +334,7 @@
   },
   {
     "testName": "15.Каширское шоссе u-turn",
+    "url": "https://test.osmand.net/map/navigate/?start=55.633774,37.7008443&end=55.6339014,37.7012693&profile=car#18/55.63384/37.70106",
     "startPoint": {
       "latitude": 45.66869817293356,
       "longitude": 35.44163727760315
@@ -346,6 +365,7 @@
   },
   {
     "testName": "18.Stuttgarter Straße  S",
+    "url": "https://test.osmand.net/map/navigate/?start=48.4713974,8.4779648&end=48.4736016,8.478519&profile=car#18/48.47250/8.47824",
     "startPoint": {
       "latitude": 45.66799997535318,
       "longitude": 35.52440086007118
@@ -360,6 +380,7 @@
   },
   {
     "testName": "19.L353 straight",
+    "url": "https://test.osmand.net/map/navigate/?start=48.5367798,8.5780139&end=48.5506657,8.6039254&profile=car#18/48.54372/8.59097",
     "startPoint": {
       "latitude": 45.65874639488115,
       "longitude": 35.54377349972731
@@ -435,6 +456,7 @@
   },
   {
     "testName": "25.Blumberger Damm TR Warener Straße",
+    "url": "https://test.osmand.net/map/navigate/?start=52.5161979,13.5634818&end=52.5189887,13.5659228&profile=car#18/52.51759/13.56470",
     "startPoint": {
       "latitude": 45.633618533007024,
       "longitude": 35.43691737949851
@@ -464,6 +486,7 @@
   },
   {
     "testName": "27.TSLR Großer Stern (Berlin)",
+    "url": "https://test.osmand.net/map/navigate/?start=52.5151338,13.3495504&end=52.5143124,13.3467769&profile=car#18/52.51472/13.34816",
     "startPoint": {
       "latitude": 45.64019080086255,
       "longitude": 35.5037784576416
@@ -494,6 +517,7 @@
   },
   {
     "testName": "28.2.Link +TSLR,С",
+    "url": "https://test.osmand.net/map/navigate/?start=-32.9379942,-60.8198922&end=-32.9392207,-60.8224575&profile=car#18/-32.93861/-60.82117",
     "startPoint": {
       "latitude": 45.64211106582103,
       "longitude": 35.54128705700879
@@ -508,6 +532,7 @@
   },
   {
     "testName": "29.1.Reichsstraße TR Steubenplatz",
+    "url": "https://test.osmand.net/map/navigate/?start=52.5160322,13.2614759&end=52.5165047,13.2611492&profile=car#18/52.51627/13.26131",
     "startPoint": {
       "latitude": 45.641390502389285,
       "longitude": 35.57718708356862
@@ -522,6 +547,7 @@
   },
   {
     "testName": "29.2.Reichsstraße TL Steubenplatz",
+    "url": "https://test.osmand.net/map/navigate/?start=52.5160322,13.2614759&end=52.5165507,13.260197&profile=car#18/52.51629/13.26084",
     "startPoint": {
       "latitude": 45.641390502389285,
       "longitude": 35.57718708356862
@@ -567,6 +593,7 @@
   },
   {
     "testName": "32.Motorway TR South Kent Des Moines Road",
+    "url": "https://test.osmand.net/map/navigate/?start=47.3976878,-122.2917755&end=47.3962659,-122.2986049&profile=car#18/47.39698/-122.29519",
     "startPoint": {
       "latitude": 45.64518099200965,
       "longitude": 35.668448954820605
@@ -583,6 +610,7 @@
   },
   {
     "testName": "32.2 Motorway TR - Turn Left",
+    "url": "https://test.osmand.net/map/navigate/?start=47.397797,-122.2917658&end=47.3869934,-122.2964669&profile=car#18/47.39240/-122.29412",
     "startPoint": {
       "latitude": 45.64529022972,
       "longitude": 35.66845825521
@@ -614,6 +642,7 @@
   },
   {
     "testName": "34. Semmering-Schnellstraße TL Wiener Straße",
+    "url": "https://test.osmand.net/map/navigate/?start=47.602817,15.6974789&end=47.6021415,15.7207543&profile=car#18/47.60248/15.70912",
     "startPoint": {
       "latitude": 45.60877412952071,
       "longitude": 35.41727355122569
@@ -629,6 +658,7 @@
   },
   {
     "testName": "35.B 22 TR NEW 41",
+    "url": "https://test.osmand.net/map/navigate/?start=49.5822883,12.2717498&end=49.5733719,12.2670273&profile=car#18/49.57783/12.26939",
     "params": {
       "vehicle": "car",
       "short_way": "true"
@@ -647,6 +677,7 @@
   },
   {
     "testName": "36.Bierweg TR Äußere Bayreuther Straße (B 2) ",
+    "url": "https://test.osmand.net/map/navigate/?start=49.4893395,11.1224715&end=49.488121,11.1240687&profile=car#18/49.48873/11.12327",
     "startPoint": {
       "latitude": 45.61486172708771,
       "longitude": 35.50859335064885
@@ -661,6 +692,7 @@
   },
   {
     "testName": "37.Lingener Straße TR Osttangente",
+    "url": "https://test.osmand.net/map/navigate/?start=52.4408435,7.0808644&end=52.4393952,7.0837713&profile=car#18/52.44012/7.08232",
     "startPoint": {
       "latitude": 45.61665251148337,
       "longitude": 35.534761190414315
@@ -675,6 +707,7 @@
   },
   {
     "testName": "38.Freeway A20 TR",
+    "url": "https://test.osmand.net/map/navigate/?start=51.9789244,4.6164787&end=51.9786842,4.6205939&profile=car#18/51.97880/4.61854",
     "startPoint": {
       "latitude": 45.614017077100364,
       "longitude": 35.56860889494419
@@ -689,6 +722,7 @@
   },
   {
     "testName": "39.5003",
+    "url": "https://test.osmand.net/map/navigate/?start=52.0284104,4.7150999&end=52.0283447,4.7131834&profile=car#18/52.02838/4.71414",
     "startPoint": {
       "latitude": 45.61561133366637,
       "longitude": 35.60593853890896
@@ -703,6 +737,7 @@
   },
   {
     "testName": "40.Проспект Косыгина TSLL",
+    "url": "https://test.osmand.net/map/navigate/?start=59.9452728,30.4843617&end=59.9434428,30.4714428&profile=car#18/59.94436/30.47790",
     "startPoint": {
       "latitude": 45.61587,
       "longitude": 35.63860
@@ -717,6 +752,7 @@
   },
   {
     "testName": "41.Лесной проспект TSLR",
+    "url": "https://test.osmand.net/map/navigate/?start=59.9811798,30.343452&end=59.9757898,30.3438993&profile=car#18/59.97848/30.34368",
     "startPoint": {
       "latitude": 45.61822,
       "longitude": 35.66195
@@ -731,6 +767,7 @@
   },
   {
     "testName": "42.Испытателей (Ispytateley) prospect -> Светлановский (Svetlanovsky) prospect via Светлановская (Svetlanovskaya) square C https://github.com/osmandapp/Osmand/issues/6439",
+    "url": "https://test.osmand.net/map/navigate/?start=60.0027418,30.3221172&end=60.0043118,30.3301617&profile=car#18/60.00353/30.32614",
     "startPoint": {
       "latitude": 45.61533,
       "longitude": 35.68074
@@ -745,6 +782,7 @@
   },
   {
     "testName": "43.prospect Сизова (Sizova) -> Полевая Сабировская (Polevaya Sabirovskaya) A https://github.com/osmandapp/Osmand/issues/6439",
+    "url": "https://test.osmand.net/map/navigate/?start=60.000688,30.2698012&end=59.995228,30.2717748&profile=car#18/59.99796/30.27079",
     "startPoint": {
       "latitude": 45.58600,
       "longitude": 35.43707
@@ -759,6 +797,7 @@
   },
   {
     "testName": "44.Репищева (Repisheva) street straight B https://github.com/osmandapp/Osmand/issues/6439",
+    "url": "https://test.osmand.net/map/navigate/?start=60.0268263,30.2842836&end=60.0284163,30.2842976&profile=car#18/60.02762/30.28429",
     "startPoint": {
       "latitude": 45.58297,
       "longitude": 35.47153
@@ -773,6 +812,7 @@
   },
   {
     "testName": "45.UT https://github.com/osmandapp/Osmand/issues/4862",
+    "url": "https://test.osmand.net/map/navigate/?start=32.3096587,50.8283652&end=32.3118687,50.8294915&profile=car#18/32.31076/50.82893",
     "startPoint": {
       "latitude": 45.58111,
       "longitude": 35.50252
@@ -803,6 +843,7 @@
   },
   {
     "testName": "48.Turn lanes incorrect: turn left instead of straight https://github.com/osmandapp/OsmAnd/issues/11607",
+    "url": "https://test.osmand.net/map/navigate/?start=51.5636095,7.4085269&end=51.5659295,7.3995085&profile=car#18/51.56477/7.40402",
     "startPoint": {
       "latitude": 45.58110,
       "longitude": 35.60466
@@ -913,6 +954,7 @@
   },
   {
       "testName": "55. 43.72805° N, 79.45033° W https://github.com/osmandapp/OsmAnd-Issues/issues/1104",
+      "url": "https://test.osmand.net/map/navigate/?start=43.7279196,-79.4569966&end=43.7249688,-79.4480898&profile=car#18/43.72644/-79.45254",
       "startPoint": {
           "latitude": 45.5612437,
           "longitude": 35.5686293
@@ -1122,6 +1164,7 @@
   },
   {
     "testName": "64. Äußere Nürnberger Straße TL Hammerbacherstraße https://github.com/osmandapp/OsmAnd/issues/16752#issuecomment-1592678308",
+    "url": "https://test.osmand.net/map/navigate/?start=49.5758803,11.0174615&end=49.5753003,11.0156796&profile=car#18/49.57559/11.01657",
     "startPoint": {
       "latitude": 45.55071,
       "longitude": 35.57804
@@ -1382,6 +1425,7 @@
   },
   {
     "testName": "80.1 Missing or muted turn directions https://github.com/osmandapp/OsmAnd/issues/19458",
+    "url": "https://test.osmand.net/map/navigate/?start=43.1403246,5.9998814&end=43.1426346,6.0105696&profile=car#18/43.14148/6.00523",
     "startPoint": {
       "latitude": 45.51574,
       "longitude": 35.42940
@@ -1397,6 +1441,7 @@
   },
   {
     "testName": "80.2 Missing or muted turn directions https://github.com/osmandapp/OsmAnd/issues/19458",
+    "url": "https://test.osmand.net/map/navigate/?start=43.140336,5.9997852&end=43.142496,6.0105502&profile=car#18/43.14142/6.00517",
     "startPoint": {
       "latitude": 45.51574,
       "longitude": 35.42940
@@ -1411,6 +1456,7 @@
   },
   {
     "testName": "80.3 Missing or muted turn directions https://github.com/osmandapp/OsmAnd/issues/19458",
+    "url": "https://test.osmand.net/map/navigate/?start=43.1402909,5.9996806&end=43.1423609,6.0105512&profile=car#18/43.14133/6.00512",
     "startPoint": {
       "latitude": 45.51574,
       "longitude": 35.42940


### PR DESCRIPTION
Follow-up to `Restore json url by id` (c399c14), which added `url` to the 66 turn-lane cases whose way ids still resolve in OSM. This adds the remaining 46.

## Why they needed a different method

`turn_lanes_test.osm` is a synthetic playground: real junctions were lifted out of OSM and dropped into empty space in Crimea, keeping the way ids. For the older cases (roughly tests 1–19, 32–48, 64) the ids were renumbered instead, and several of them collide with unrelated real ways — test 4 "Tiefer / Wilhelm-Kaisen-Brücke" (Bremen) resolves by id onto Kings Road on the Isle of Wight.

## How the locations were recovered

1. **Re-find the junction by name.** The synthetic map still carries `name` and `ref`, so the junction is found by looking for the two streets crossing anywhere in OSM (`node(w.a); node(w.b); node.na.nb`). Where the streets share no node, all ways with the rarer name are taken as candidates instead.
2. **Invert the transplant.** Latitude is a pure shift; longitude is not — it scales by `cos(clat)/cos(alat)`. Assuming a plain translation costs about 50 m at Berlin latitudes.
3. **Fit the geometry.** The transplanted roads are rasterised into a metric grid and the offset that maximises their overlap with today's road network is searched for.
4. **Confirm with `turn:lanes`.** Each transplanted way carrying `turn:lanes` is matched against a real way within 45 m and the tag strings are compared. This is the decisive check, and it disagrees with geometry in both directions: test 48 scored 0.99 on shape at the wrong place, and test 2.3 scored 0.33 at the right one (the interchange was rebuilt, the lane tagging survived).

Two cheap fixes closed the hard cases: reusing a sibling test's transform where two cases sit a few hundred metres apart in synthetic space (5.2 from 5.1, 32 from 32.2 — both went from no lane matches to a full match), and anchoring on a surviving expected way id by querying its current centre (80.1–80.3, which both other methods had put ~400 m off).

## Verification

Every location was reviewed against a side-by-side render of the test map and a fresh OSM cut of the same spot, drawn at the same ground scale with the legacy renderer. Reference points: test 91/92 matches 27 of 27 `turn:lanes` strings, test 64 22 of 22, test 27 18 of 19.

`RouteResultPreparationTest` stays green: 114 of 114. The `url` field is ignored by `TestEntry`, exactly as in `test_routing.json`.

## Not included

- `14*.Figure 8 TL` — a synthetic junction with no real prototype.
- `16.A10 TL Bos en Lommerweg` — not confirmed; no lane-tagged road survives near any candidate (0 of 15).

## AI disclaimer

Produced with Claude Code (Opus 5).

Prompts used (summarised):
1. Study the "Turn lanes" epic, work out what can be fixed quickly, and look at how hard the tests are to work with.
2. We have long been cutting mini map extracts instead of the big turn-lanes map; try to reproduce the real tests and the extracts with Overpass.
3. First just determine the real locations and we will add them to the json; then each junction has to be checked separately for how it changed — recall them from history or some other way.
4. Identify them by eye from secondary clues in the issues, then compare the road geometries themselves; send two renderings to look at — the current one and the extract — we can draw map pieces with the legacy v1 rendering utility.
5. Show the pictures as HTML so I can say matched or not.
6. All matched; keep looking. If any are doubtful you can show me, or just check the turn:lanes themselves — if they match it is the right test.
7. Corrections after review: 16 is wrong, 2.3 is very close by, 14* is synthetic and not needed, 80.1 not sure.
8. Make a pull request for the urls.

Decided by the agent, not requested explicitly:
- The choice of recovery methods (name search, inverse transform, geometry fit) and the decision to make the `turn:lanes` comparison the deciding check rather than shape overlap.
- Excluding `14*` and `16` instead of writing a low-confidence url for them.
- Reusing a sibling test's transform for 5.2 and 32, and anchoring 80.1–80.3 on a surviving way id, after their own searches produced weak results.
- Dropping the two locations that the id-based restoration had placed wrongly (tests 4 and 18) rather than keeping them.
- The commit message and this description.
