### PR TITLE
Rank places of worship by prominence (elo rating) instead of showing every one

### DIFF
--- a/obf_creation/rendering_types.xml
+++ b/obf_creation/rendering_types.xml
@@ -5361,13 +5361,13 @@
 		<entity_convert pattern="tag_transform" from_tag="religion" if_tag1="denomination" if_value1="jehovahs_witness" poi="no"/>
 		<entity_convert pattern="tag_transform" from_tag="denomination" from_value="theravāda" to_tag1="denomination" to_value1="theravada" map="no"/>
 		<type tag="travel_elo_rounded" minzoom="12" additional="true" notosm="true"/>
-		<entity_convert pattern="tag_transform" from_tag="travel_elo" if_tag1="amenity" if_value1="place_of_worship" if_less_tag1="travel_elo" if_less_value1="4000" to_tag1="travel_elo_rounded" to_value1="4000"/>
-		<entity_convert pattern="tag_transform" from_tag="travel_elo" if_tag1="amenity" if_value1="place_of_worship" if_less_tag1="travel_elo" if_less_value1="3000" to_tag1="travel_elo_rounded" to_value1="3000"/>
-		<entity_convert pattern="tag_transform" from_tag="travel_elo" if_tag1="amenity" if_value1="place_of_worship" if_less_tag1="travel_elo" if_less_value1="2500" to_tag1="travel_elo_rounded" to_value1="2500"/>
-		<entity_convert pattern="tag_transform" from_tag="travel_elo" if_tag1="amenity" if_value1="place_of_worship" if_less_tag1="travel_elo" if_less_value1="2000" to_tag1="travel_elo_rounded" to_value1="2000"/>
-		<entity_convert pattern="tag_transform" from_tag="travel_elo" if_tag1="amenity" if_value1="place_of_worship" if_less_tag1="travel_elo" if_less_value1="1500" to_tag1="travel_elo_rounded" to_value1="1500"/>
-		<entity_convert pattern="tag_transform" from_tag="travel_elo" if_tag1="amenity" if_value1="place_of_worship" if_less_tag1="travel_elo" if_less_value1="1000" to_tag1="travel_elo_rounded" to_value1="1000"/>
 		<entity_convert pattern="tag_transform" from_tag="travel_elo" if_tag1="amenity" if_value1="place_of_worship" if_less_tag1="travel_elo" if_less_value1="500" to_tag1="travel_elo_rounded" to_value1="500"/>
+		<entity_convert pattern="tag_transform" from_tag="travel_elo" if_tag1="amenity" if_value1="place_of_worship" if_not_less_tag1="travel_elo" if_not_less_value1="500" if_less_tag1="travel_elo" if_less_value1="1000" to_tag1="travel_elo_rounded" to_value1="1000"/>
+		<entity_convert pattern="tag_transform" from_tag="travel_elo" if_tag1="amenity" if_value1="place_of_worship" if_not_less_tag1="travel_elo" if_not_less_value1="1000" if_less_tag1="travel_elo" if_less_value1="1500" to_tag1="travel_elo_rounded" to_value1="1500"/>
+		<entity_convert pattern="tag_transform" from_tag="travel_elo" if_tag1="amenity" if_value1="place_of_worship" if_not_less_tag1="travel_elo" if_not_less_value1="1500" if_less_tag1="travel_elo" if_less_value1="2000" to_tag1="travel_elo_rounded" to_value1="2000"/>
+		<entity_convert pattern="tag_transform" from_tag="travel_elo" if_tag1="amenity" if_value1="place_of_worship" if_not_less_tag1="travel_elo" if_not_less_value1="2000" if_less_tag1="travel_elo" if_less_value1="2500" to_tag1="travel_elo_rounded" to_value1="2500"/>
+		<entity_convert pattern="tag_transform" from_tag="travel_elo" if_tag1="amenity" if_value1="place_of_worship" if_not_less_tag1="travel_elo" if_not_less_value1="2500" if_less_tag1="travel_elo" if_less_value1="3000" to_tag1="travel_elo_rounded" to_value1="3000"/>
+		<entity_convert pattern="tag_transform" from_tag="travel_elo" if_tag1="amenity" if_value1="place_of_worship" if_not_less_tag1="travel_elo" if_not_less_value1="3000" to_tag1="travel_elo_rounded" to_value1="4000"/>
 
 	</category>
 

--- a/rendering_styles/default.render.xml
+++ b/rendering_styles/default.render.xml
@@ -7935,9 +7935,15 @@
 					</case>
 					<apply_if baseAppMode="car" moreDetailed="false" maxzoom="17" icon=""/>
 				</switch>
-				<switch tag="amenity" value="place_of_worship" icon="amenity_place_of_worship" iconVisibleSize="11" intersectionSizeFactor="0.8">
+				<!-- Places of worship are ranked by prominence (travel_elo_rounded, the bucketed wiki/travel elo
+				     rating): a top rated one appears one zoom earlier and keeps the high icon order, so it wins
+				     every collision. iconMinDistance thins out the rest in dense historical centres, while a lone
+				     village church is always drawn. https://github.com/osmandapp/OsmAnd/issues/24901 -->
+				<switch tag="amenity" value="place_of_worship" icon="amenity_place_of_worship" iconVisibleSize="11" intersectionSizeFactor="0.8" iconMinDistance="48">
 					<case minzoom="14" moreDetailed="true" iconOrder="43" iconVisibleSize="9" intersectionSizeFactor="0.7"/>
-					<case minzoom="15" moreDetailed="false" additional="wiki=yes" iconOrder="43" iconVisibleSize="9" intersectionSizeFactor="0.7"/>
+					<case minzoom="15" moreDetailed="false" additional="travel_elo_rounded=4000" iconOrder="43" iconVisibleSize="9" intersectionSizeFactor="0.7"/>
+					<!-- fallback for maps generated before travel_elo_rounded existed -->
+					<case minzoom="15" maxzoom="15" moreDetailed="false" additional="wiki=yes" iconOrder="43" iconVisibleSize="9" intersectionSizeFactor="0.7"/>
 					<case minzoom="16" iconOrder="132"/>
 					<apply_if nightMode="true" icon="amenity_place_of_worship_night"/>
 					<apply>


### PR DESCRIPTION
Draft — for review of the approach. Fixes the remaining half of #24901 ("Churches are too prominent"): the grey night shields were already removed in 13a95405, but a historical centre is still covered by identical church icons, and @vshcherb asked for prominence based rendering driven by the elo rating (day mode included).

## 1. `travel_elo_rounded` never worked

The tag was added in a2467438 but the buckets are dead code. `MapRenderingTypesEncoder.applyTagTransforms()` starts with

```java
if (tags.remove(fromTag) == null) {
    return;
}
```

so the first `entity_convert` that matches consumes `travel_elo` and every later rule bails out. All seven rules were `if_less`, so the `< 4000` rule always matched first.

Measured on a generated OBF (8 synthetic places of worship, elo 300…4500):

| travel_elo | master | this PR |
|---|---|---|
| 300 | 4000 | 500 |
| 700 | 4000 | 1000 |
| 1200 | 4000 | 1500 |
| 1700 | 4000 | 2000 |
| 2200 | 4000 | 2500 |
| 2700 | 4000 | 3000 |
| 3500 | 4000 | 4000 |
| 4500 | *(no tag)* | 4000 |

Real maps confirm it: `Czech-republic_praha` (Sep 1 2026), `Italy_toscana`, `Malta` — the only value that occurs anywhere is `travel_elo_rounded=4000`, and the actual `travel_elo` values behind it span ~750…4500 (Prague centre churches: 974…3560, median 2291). So today the tag is a boolean "is in the wiki DB", not a rating.

Rewritten as explicit half-open ranges (`if_not_less` + `if_less`), the same shape the `ele` buckets a few thousand lines above already use, so the outcome no longer depends on rule order. `>= 3000` keeps the top bucket 4000, which previously swallowed everything.

## 2. Style: rank the icons

```xml
<switch tag="amenity" value="place_of_worship" ... iconMinDistance="48">
    <case minzoom="15" additional="travel_elo_rounded=4000" iconOrder="43" .../>
    <case minzoom="15" maxzoom="15" additional="wiki=yes" iconOrder="43" .../>  <!-- old maps -->
    <case minzoom="16" iconOrder="132"/>
```

* a top rated place of worship keeps `iconOrder=43`, so it is placed first and always survives;
* `iconMinDistance` (48 dp) applies to every place of worship, and the renderer only rejects a symbol when another symbol **with the same icon** is within that distance — so it thins clusters of crosses without ever competing against hospitals, museums or anything else;
* a lone village church has no other cross near it and is drawn exactly as before;
* `wiki=yes` is kept as a z15-only fallback for maps generated before `travel_elo_rounded` existed.

## Depends on a core fix

`iconMinDistance` is currently inert in the v2 (OpenGL) renderer: `MapPrimitiviser_P::obtainPrimitiveIcon()` reads it from the text evaluation result instead of `primitive->evaluationResult`, so `icon->minDistance` stays 0 whatever the style says (verified: values 32, 96 and 400 produced pixel-identical renders). One-line fix + dip scaling in OsmAnd-core, PR linked below. Without it the style change degrades to "top rated churches appear at z15", nothing more — nothing breaks.

## Measurements

Church icons counted on the rendered PNG (v2 renderer / `eyepiece`, z16, 900×900 @ density 2, current production maps):

| place | night before → after | day before → after |
|---|---|---|
| Prague, Old Town | 11 → 4 | 12 → 4 |
| Florence | 29 → 6 | 32 → 6 |
| Valletta | 16 → 2 | 14 → 3 |
| Lisbon | 27 → 6 | 28 → 6 |
| Munich | 10 → 2 | 10 → 3 |
| Paris, Marais | 9 → 3 | 9 → 3 |
| Kyiv | 9 → 4 | 7 → 4 |
| **Baierbrunn (village)** | **2 → 2** | **2 → 2** |
| **Greve in Chianti (village)** | **1 → 1** | **2 → 2** |

Screenshots (before | after) in the comments below.

## AI disclaimer

Produced with Claude Code (Opus 5).

Prompts used (summarised):
1. Investigate osmandapp/OsmAnd#24901, test it, look at the screenshots and try to fix it, producing before/after images only, without committing.
2. Take before/after screenshots of several different places, using the maps already downloaded locally.
3. Show how it looks now, since the data already exists, and open a draft PR with the style fix for review.

Decided by the agent, not requested explicitly:
- root-causing the `travel_elo_rounded` bucket collapse and fixing `obf_creation/rendering_types.xml` (the issue only asked about rendering);
- choosing `iconMinDistance` over hiding unrated places of worship at z16 — the latter was measured first and removed village churches, which have no elo rating at all (0 of 32 in the rural part of the Czech Prague region);
- the 48 dp value, picked from a sweep of 32/48/64/80 dp against both dense centres and villages;
- keeping `wiki=yes` as a z15-only fallback for older maps;
- finding and fixing the `iconMinDistance` bug in OsmAnd-core, without which the style change does nothing.
