### PR TITLE
Restore Austria region name in regions.xml

### DIFF
--- a/countries-info/regions.xml
+++ b/countries-info/regions.xml
@@ -279,7 +279,7 @@
 			</region>
 
 			<!-- west-europe -->
-			<region name="austria" inner_download_prefix="$name" lang="de" poly_extract="west-europe" join_map_files="yes" translate="name:en=Lower Austria, Vienna;entity=relation">
+			<region name="austria" inner_download_prefix="$name" lang="de" poly_extract="west-europe" join_map_files="yes" translate="name:en=Austria;entity=relation">
 				<region type="map" name="burgenland"/>
 				<region type="map" name="carinthia"/>
 				<region type="map" name="lower-austria" translate="name:en=Lower Austria;entity=relation"/>


### PR DESCRIPTION
1dccc5afb9 (translations for #25150) changed the \`austria\` region to \`translate="name:en=Lower Austria, Vienna"\`. Since then the download list shows *Niederösterreich, Wien* instead of *Österreich / Austria* at the country level (support ticket with a screenshot from Android 5.4.4, German UI). This PR restores \`name:en=Austria\`; the other translations in that commit are correct.

Users only get the fix after \`regions.ocbf\` is rebuilt on builder.osmand.net and bundled into the app.

## AI disclaimer

Produced with Claude Code (Opus 5).

Prompts used (summarised):
1. Build a report on the open Zendesk tickets and verify the claims against code and releases (this is where the Austria regression was found).
2. Open a PR fixing commit 1dccc5afb9.

Decided by the agent, not requested explicitly: only the Austria line is reverted, after checking the other region translations changed in 1dccc5afb9.