### PR TITLE
Add rail keyword to train riding activity

### DIFF
--- a/poi/activities.json
+++ b/poi/activities.json
@@ -571,7 +571,8 @@
                     "id": "train_riding",
                     "icon_name": "activities_train",
                     "tags": [
-                        "train"
+                        "train",
+                        "rail"
                     ]
                 },
                 {


### PR DESCRIPTION
OsmGpx activity classification (`DownloadOsmGPX` in OsmAnd-tools) takes its keywords from `poi/activities.json`. Train rides named like "SE_Rail_Kungsbacka_Halmstad" or "Rail Zurich - Bern" matched nothing, because `train_riding` had only `train`. With usable timestamps the label still has to fit the train speed range (p85 20–350 km/h), so a walk to a "rail station" stays foot.

On the 30,000-track sample `rail` changes 8 tracks to `train_riding`: 6 timed rides that were `driving` by speed (for example "Rail Zurich - Bern" and "Istanbul to Tehran Railway track") and 2 untimed tracks that were `nospeed`, one of them a railway line traced from old maps. "Sholing Rail Station Footbridge" and a StreetComplete note "rail in the middle" are too short to classify and stay garbage.

## AI disclaimer

Produced with Claude Code (Opus 5).

Prompts used (summarised):
1. Review of `nospeed` OsmGpx tracks: "SE_Rail_Kungsbacka_Halmstad" looks like rail and could be recognised.
2. Add `rail`.

Decided by the agent, not requested explicitly: adding only `rail` (no `railway` or other languages).
