### PR TITLE
Fix churchs visualization (travel_elo)

### DIFF
--- a/obf_creation/rendering_types.xml
+++ b/obf_creation/rendering_types.xml
@@ -5361,13 +5361,12 @@
 		<entity_convert pattern="tag_transform" from_tag="religion" if_tag1="denomination" if_value1="jehovahs_witness" poi="no"/>
 		<entity_convert pattern="tag_transform" from_tag="denomination" from_value="theravāda" to_tag1="denomination" to_value1="theravada" map="no"/>
 		<type tag="travel_elo_rounded" minzoom="12" additional="true" notosm="true"/>
-		<entity_convert pattern="tag_transform" from_tag="travel_elo" if_tag1="amenity" if_value1="place_of_worship" if_less_tag1="travel_elo" if_less_value1="4000" to_tag1="travel_elo_rounded" to_value1="4000"/>
-		<entity_convert pattern="tag_transform" from_tag="travel_elo" if_tag1="amenity" if_value1="place_of_worship" if_less_tag1="travel_elo" if_less_value1="3000" to_tag1="travel_elo_rounded" to_value1="3000"/>
-		<entity_convert pattern="tag_transform" from_tag="travel_elo" if_tag1="amenity" if_value1="place_of_worship" if_less_tag1="travel_elo" if_less_value1="2500" to_tag1="travel_elo_rounded" to_value1="2500"/>
-		<entity_convert pattern="tag_transform" from_tag="travel_elo" if_tag1="amenity" if_value1="place_of_worship" if_less_tag1="travel_elo" if_less_value1="2000" to_tag1="travel_elo_rounded" to_value1="2000"/>
-		<entity_convert pattern="tag_transform" from_tag="travel_elo" if_tag1="amenity" if_value1="place_of_worship" if_less_tag1="travel_elo" if_less_value1="1500" to_tag1="travel_elo_rounded" to_value1="1500"/>
-		<entity_convert pattern="tag_transform" from_tag="travel_elo" if_tag1="amenity" if_value1="place_of_worship" if_less_tag1="travel_elo" if_less_value1="1000" to_tag1="travel_elo_rounded" to_value1="1000"/>
-		<entity_convert pattern="tag_transform" from_tag="travel_elo" if_tag1="amenity" if_value1="place_of_worship" if_less_tag1="travel_elo" if_less_value1="500" to_tag1="travel_elo_rounded" to_value1="500"/>
+		<entity_convert pattern="tag_transform" from_tag="travel_elo" if_tag1="amenity" if_value1="place_of_worship" if_not_less_tag1="travel_elo" if_not_less_value1="500" if_less_tag1="travel_elo" if_less_value1="1000" to_tag1="travel_elo_rounded" to_value1="1000"/>
+		<entity_convert pattern="tag_transform" from_tag="travel_elo" if_tag1="amenity" if_value1="place_of_worship" if_not_less_tag1="travel_elo" if_not_less_value1="1000" if_less_tag1="travel_elo" if_less_value1="1500" to_tag1="travel_elo_rounded" to_value1="1500"/>
+		<entity_convert pattern="tag_transform" from_tag="travel_elo" if_tag1="amenity" if_value1="place_of_worship" if_not_less_tag1="travel_elo" if_not_less_value1="1500" if_less_tag1="travel_elo" if_less_value1="2000" to_tag1="travel_elo_rounded" to_value1="2000"/>
+		<entity_convert pattern="tag_transform" from_tag="travel_elo" if_tag1="amenity" if_value1="place_of_worship" if_not_less_tag1="travel_elo" if_not_less_value1="2000" if_less_tag1="travel_elo" if_less_value1="2500" to_tag1="travel_elo_rounded" to_value1="2500"/>
+		<entity_convert pattern="tag_transform" from_tag="travel_elo" if_tag1="amenity" if_value1="place_of_worship" if_not_less_tag1="travel_elo" if_not_less_value1="2500" if_less_tag1="travel_elo" if_less_value1="3000" to_tag1="travel_elo_rounded" to_value1="3000"/>
+		<entity_convert pattern="tag_transform" from_tag="travel_elo" if_tag1="amenity" if_value1="place_of_worship" if_not_less_tag1="travel_elo" if_not_less_value1="3000" to_tag1="travel_elo_rounded" to_value1="4000"/>
 
 	</category>
 

--- a/rendering_styles/default.render.xml
+++ b/rendering_styles/default.render.xml
@@ -7937,7 +7937,7 @@
 				</switch>
 				<switch tag="amenity" value="place_of_worship" icon="amenity_place_of_worship" iconVisibleSize="11" intersectionSizeFactor="0.8">
 					<case minzoom="14" moreDetailed="true" iconOrder="43" iconVisibleSize="9" intersectionSizeFactor="0.7"/>
-					<case minzoom="15" moreDetailed="false" additional="wiki=yes" iconOrder="43" iconVisibleSize="9" intersectionSizeFactor="0.7"/>
+					<case minzoom="15" moreDetailed="false" additional="travel_elo_rounded=4000" iconOrder="43" iconVisibleSize="9" intersectionSizeFactor="0.7"/>
 					<case minzoom="16" iconOrder="132"/>
 					<apply_if nightMode="true" icon="amenity_place_of_worship_night"/>
 					<apply>


### PR DESCRIPTION
Fix travel_elo_rounded bucketing and show only top-rated churches (https://github.com/osmandapp/OsmAnd/issues/24901)

## AI disclaimer

Produced with Claude Code (Sonnet 5).

Prompts used (summarised):
1. Inspect the Prague OBF and find why `travel_elo_rounded` was always 4000 -- traced to a bug in [commit](https://github.com/osmandapp/OsmAnd-resources/commit/a2467438cb4ff669c88714bd6aec7251465348c0) `xmd5a`.
2. Add a rule in `default.render.xml` to show only high-rated places of worship.

**Before / After**

**Hradcany, z15, day**
Before:
<img width="500" alt="castle_z15_before" src="https://github.com/user-attachments/assets/090f3844-7fe4-4ed9-848f-9215264592a3" />

After:
<img width="500" alt="castle_z15_after" src="https://github.com/user-attachments/assets/45ee04a5-e615-4294-b87f-f1cc1f370487" />


**Stare Mesto, z15, night**
Before:
<img width="500" alt="oldtown_z15_before" src="https://github.com/user-attachments/assets/135c3c9c-1802-4cee-940e-63d21eb40f1e" />

After:
<img width="500" alt="oldtown_z15_after" src="https://github.com/user-attachments/assets/f10a68cc-36f0-4b44-abb9-a53c41c875b0" />


**Vysehrad, z15, night**
Before:
<img width="500" alt="vysehrad_z15_before" src="https://github.com/user-attachments/assets/9a89f23e-c909-44a9-ae1c-3f4913b7a0d4" />

After:
<img width="500" alt="vysehrad_z15_after" src="https://github.com/user-attachments/assets/024d9c38-88a6-4266-87c5-755894795366" />

